### PR TITLE
Added tag based image build workflow for gh actions

### DIFF
--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -4,7 +4,7 @@ on:
   create: # This listens to create events, which includes tag creations
 
 jobs:
-  promote:
+  buildImageForNewTag:
     if: startsWith(github.ref, 'refs/tags/') # Only run this job when a tag is created
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Changes

Updated github workflows to add a new workflow, which will build new images whenever a new tag is generated for a commit which is on main branch

## How this PR will be tested

- push a change to main
- create a new tag and it should then push the new image with the new tag to docker hub

