### PR TITLE
[Breaking] Rename x-wallet-address header to x-backend-wallet-address

### DIFF
--- a/.env.benchmark.example
+++ b/.env.benchmark.example
@@ -15,7 +15,10 @@ THIRDWEB_API_SECRET_KEY = ""
 # At minimum, you need to configure a chain and a wallet address
 # ============================================================================= #
 BENCHMARK_CHAIN = "mumbai"
-BENCHMARK_WALLET_ADDRESS = ""
+BENCHMARK_BACKEND_WALLET_ADDRESS = ""
+
+# If you want to test with a smart wallet, you can use this header as well
+# BENCHMARK_ACCOUNT_ADDRESS
 
 # Then you can configure the contract address and function to call
 # NOTE: If you don't configure a contract address and function call, an ERC20

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ POSTGRES_CONNECTION_URL="postgresql://postgres:postgres@host.docker.internal:543
 - In development mode, go to the server url to see an admin interface
 - Every request to the server requires an authentication token for admin actions use the thirdweb SecretKey. Use the `Authorization` Header to set the value shown below:
   - `Authorization: Bearer: <thirdweb SecretKey>`
-- Every write request to the server also requires the `x-wallet-address` header to specify which admin wallet to send a transaction with. Use the following format to set this header:
+- Every write request to the server also requires the `x-backend-wallet-address` header to specify which admin wallet to send a transaction with. Use the following format to set this header:
 
-  - `X-Wallet-Address: 0x3ecdbf3b911d0e9052b64850693888b008e18373`
+  - `x-backend-wallet-address: 0x3ecdbf3b911d0e9052b64850693888b008e18373`
 
 - Contract API
 

