### PR TITLE
commented ws auth

### DIFF
--- a/server/helpers/server.ts
+++ b/server/helpers/server.ts
@@ -6,10 +6,7 @@ import fastify, { FastifyInstance } from "fastify";
 import * as fs from "fs";
 import { env, errorHandler, getLogSettings } from "../../core";
 import { apiRoutes } from "../../server/api";
-import {
-  performHTTPAuthentication,
-  performWSAuthentication,
-} from "../middleware/auth";
+import { performHTTPAuthentication } from "../middleware/auth";
 import { openapi } from "./openapi";
 
 const createServer = async (serverName: string): Promise<FastifyInstance> => {
@@ -48,7 +45,8 @@ const createServer = async (serverName: string): Promise<FastifyInstance> => {
       request.headers.upgrade.toLowerCase() === "websocket"
     ) {
       server.log.info("WebSocket connection attempt");
-      await performWSAuthentication(request, reply);
+      // ToDo: Uncomment WebSocket Authentication post Auth SDK is implemented
+      // await performWSAuthentication(request, reply);
     } else {
       server.log.info("Regular HTTP request");
       await performHTTPAuthentication(request, reply);


### PR DESCRIPTION
## Changes

- Linear: Removing WS Auth
- Auth check on ws being removed.
- commented out the ws auth function

## How this PR will be tested

- [ ] connect to websocket on the `/trasaction/status/<tx_queue_id>` and should be able to without a token in query params

How to connect to websocket on Chrome DevTools

```js
let socket = new WebSocket("ws://localhost:3005/transaction/status/a571b90c-13a7-4243-a04d-0b914de8a7f2");

socket.onopen = (event) => {
  console.log("opened");
};

socket.onclose = (event) => {
  console.log("connection closed");
};

socket.onmessage = (event) => {
  const res = JSON.parse(event.data);
  res.result = JSON.parse(res.result);
  console.log("Received Data", res);
};
```

## Output

Output will be like below:

```
opened
Received Data {result: {…}, queueId: 'a571b90c-13a7-4243-a04d-0b914de8a7f2', message: 'Transaction mined. Closing connection.'}
```
