### PR TITLE
added new argument to checkout code step

### DIFF
--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # This fetches all history for all tags and branches
 
       - name: Verify tag is on main branch
         run: |


### PR DESCRIPTION
Possible fix for the error (as added below) for when trying to check if the tag is generated from main

shell: /usr/bin/bash -e {0}
fatal: ambiguous argument 'main': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'