### PR TITLE
Web3-API -> Engine Update

### DIFF
--- a/.github/aws_kms_how_to.md
+++ b/.github/aws_kms_how_to.md
@@ -1,4 +1,4 @@
-Web3-API supports AWS KMS for signing & sending transactions over any EVM chain. This is a guide on how to set up AWS KMS for Web3-API.
+Thirdweb Engine supports AWS KMS for signing & sending transactions over any EVM chain. This is a guide on how to set up AWS KMS.
 
 ### Steps to set up AWS KMS
 

--- a/.github/google_kms_how_to.md
+++ b/.github/google_kms_how_to.md
@@ -1,4 +1,4 @@
-Web3-API supports Google KMS for signing & sending transactions over any EVM chain. This is a guide on how to set up Google KMS for Web3-API.
+Thirdweb Engine supports Google KMS for signing & sending transactions over any EVM chain. This is a guide on how to set up Google KMS for.
 
 ### Steps to set up Google KMS
 
@@ -19,7 +19,7 @@ Cloud KMS CryptoKey Signer/Verifier
 
 Optional: Create a key in the keyring, see [here](https://cloud.google.com/kms/docs/create-key) for more details. or, you can use the `/wallet/create` to create a key in the keyring.
 
-### Set up Web3-API with Google KMS
+### Set up with Google KMS
 
 Create a `.env` file in the root directory of the project and add the below details.
 

--- a/.github/websocket_usage.md
+++ b/.github/websocket_usage.md
@@ -14,11 +14,11 @@ For listening for updates on your requests, you can either poll using the `get` 
    - `<host>`: Hostname of the server
    - `<port>`: Port of the server
    - `<queueId>`: Queue ID of the request
-   - `<w3a_thirdweb_secret_key>`: Web3-API Thirdweb secret key
+   - `<thirdweb_api_secret_key>`: Thirdweb api secret key
 
 ```js
 const socket = new WebSocket(
-  "ws://<host>:<port>/transaction/status/<queueId>?token=<w3a_thirdweb_secret_key>",
+  "ws://<host>:<port>/transaction/status/<queueId>?token=<thirdweb_api_secret_key>",
 );
 
 socket.onopen = (event) => {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,4 +32,4 @@ jobs:
           target: prod
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: thirdweb/web3-api:nightly
+          tags: thirdweb/engine:nightly

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -30,4 +30,4 @@ jobs:
           target: prod
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: thirdweb/web3-api:latest
+          tags: thirdweb/engine:latest

--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -28,4 +28,4 @@ jobs:
           target: prod
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: thirdweb/web3-api:${{ github.ref_name }} # Set the docker tag to the Git tag name
+          tags: thirdweb/engine:${{ github.ref_name }} # Set the docker tag to the Git tag name

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Set these variables in the .env file (copy .env.example to get started)
 Docker
 
 ```
-docker run -e .env -p 3005:3005 thirdweb/web3-api
+docker run -e .env -p 3005:3005 thirdweb/engine:latest
 ```
 
 ### Using the server

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,7 @@
-version: '3.8'
+version: "3.8"
 services:
-  web3-api:
+  engine:
     build:
       context: .
       target: prod
-    image: thirdweb/web3-api:0.1.0
+    image: thirdweb/engine:0.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - pgadmin:/var/lib/pgadmin
 
-  web3-api:
+  engine-api:
     build:
       dockerfile: Dockerfile
       context: .
@@ -31,7 +31,7 @@ services:
       - ./:/app
       - node_modules:/app/node_modules
 
-  web3-worker:
+  engine-worker:
     build:
       dockerfile: Dockerfile
       context: .

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -80,8 +80,8 @@ For updates on your requests, you can either poll using the `get` (`/tranasction
 3. Run the below command
    <br />
    ```
-   docker run -e .env -p 3005:3005 thirdweb/web3-api:nightly
-   # check other images at https://hub.docker.com/r/thirdweb/web3-api/tags
+   docker run -e .env -p 3005:3005 thirdweb/engine:nightly
+   # check other images at https://hub.docker.com/r/thirdweb/engine/tags
    ```
 
 ### Note:


### PR DESCRIPTION
## Changes

- renamed docker image from `web3-api` to `engine`
- updated readme to say `thirdweb engine`
- updated GH Workflow to build `thirdweb/engine` image & not `thirdweb/web3-api`