--- a/core/schema/index.ts
+++ b/core/schema/index.ts
@@ -38,7 +38,7 @@ export const chainResponseSchema = Type.Object({
 });
 
 export const walletAuthSchema = Type.Object({
-  "x-wallet-address": Type.String({
+  "x-backend-wallet-address": Type.String({
     description: "Wallet address",
   }),
   "x-account-address": Type.Optional(

--- a/server/api/contract/extensions/account/write/grantAdmin.ts
+++ b/server/api/contract/extensions/account/write/grantAdmin.ts
@@ -40,7 +40,7 @@ export const grantAdmin = async (fastify: FastifyInstance) => {
     handler: async (req, rep) => {
       const { chain, contract_address } = req.params;
       const { signer_address } = req.body;
-      const walletAddress = req.headers["x-wallet-address"] as string;
+      const walletAddress = req.headers["x-backend-wallet-address"] as string;
       const accountAddress = req.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
 

--- a/server/api/contract/extensions/account/write/grantSession.ts
+++ b/server/api/contract/extensions/account/write/grantSession.ts
@@ -37,7 +37,7 @@ export const grantSession = async (fastify: FastifyInstance) => {
     handler: async (req, rep) => {
       const { chain, contract_address } = req.params;
       const { signerAddress, ...permissions } = req.body;
-      const walletAddress = req.headers["x-wallet-address"] as string;
+      const walletAddress = req.headers["x-backend-wallet-address"] as string;
       const accountAddress = req.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
 

--- a/server/api/contract/extensions/account/write/revokeAdmin.ts
+++ b/server/api/contract/extensions/account/write/revokeAdmin.ts
@@ -40,7 +40,7 @@ export const revokeAdmin = async (fastify: FastifyInstance) => {
     handler: async (req, rep) => {
       const { chain, contract_address } = req.params;
       const { wallet_address } = req.body;
-      const walletAddress = req.headers["x-wallet-address"] as string;
+      const walletAddress = req.headers["x-backend-wallet-address"] as string;
       const accountAddress = req.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
 

--- a/server/api/contract/extensions/account/write/revokeSession.ts
+++ b/server/api/contract/extensions/account/write/revokeSession.ts
@@ -40,7 +40,7 @@ export const revokeSession = async (fastify: FastifyInstance) => {
     handler: async (req, rep) => {
       const { chain, contract_address } = req.params;
       const { wallet_address } = req.body;
-      const walletAddress = req.headers["x-wallet-address"] as string;
+      const walletAddress = req.headers["x-backend-wallet-address"] as string;
       const accountAddress = req.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
 

--- a/server/api/contract/extensions/account/write/updateSession.ts
+++ b/server/api/contract/extensions/account/write/updateSession.ts
@@ -42,7 +42,7 @@ export const updateSession = async (fastify: FastifyInstance) => {
     handler: async (req, rep) => {
       const { chain, contract_address } = req.params;
       const { signerAddress, ...permissions } = req.body;
-      const walletAddress = req.headers["x-wallet-address"] as string;
+      const walletAddress = req.headers["x-backend-wallet-address"] as string;
       const accountAddress = req.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
 

--- a/server/api/contract/extensions/accountFactory/write/createAccount.ts
+++ b/server/api/contract/extensions/accountFactory/write/createAccount.ts
@@ -45,7 +45,7 @@ export const createAccount = async (fastify: FastifyInstance) => {
     handler: async (req, rep) => {
       const { chain, contract_address } = req.params;
       const { admin_address, extra_data } = req.body;
-      const walletAddress = req.headers["x-wallet-address"] as string;
+      const walletAddress = req.headers["x-backend-wallet-address"] as string;
       const accountAddress = req.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
 

--- a/server/api/contract/extensions/erc1155/write/airdrop.ts
+++ b/server/api/contract/extensions/erc1155/write/airdrop.ts
@@ -71,7 +71,9 @@ export async function erc1155airdrop(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { token_id, addresses } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/burn.ts
+++ b/server/api/contract/extensions/erc1155/write/burn.ts
@@ -54,7 +54,9 @@ export async function erc1155burn(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { token_id, amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/burnBatch.ts
+++ b/server/api/contract/extensions/erc1155/write/burnBatch.ts
@@ -60,7 +60,9 @@ export async function erc1155burnBatch(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { token_ids, amounts } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/claimTo.ts
+++ b/server/api/contract/extensions/erc1155/write/claimTo.ts
@@ -58,7 +58,9 @@ export async function erc1155claimTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { receiver, token_id, quantity } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/lazyMint.ts
+++ b/server/api/contract/extensions/erc1155/write/lazyMint.ts
@@ -61,7 +61,9 @@ export async function erc1155lazyMint(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { metadatas } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/mintAdditionalSupplyTo.ts
+++ b/server/api/contract/extensions/erc1155/write/mintAdditionalSupplyTo.ts
@@ -58,7 +58,9 @@ export async function erc1155mintAdditionalSupplyTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { receiver, additional_supply, token_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/mintBatchTo.ts
+++ b/server/api/contract/extensions/erc1155/write/mintBatchTo.ts
@@ -74,7 +74,9 @@ export async function erc1155mintBatchTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { receiver, metadataWithSupply } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/mintTo.ts
+++ b/server/api/contract/extensions/erc1155/write/mintTo.ts
@@ -62,7 +62,9 @@ export async function erc1155mintTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { receiver, metadataWithSupply } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/setApprovalForAll.ts
+++ b/server/api/contract/extensions/erc1155/write/setApprovalForAll.ts
@@ -57,7 +57,9 @@ export async function erc1155SetApprovalForAll(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { operator, approved } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/signatureMint.ts
+++ b/server/api/contract/extensions/erc1155/write/signatureMint.ts
@@ -53,7 +53,9 @@ export async function erc1155SignatureMint(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { payload, signature } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/transfer.ts
+++ b/server/api/contract/extensions/erc1155/write/transfer.ts
@@ -59,7 +59,9 @@ export async function erc1155transfer(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { to, token_id, amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc1155/write/transferFrom.ts
+++ b/server/api/contract/extensions/erc1155/write/transferFrom.ts
@@ -64,7 +64,9 @@ export async function erc1155transferFrom(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { from, to, token_id, amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc20/read/signatureGenerate.ts
+++ b/server/api/contract/extensions/erc20/read/signatureGenerate.ts
@@ -64,7 +64,9 @@ export async function erc20SignatureGenerate(fastify: FastifyInstance) {
         quantity,
         uid,
       } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({
         chainId,

--- a/server/api/contract/extensions/erc20/write/burn.ts
+++ b/server/api/contract/extensions/erc20/write/burn.ts
@@ -51,7 +51,9 @@ export async function erc20burn(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc20/write/burnFrom.ts
+++ b/server/api/contract/extensions/erc20/write/burnFrom.ts
@@ -56,7 +56,9 @@ export async function erc20burnFrom(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { holder_address, amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc20/write/claimTo.ts
+++ b/server/api/contract/extensions/erc20/write/claimTo.ts
@@ -55,7 +55,9 @@ export async function erc20claimTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { recipient, amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc20/write/mintBatchTo.ts
+++ b/server/api/contract/extensions/erc20/write/mintBatchTo.ts
@@ -66,7 +66,9 @@ export async function erc20mintBatchTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { data } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc20/write/mintTo.ts
+++ b/server/api/contract/extensions/erc20/write/mintTo.ts
@@ -55,7 +55,9 @@ export async function erc20mintTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { to_address, amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc20/write/setAllowance.ts
+++ b/server/api/contract/extensions/erc20/write/setAllowance.ts
@@ -55,7 +55,9 @@ export async function erc20SetAlowance(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { spender_address, amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc20/write/signatureMint.ts
+++ b/server/api/contract/extensions/erc20/write/signatureMint.ts
@@ -53,7 +53,9 @@ export async function erc20SignatureMint(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { payload, signature } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc20/write/transfer.ts
+++ b/server/api/contract/extensions/erc20/write/transfer.ts
@@ -57,7 +57,9 @@ export async function erc20Transfer(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { to_address, amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc20/write/transferFrom.ts
+++ b/server/api/contract/extensions/erc20/write/transferFrom.ts
@@ -62,7 +62,9 @@ export async function erc20TransferFrom(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { from_address, to_address, amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/read/signatureGenerate.ts
+++ b/server/api/contract/extensions/erc721/read/signatureGenerate.ts
@@ -93,7 +93,9 @@ export async function erc721SignatureGenerate(fastify: FastifyInstance) {
         royaltyRecipient,
         uid,
       } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({
         chainId,

--- a/server/api/contract/extensions/erc721/write/burn.ts
+++ b/server/api/contract/extensions/erc721/write/burn.ts
@@ -50,7 +50,9 @@ export async function erc721burn(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { token_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/write/claimTo.ts
+++ b/server/api/contract/extensions/erc721/write/claimTo.ts
@@ -54,7 +54,9 @@ export async function erc721claimTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { receiver, quantity } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/write/lazyMint.ts
+++ b/server/api/contract/extensions/erc721/write/lazyMint.ts
@@ -61,7 +61,9 @@ export async function erc721lazyMint(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { metadatas } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/write/mintBatchTo.ts
+++ b/server/api/contract/extensions/erc721/write/mintBatchTo.ts
@@ -64,7 +64,9 @@ export async function erc721mintBatchTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { receiver, metadatas } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/write/mintTo.ts
+++ b/server/api/contract/extensions/erc721/write/mintTo.ts
@@ -57,7 +57,9 @@ export async function erc721mintTo(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { receiver, metadata } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/write/setApprovalForAll.ts
+++ b/server/api/contract/extensions/erc721/write/setApprovalForAll.ts
@@ -55,7 +55,9 @@ export async function erc721SetApprovalForAll(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { operator, approved } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/write/setApprovalForToken.ts
+++ b/server/api/contract/extensions/erc721/write/setApprovalForToken.ts
@@ -55,7 +55,9 @@ export async function erc721SetApprovalForToken(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { operator, token_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/write/signatureMint.ts
+++ b/server/api/contract/extensions/erc721/write/signatureMint.ts
@@ -70,7 +70,9 @@ export async function erc721SignatureMint(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { payload, signature } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/write/transfer.ts
+++ b/server/api/contract/extensions/erc721/write/transfer.ts
@@ -55,7 +55,9 @@ export async function erc721transfer(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { to, token_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-addressaddress"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/erc721/write/transferFrom.ts
+++ b/server/api/contract/extensions/erc721/write/transferFrom.ts
@@ -58,7 +58,9 @@ export async function erc721transferFrom(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { from, to, token_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/approveBuyerForReservedListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/approveBuyerForReservedListing.ts
@@ -56,7 +56,9 @@ export async function directListingsApproveBuyerForReservedListing(
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id, buyer } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/buyFromListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/buyFromListing.ts
@@ -57,7 +57,9 @@ export async function directListingsBuyFromListing(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id, quantity, buyer } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/cancelListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/cancelListing.ts
@@ -52,7 +52,9 @@ export async function directListingsCancelListing(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/createListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/createListing.ts
@@ -61,7 +61,9 @@ export async function directListingsCreateListing(fastify: FastifyInstance) {
         startTimestamp,
         endTimestamp,
       } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/revokeBuyerApprovalForReservedListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/revokeBuyerApprovalForReservedListing.ts
@@ -57,7 +57,9 @@ export async function directListingsRevokeBuyerApprovalForReservedListing(
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id, buyer_address } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/revokeCurrencyApprovalForListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/revokeCurrencyApprovalForListing.ts
@@ -56,7 +56,9 @@ export async function directListingsRevokeCurrencyApprovalForListing(
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id, currency_contract_address } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/updateListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/updateListing.ts
@@ -70,7 +70,9 @@ export async function directListingsUpdateListing(fastify: FastifyInstance) {
         startTimestamp,
         endTimestamp,
       } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/buyoutAuction.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/buyoutAuction.ts
@@ -54,7 +54,9 @@ export async function englishAuctionsBuyoutAuction(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/cancelAuction.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/cancelAuction.ts
@@ -54,7 +54,9 @@ export async function englishAuctionsCancelAuction(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/closeAuctionForBidder.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/closeAuctionForBidder.ts
@@ -58,7 +58,9 @@ export async function englishAuctionsCloseAuctionForBidder(
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/closeAuctionForSeller.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/closeAuctionForSeller.ts
@@ -57,7 +57,9 @@ export async function englishAuctionsCloseAuctionForSeller(
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/createAuction.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/createAuction.ts
@@ -64,7 +64,9 @@ export async function englishAuctionsCreateAuction(fastify: FastifyInstance) {
         bidBufferBps,
         timeBufferInSeconds,
       } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/executeSale.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/executeSale.ts
@@ -56,7 +56,9 @@ export async function englishAuctionsExecuteSale(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/makeBid.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/makeBid.ts
@@ -57,7 +57,9 @@ export async function englishAuctionsMakeBid(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { listing_id, bid_amount } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/offers/write/acceptOffer.ts
+++ b/server/api/contract/extensions/marketplaceV3/offers/write/acceptOffer.ts
@@ -50,7 +50,9 @@ export async function offersAcceptOffer(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { offer_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/offers/write/cancelOffer.ts
+++ b/server/api/contract/extensions/marketplaceV3/offers/write/cancelOffer.ts
@@ -50,7 +50,9 @@ export async function offersCancelOffer(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { offer_id } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/extensions/marketplaceV3/offers/write/makeOffer.ts
+++ b/server/api/contract/extensions/marketplaceV3/offers/write/makeOffer.ts
@@ -59,7 +59,9 @@ export async function offersMakeOffer(fastify: FastifyInstance) {
         endTimestamp,
         quantity,
       } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/roles/write/grant.ts
+++ b/server/api/contract/roles/write/grant.ts
@@ -48,7 +48,9 @@ export async function grantRole(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { role, address } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/roles/write/revoke.ts
+++ b/server/api/contract/roles/write/revoke.ts
@@ -48,7 +48,9 @@ export async function revokeRole(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { role, address } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/contract/write/write.ts
+++ b/server/api/contract/write/write.ts
@@ -65,7 +65,9 @@ export async function writeToContract(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contract_address } = request.params;
       const { function_name, args, tx_overrides } = request.body;
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
       const chainId = getChainIdFromChain(chain);
       const contract = await getContract({

--- a/server/api/deploy/prebuilt.ts
+++ b/server/api/deploy/prebuilt.ts
@@ -72,7 +72,9 @@ export async function deployPrebuilt(fastify: FastifyInstance) {
       const { chain, contract_type } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/edition.ts
+++ b/server/api/deploy/prebuilts/edition.ts
@@ -66,7 +66,9 @@ export async function deployPrebuiltEdition(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/editionDrop.ts
+++ b/server/api/deploy/prebuilts/editionDrop.ts
@@ -68,7 +68,9 @@ export async function deployPrebuiltEditionDrop(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/marketplaceV3.ts
+++ b/server/api/deploy/prebuilts/marketplaceV3.ts
@@ -60,7 +60,9 @@ export async function deployPrebuiltMarketplaceV3(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/multiwrap.ts
+++ b/server/api/deploy/prebuilts/multiwrap.ts
@@ -62,7 +62,9 @@ export async function deployPrebuiltMultiwrap(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/nftCollection.ts
+++ b/server/api/deploy/prebuilts/nftCollection.ts
@@ -66,7 +66,9 @@ export async function deployPrebuiltNFTCollection(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/nftDrop.ts
+++ b/server/api/deploy/prebuilts/nftDrop.ts
@@ -68,7 +68,9 @@ export async function deployPrebuiltNFTDrop(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/pack.ts
+++ b/server/api/deploy/prebuilts/pack.ts
@@ -64,7 +64,9 @@ export async function deployPrebuiltPack(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/signatureDrop.ts
+++ b/server/api/deploy/prebuilts/signatureDrop.ts
@@ -68,7 +68,9 @@ export async function deployPrebuiltSignatureDrop(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/split.ts
+++ b/server/api/deploy/prebuilts/split.ts
@@ -57,11 +57,12 @@ export async function deployPrebuiltSplit(fastify: FastifyInstance) {
       },
     },
     handler: async (request, reply) => {
-      //TODO add x-wallet-address to headers
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/token.ts
+++ b/server/api/deploy/prebuilts/token.ts
@@ -64,7 +64,9 @@ export async function deployPrebuiltToken(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/tokenDrop.ts
+++ b/server/api/deploy/prebuilts/tokenDrop.ts
@@ -66,7 +66,9 @@ export async function deployPrebuiltTokenDrop(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/prebuilts/vote.ts
+++ b/server/api/deploy/prebuilts/vote.ts
@@ -60,7 +60,9 @@ export async function deployPrebuiltVote(fastify: FastifyInstance) {
       const { chain } = request.params;
       const { contractMetadata, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/server/api/deploy/published.ts
+++ b/server/api/deploy/published.ts
@@ -62,7 +62,9 @@ export async function deployPublished(fastify: FastifyInstance) {
       const { chain, publisher, contract_name } = request.params;
       const { constructorParams, version } = request.body;
       const chainId = getChainIdFromChain(chain);
-      const walletAddress = request.headers["x-wallet-address"] as string;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
       const accountAddress = request.headers["x-account-address"] as string;
 
       const sdk = await getSdk({ chainId, walletAddress, accountAddress });

--- a/test/benchmark/utils/api.ts
+++ b/test/benchmark/utils/api.ts
@@ -21,7 +21,7 @@ export const fetchApi = async ({
     method,
     headers: {
       "Content-Type": "application/json",
-      "x-wallet-address": walletAddress,
+      "x-backend-wallet-address": walletAddress,
       Authorization: `Bearer ${apiKey}`,
       ...(accountAddress ? { "x-account-address": accountAddress } : {}),
     },

--- a/test/benchmark/utils/config.ts
+++ b/test/benchmark/utils/config.ts
@@ -36,7 +36,7 @@ export const getBenchmarkConfiguration =
       host: process.env.BENCHMARK_HOST ?? `http://127.0.0.1:3005`,
       requests: parseInt(requireEnv("BENCHMARK_REQUESTS") ?? 100),
       concurrency: parseInt(requireEnv("BENCHMARK_CONCURRENCY") ?? 10),
-      walletAddress: requireEnv("BENCHMARK_WALLET_ADDRESS"),
+      walletAddress: requireEnv("BENCHMARK_BACKEND_WALLET_ADDRESS"),
       accountAddress: process.env.BENCHMARK_ACCOUNT_ADDRESS,
     };
 

--- a/test/benchmark/utils/transactions.ts
+++ b/test/benchmark/utils/transactions.ts
@@ -19,7 +19,7 @@ export const sendTxs = async (config: BenchmarkConfiguration) => {
           path: config.path,
           headers: {
             authorization: `Bearer ${config.apiKey}`,
-            "x-wallet-address": config.walletAddress,
+            "x-backend-wallet-address": config.walletAddress,
             "content-type": "application/json",
             ...(config.accountAddress
               ? { "x-account-address": config.accountAddress }

--- a/test/e2e/contract/contract.test.ts
+++ b/test/e2e/contract/contract.test.ts
@@ -15,7 +15,10 @@ describe.skip("Deploy EditionDrop to Test : Contract Endpoints", () => {
     const contractDeployedResponse = await request(createdServerInstance.server)
       .post("/deploy/localhost/prebuilts/editionDrop")
       .set("Authorization", `Bearer ${env.THIRDWEB_API_SECRET_KEY}`)
-      .set("x-wallet-address", "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266")
+      .set(
+        "x-backend-wallet-address",
+        "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+      )
       .send({
         contractMetadata: {
           name: "Test",

--- a/test/e2e/transaction/transaction.test.ts
+++ b/test/e2e/transaction/transaction.test.ts
@@ -16,7 +16,10 @@ describe("Transaction End-point Test", () => {
     const response = await request(createdServerInstance.server)
       .get("/transaction/status/8fe7d546-2b8b-465e-b0d2-f1cb5d3d0db3")
       .set("Authorization", `Bearer ${env.THIRDWEB_API_SECRET_KEY}`)
-      .set("x-wallet-address", "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266")
+      .set(
+        "x-backend-wallet-address",
+        "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+      )
       .send();
 
     console.log(response.body);


### PR DESCRIPTION
## Breaking Changes

- `x-wallet-address` header renamed to `x-backend-wallet-address`
- In previous PR but forgot to note as breaking: `/wallet` endpoints renamed to `/backend-wallet`
