### PR TITLE
env: add required and optional info

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# WALLET
+# WALLET [Required]
 # ------
 # Either a private key
 WALLET_PRIVATE_KEY=<your_admin_wallet_private_key>
@@ -8,13 +8,13 @@ AWS_SECRET_ACCESS_KEY=<your_aws_secret_access_key>
 AWS_KMS_KEY_ID=<your_aws_kms_key_id>
 AWS_REGION=<your_aws_region>
 
-# THIRDWEB SDK SECRET KEY
+# THIRDWEB SDK SECRET KEY [Required]
 # -----------------------
 # Obtain an Secret Key from thirdweb.com/dashboard
 # this enables you to use the default RPCs and extra features
 THIRDWEB_SDK_SECRET_KEY=<your_thirdweb_sdk_secret_key>
 
-# DATABASE OPTIONS
+# DATABASE OPTIONS [Required]
 # ----------------
 POSTGRES_HOST=localhost
 POSTGRES_DATABASE_NAME=postgres
@@ -23,13 +23,13 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_PORT=5432
 POSTGRES_USE_SSL=false
 
-# SERVING OPTIONS
+# SERVING OPTIONS [Optional]
 # ---------------
 PORT=3005
 HOST=localhost
 OPENAPI_BASE_ORIGIN=http://localhost:3005
 
-# CONFIGURATION OPTIONS
+# CONFIGURATION OPTIONS [Optional]
 # ----------------------
 # the number of transactions to queue for before starting processing
 MIN_TRANSACTION_TO_PROCESS=1
@@ -40,7 +40,7 @@ TRANSACTIONS_TO_BATCH=10
 # See example config file: chain-overrides.example.json
 CHAIN_OVERRIDES=<path_or_url_to_file>
 
-# CORS OPTIONS
+# CORS OPTIONS [Optional]
 # ------------
 # Configures the Access-Control-Allow-Origin CORS header. Defaults to * (Allow All)
 # The value of origin could be of different types:
@@ -55,7 +55,7 @@ CHAIN_OVERRIDES=<path_or_url_to_file>
 ACCESS_CONTROL_ALLOW_ORIGIN=*
 
 
-# benchmark vars
+# benchmark vars [Optional]
 BENCHMARK_HOST='http://localhost:3005'
 BENCHMARK_URL_PATH='/contract/mumbai/0xc8be6265C06aC376876b4F62670adB3c4d72EABA/write'
 BENCHMARK_POST_BODY='{


### PR DESCRIPTION
Added info on what environment variables are optional & required into the `.env.example` since I missed this when I tried to set it up again.