### PR TITLE
Stopping Swagger UI rendering on Production

### DIFF
--- a/server/helpers/openapi.ts
+++ b/server/helpers/openapi.ts
@@ -7,9 +7,6 @@ import { env } from "../../core";
 // to be separate unlike old implementation
 
 export const openapi = async (server: FastifyInstance) => {
-  if (process.env.NODE_ENV === "production") {
-    return Promise.resolve();
-  }
   await server.register(swagger, {
     mode: "dynamic",
     openapi: {

--- a/server/helpers/server.ts
+++ b/server/helpers/server.ts
@@ -26,6 +26,16 @@ const createServer = async (serverName: string): Promise<FastifyInstance> => {
       );
     }
 
+    if (process.env.NODE_ENV === "production") {
+      if (request.routerPath?.includes("static")) {
+        return reply.status(404).send({
+          statusCode: 404,
+          error: "Not Found",
+          message: "Not Found",
+        });
+      }
+    }
+
     const { url } = request;
     // Skip Authentication for Health Check and Static Files and JSON Files for Swagger
     // Doing Auth check onRequest helps prevent unauthenticated requests from consuming server resources.


### PR DESCRIPTION
## Changes

- We are not able to access the JSON format swagger data.
- We made to stop serving the HTML on any static route, thus enabling json route
