### PR TITLE
[Breaking] Use queueId inside result for write endpoints

### DIFF
--- a/server/api/contract/extensions/account/write/grantAdmin.ts
+++ b/server/api/contract/extensions/account/write/grantAdmin.ts
@@ -57,7 +57,9 @@ export const grantAdmin = async (fastify: FastifyInstance) => {
       const queueId = await queueTx({ tx, chainId, extension: "account" });
 
       rep.status(StatusCodes.OK).send({
-        result: queueId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/account/write/grantSession.ts
+++ b/server/api/contract/extensions/account/write/grantSession.ts
@@ -61,7 +61,9 @@ export const grantSession = async (fastify: FastifyInstance) => {
       const queueId = await queueTx({ tx, chainId, extension: "account" });
 
       rep.status(StatusCodes.OK).send({
-        result: queueId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/account/write/revokeAdmin.ts
+++ b/server/api/contract/extensions/account/write/revokeAdmin.ts
@@ -57,7 +57,9 @@ export const revokeAdmin = async (fastify: FastifyInstance) => {
       const queueId = await queueTx({ tx, chainId, extension: "account" });
 
       rep.status(StatusCodes.OK).send({
-        result: queueId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/account/write/revokeSession.ts
+++ b/server/api/contract/extensions/account/write/revokeSession.ts
@@ -54,7 +54,9 @@ export const revokeSession = async (fastify: FastifyInstance) => {
       const queueId = await queueTx({ tx, chainId, extension: "account" });
 
       rep.status(StatusCodes.OK).send({
-        result: queueId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/account/write/updateSession.ts
+++ b/server/api/contract/extensions/account/write/updateSession.ts
@@ -70,7 +70,9 @@ export const updateSession = async (fastify: FastifyInstance) => {
       const queueId = await queueTx({ tx, chainId, extension: "account" });
 
       rep.status(StatusCodes.OK).send({
-        result: queueId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/accountFactory/write/createAccount.ts
+++ b/server/api/contract/extensions/accountFactory/write/createAccount.ts
@@ -64,7 +64,7 @@ export const createAccount = async (fastify: FastifyInstance) => {
           admin_address,
           extra_data,
         );
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "account-factory",
@@ -74,7 +74,7 @@ export const createAccount = async (fastify: FastifyInstance) => {
 
       rep.status(StatusCodes.OK).send({
         result: {
-          queuedId,
+          queueId,
           deployedAddress,
         },
       });

--- a/server/api/contract/extensions/erc1155/write/airdrop.ts
+++ b/server/api/contract/extensions/erc1155/write/airdrop.ts
@@ -84,9 +84,11 @@ export async function erc1155airdrop(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc1155.airdrop.prepare(token_id, addresses);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/burn.ts
+++ b/server/api/contract/extensions/erc1155/write/burn.ts
@@ -67,9 +67,11 @@ export async function erc1155burn(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc1155.burn.prepare(token_id, amount);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/burnBatch.ts
+++ b/server/api/contract/extensions/erc1155/write/burnBatch.ts
@@ -73,9 +73,11 @@ export async function erc1155burnBatch(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc1155.burnBatch.prepare(token_ids, amounts);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/claimTo.ts
+++ b/server/api/contract/extensions/erc1155/write/claimTo.ts
@@ -75,9 +75,11 @@ export async function erc1155claimTo(fastify: FastifyInstance) {
         token_id,
         quantity,
       );
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/lazyMint.ts
+++ b/server/api/contract/extensions/erc1155/write/lazyMint.ts
@@ -74,10 +74,12 @@ export async function erc1155lazyMint(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc1155.lazyMint.prepare(metadatas);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
 
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/mintAdditionalSupplyTo.ts
+++ b/server/api/contract/extensions/erc1155/write/mintAdditionalSupplyTo.ts
@@ -76,9 +76,11 @@ export async function erc1155mintAdditionalSupplyTo(fastify: FastifyInstance) {
         additional_supply,
       );
 
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/mintBatchTo.ts
+++ b/server/api/contract/extensions/erc1155/write/mintBatchTo.ts
@@ -90,10 +90,12 @@ export async function erc1155mintBatchTo(fastify: FastifyInstance) {
         receiver,
         metadataWithSupply,
       );
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
 
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/mintTo.ts
+++ b/server/api/contract/extensions/erc1155/write/mintTo.ts
@@ -79,9 +79,11 @@ export async function erc1155mintTo(fastify: FastifyInstance) {
         metadataWithSupply,
       );
 
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/setApprovalForAll.ts
+++ b/server/api/contract/extensions/erc1155/write/setApprovalForAll.ts
@@ -74,9 +74,11 @@ export async function erc1155SetApprovalForAll(fastify: FastifyInstance) {
         approved,
       );
 
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/signatureMint.ts
+++ b/server/api/contract/extensions/erc1155/write/signatureMint.ts
@@ -77,9 +77,11 @@ export async function erc1155SignatureMint(fastify: FastifyInstance) {
         signature,
       };
       const tx = await contract.erc1155.signature.mint.prepare(signedPayload);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/transfer.ts
+++ b/server/api/contract/extensions/erc1155/write/transfer.ts
@@ -72,9 +72,11 @@ export async function erc1155transfer(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc1155.transfer.prepare(to, token_id, amount);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc1155/write/transferFrom.ts
+++ b/server/api/contract/extensions/erc1155/write/transferFrom.ts
@@ -82,9 +82,11 @@ export async function erc1155transferFrom(fastify: FastifyInstance) {
         token_id,
         amount,
       );
-      const queuedId = await queueTx({ tx, chainId, extension: "erc1155" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc1155" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc20/write/burn.ts
+++ b/server/api/contract/extensions/erc20/write/burn.ts
@@ -64,9 +64,11 @@ export async function erc20burn(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc20.burn.prepare(amount);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc20" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc20" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc20/write/burnFrom.ts
+++ b/server/api/contract/extensions/erc20/write/burnFrom.ts
@@ -69,9 +69,11 @@ export async function erc20burnFrom(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc20.burnFrom.prepare(holder_address, amount);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc20" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc20" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc20/write/claimTo.ts
+++ b/server/api/contract/extensions/erc20/write/claimTo.ts
@@ -68,9 +68,11 @@ export async function erc20claimTo(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc20.claimTo.prepare(recipient, amount);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc20" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc20" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc20/write/mintBatchTo.ts
+++ b/server/api/contract/extensions/erc20/write/mintBatchTo.ts
@@ -79,9 +79,11 @@ export async function erc20mintBatchTo(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc20.mintBatchTo.prepare(data);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc20" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc20" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc20/write/mintTo.ts
+++ b/server/api/contract/extensions/erc20/write/mintTo.ts
@@ -68,9 +68,11 @@ export async function erc20mintTo(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc20.mintTo.prepare(to_address, amount);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc20" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc20" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc20/write/setAllowance.ts
+++ b/server/api/contract/extensions/erc20/write/setAllowance.ts
@@ -71,9 +71,11 @@ export async function erc20SetAlowance(fastify: FastifyInstance) {
         spender_address,
         amount,
       );
-      const queuedId = await queueTx({ tx, chainId, extension: "erc20" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc20" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc20/write/signatureMint.ts
+++ b/server/api/contract/extensions/erc20/write/signatureMint.ts
@@ -75,9 +75,11 @@ export async function erc20SignatureMint(fastify: FastifyInstance) {
         signature,
       };
       const tx = await contract.erc20.signature.mint.prepare(signedPayload);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc20" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc20" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc20/write/transfer.ts
+++ b/server/api/contract/extensions/erc20/write/transfer.ts
@@ -70,11 +70,11 @@ export async function erc20Transfer(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc20.transfer.prepare(to_address, amount);
-
-      const queuedId = await queueTx({ tx, chainId, extension: "erc20" });
-
+      const queueId = await queueTx({ tx, chainId, extension: "erc20" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc20/write/transferFrom.ts
+++ b/server/api/contract/extensions/erc20/write/transferFrom.ts
@@ -80,10 +80,12 @@ export async function erc20TransferFrom(fastify: FastifyInstance) {
         amount,
       );
 
-      const queuedId = await queueTx({ tx, chainId, extension: "erc20" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc20" });
 
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/burn.ts
+++ b/server/api/contract/extensions/erc721/write/burn.ts
@@ -63,9 +63,11 @@ export async function erc721burn(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc721.burn.prepare(token_id);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/claimTo.ts
+++ b/server/api/contract/extensions/erc721/write/claimTo.ts
@@ -67,9 +67,11 @@ export async function erc721claimTo(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc721.claimTo.prepare(receiver, quantity);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/lazyMint.ts
+++ b/server/api/contract/extensions/erc721/write/lazyMint.ts
@@ -74,9 +74,11 @@ export async function erc721lazyMint(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc721.lazyMint.prepare(metadatas);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/mintBatchTo.ts
+++ b/server/api/contract/extensions/erc721/write/mintBatchTo.ts
@@ -77,9 +77,11 @@ export async function erc721mintBatchTo(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc721.mintBatchTo.prepare(receiver, metadatas);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/mintTo.ts
+++ b/server/api/contract/extensions/erc721/write/mintTo.ts
@@ -70,9 +70,11 @@ export async function erc721mintTo(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc721.mintTo.prepare(receiver, metadata);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/setApprovalForAll.ts
+++ b/server/api/contract/extensions/erc721/write/setApprovalForAll.ts
@@ -71,9 +71,11 @@ export async function erc721SetApprovalForAll(fastify: FastifyInstance) {
         operator,
         approved,
       );
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/setApprovalForToken.ts
+++ b/server/api/contract/extensions/erc721/write/setApprovalForToken.ts
@@ -71,9 +71,11 @@ export async function erc721SetApprovalForToken(fastify: FastifyInstance) {
         operator,
         token_id,
       );
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/signatureMint.ts
+++ b/server/api/contract/extensions/erc721/write/signatureMint.ts
@@ -93,9 +93,11 @@ export async function erc721SignatureMint(fastify: FastifyInstance) {
         signature,
       };
       const tx = await contract.erc721.signature.mint.prepare(signedPayload);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/transfer.ts
+++ b/server/api/contract/extensions/erc721/write/transfer.ts
@@ -68,9 +68,11 @@ export async function erc721transfer(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc721.transfer.prepare(to, token_id);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/erc721/write/transferFrom.ts
+++ b/server/api/contract/extensions/erc721/write/transferFrom.ts
@@ -71,9 +71,11 @@ export async function erc721transferFrom(fastify: FastifyInstance) {
       });
 
       const tx = await contract.erc721.transferFrom.prepare(from, to, token_id);
-      const queuedId = await queueTx({ tx, chainId, extension: "erc721" });
+      const queueId = await queueTx({ tx, chainId, extension: "erc721" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/approveBuyerForReservedListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/approveBuyerForReservedListing.ts
@@ -74,13 +74,15 @@ export async function directListingsApproveBuyerForReservedListing(
           buyer,
         );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-direct-listings",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/buyFromListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/buyFromListing.ts
@@ -75,13 +75,15 @@ export async function directListingsBuyFromListing(fastify: FastifyInstance) {
         buyer,
       );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-direct-listings",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/cancelListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/cancelListing.ts
@@ -68,13 +68,15 @@ export async function directListingsCancelListing(fastify: FastifyInstance) {
         listing_id,
       );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-direct-listings",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/createListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/createListing.ts
@@ -84,13 +84,15 @@ export async function directListingsCreateListing(fastify: FastifyInstance) {
         endTimestamp,
       });
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-direct-listings",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/revokeBuyerApprovalForReservedListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/revokeBuyerApprovalForReservedListing.ts
@@ -75,13 +75,15 @@ export async function directListingsRevokeBuyerApprovalForReservedListing(
           buyer_address,
         );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-direct-listings",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/revokeCurrencyApprovalForListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/revokeCurrencyApprovalForListing.ts
@@ -74,13 +74,15 @@ export async function directListingsRevokeCurrencyApprovalForListing(
           currency_contract_address,
         );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-direct-listings",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/directListings/write/updateListing.ts
+++ b/server/api/contract/extensions/marketplaceV3/directListings/write/updateListing.ts
@@ -95,13 +95,15 @@ export async function directListingsUpdateListing(fastify: FastifyInstance) {
           endTimestamp,
         },
       );
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-direct-listings",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/buyoutAuction.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/buyoutAuction.ts
@@ -70,13 +70,15 @@ export async function englishAuctionsBuyoutAuction(fastify: FastifyInstance) {
         listing_id,
       );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-english-auctions",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/cancelAuction.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/cancelAuction.ts
@@ -70,13 +70,15 @@ export async function englishAuctionsCancelAuction(fastify: FastifyInstance) {
         listing_id,
       );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-english-auctions",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/closeAuctionForBidder.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/closeAuctionForBidder.ts
@@ -74,13 +74,15 @@ export async function englishAuctionsCloseAuctionForBidder(
         listing_id,
       );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-english-auctions",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/closeAuctionForSeller.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/closeAuctionForSeller.ts
@@ -73,13 +73,15 @@ export async function englishAuctionsCloseAuctionForSeller(
         listing_id,
       );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-english-auctions",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/createAuction.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/createAuction.ts
@@ -89,13 +89,15 @@ export async function englishAuctionsCreateAuction(fastify: FastifyInstance) {
         timeBufferInSeconds,
       });
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-english-auctions",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/executeSale.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/executeSale.ts
@@ -70,13 +70,15 @@ export async function englishAuctionsExecuteSale(fastify: FastifyInstance) {
 
       const tx = await contract.englishAuctions.executeSale.prepare(listing_id);
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-english-auctions",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/englishAuctions/write/makeBid.ts
+++ b/server/api/contract/extensions/marketplaceV3/englishAuctions/write/makeBid.ts
@@ -74,13 +74,15 @@ export async function englishAuctionsMakeBid(fastify: FastifyInstance) {
         bid_amount,
       );
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-english-auctions",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/offers/write/acceptOffer.ts
+++ b/server/api/contract/extensions/marketplaceV3/offers/write/acceptOffer.ts
@@ -64,13 +64,15 @@ export async function offersAcceptOffer(fastify: FastifyInstance) {
 
       const tx = await contract.offers.acceptOffer.prepare(offer_id);
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-offers",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/offers/write/cancelOffer.ts
+++ b/server/api/contract/extensions/marketplaceV3/offers/write/cancelOffer.ts
@@ -64,13 +64,15 @@ export async function offersCancelOffer(fastify: FastifyInstance) {
 
       const tx = await contract.offers.cancelOffer.prepare(offer_id);
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-offers",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/extensions/marketplaceV3/offers/write/makeOffer.ts
+++ b/server/api/contract/extensions/marketplaceV3/offers/write/makeOffer.ts
@@ -80,13 +80,15 @@ export async function offersMakeOffer(fastify: FastifyInstance) {
         quantity,
       });
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "marketplace-v3-offers",
       });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/roles/write/grant.ts
+++ b/server/api/contract/roles/write/grant.ts
@@ -61,9 +61,11 @@ export async function grantRole(fastify: FastifyInstance) {
       });
 
       const tx = await contract.roles.grant.prepare(role, address);
-      const queuedId = await queueTx({ tx, chainId, extension: "roles" });
+      const queueId = await queueTx({ tx, chainId, extension: "roles" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/roles/write/revoke.ts
+++ b/server/api/contract/roles/write/revoke.ts
@@ -61,9 +61,11 @@ export async function revokeRole(fastify: FastifyInstance) {
       });
 
       const tx = await contract.roles.revoke.prepare(role, address);
-      const queuedId = await queueTx({ tx, chainId, extension: "roles" });
+      const queueId = await queueTx({ tx, chainId, extension: "roles" });
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/contract/write/write.ts
+++ b/server/api/contract/write/write.ts
@@ -79,10 +79,12 @@ export async function writeToContract(fastify: FastifyInstance) {
 
       const tx = await contract.prepare(function_name, args, tx_overrides);
 
-      const queuedId = await queueTx({ tx, chainId, extension: "none" });
+      const queueId = await queueTx({ tx, chainId, extension: "none" });
 
       reply.status(StatusCodes.OK).send({
-        result: queuedId,
+        result: {
+          queueId,
+        },
       });
     },
   });

--- a/server/api/deploy/prebuilt.ts
+++ b/server/api/deploy/prebuilt.ts
@@ -43,7 +43,7 @@ requestBodySchema.examples = [
 
 // OUTPUT
 const responseSchema = Type.Object({
-  queuedId: Type.Optional(Type.String()),
+  queueId: Type.Optional(Type.String()),
   deployedAddress: Type.Optional(Type.String()),
 });
 
@@ -86,14 +86,14 @@ export async function deployPrebuilt(fastify: FastifyInstance) {
       );
       const deployedAddress = await tx.simulate();
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
       });
       reply.status(StatusCodes.OK).send({
         deployedAddress,
-        queuedId,
+        queueId,
       });
     },
   });

--- a/server/api/deploy/prebuilts/edition.ts
+++ b/server/api/deploy/prebuilts/edition.ts
@@ -79,7 +79,7 @@ export async function deployPrebuiltEdition(fastify: FastifyInstance) {
         version,
       );
       const deployedAddress = await tx.simulate();
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -89,7 +89,7 @@ export async function deployPrebuiltEdition(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/editionDrop.ts
+++ b/server/api/deploy/prebuilts/editionDrop.ts
@@ -80,7 +80,7 @@ export async function deployPrebuiltEditionDrop(fastify: FastifyInstance) {
         version,
       );
       const deployedAddress = await tx.simulate();
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -91,7 +91,7 @@ export async function deployPrebuiltEditionDrop(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/marketplaceV3.ts
+++ b/server/api/deploy/prebuilts/marketplaceV3.ts
@@ -73,7 +73,7 @@ export async function deployPrebuiltMarketplaceV3(fastify: FastifyInstance) {
       );
       const deployedAddress = await tx.simulate();
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -83,7 +83,7 @@ export async function deployPrebuiltMarketplaceV3(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/multiwrap.ts
+++ b/server/api/deploy/prebuilts/multiwrap.ts
@@ -74,7 +74,7 @@ export async function deployPrebuiltMultiwrap(fastify: FastifyInstance) {
         version,
       );
       const deployedAddress = await tx.simulate();
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -84,7 +84,7 @@ export async function deployPrebuiltMultiwrap(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/nftCollection.ts
+++ b/server/api/deploy/prebuilts/nftCollection.ts
@@ -78,7 +78,7 @@ export async function deployPrebuiltNFTCollection(fastify: FastifyInstance) {
         version,
       );
       const deployedAddress = await tx.simulate();
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -88,7 +88,7 @@ export async function deployPrebuiltNFTCollection(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/nftDrop.ts
+++ b/server/api/deploy/prebuilts/nftDrop.ts
@@ -80,7 +80,7 @@ export async function deployPrebuiltNFTDrop(fastify: FastifyInstance) {
         version,
       );
       const deployedAddress = await tx.simulate();
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -90,7 +90,7 @@ export async function deployPrebuiltNFTDrop(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/pack.ts
+++ b/server/api/deploy/prebuilts/pack.ts
@@ -76,7 +76,7 @@ export async function deployPrebuiltPack(fastify: FastifyInstance) {
         version,
       );
       const deployedAddress = await tx.simulate();
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -86,7 +86,7 @@ export async function deployPrebuiltPack(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/signatureDrop.ts
+++ b/server/api/deploy/prebuilts/signatureDrop.ts
@@ -81,7 +81,7 @@ export async function deployPrebuiltSignatureDrop(fastify: FastifyInstance) {
       );
       const deployedAddress = await tx.simulate();
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -91,7 +91,7 @@ export async function deployPrebuiltSignatureDrop(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/split.ts
+++ b/server/api/deploy/prebuilts/split.ts
@@ -73,7 +73,7 @@ export async function deployPrebuiltSplit(fastify: FastifyInstance) {
       );
       const deployedAddress = await tx.simulate();
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -83,7 +83,7 @@ export async function deployPrebuiltSplit(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/token.ts
+++ b/server/api/deploy/prebuilts/token.ts
@@ -77,7 +77,7 @@ export async function deployPrebuiltToken(fastify: FastifyInstance) {
       );
 
       const deployedAddress = await tx.simulate();
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -87,7 +87,7 @@ export async function deployPrebuiltToken(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/tokenDrop.ts
+++ b/server/api/deploy/prebuilts/tokenDrop.ts
@@ -78,7 +78,7 @@ export async function deployPrebuiltTokenDrop(fastify: FastifyInstance) {
         version,
       );
       const deployedAddress = await tx.simulate();
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -88,7 +88,7 @@ export async function deployPrebuiltTokenDrop(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/prebuilts/vote.ts
+++ b/server/api/deploy/prebuilts/vote.ts
@@ -72,7 +72,7 @@ export async function deployPrebuiltVote(fastify: FastifyInstance) {
         version,
       );
       const deployedAddress = await tx.simulate();
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-prebuilt",
@@ -82,7 +82,7 @@ export async function deployPrebuiltVote(fastify: FastifyInstance) {
       reply.status(StatusCodes.OK).send({
         result: {
           deployedAddress,
-          queuedId,
+          queueId,
         },
       });
     },

--- a/server/api/deploy/published.ts
+++ b/server/api/deploy/published.ts
@@ -34,7 +34,7 @@ requestBodySchema.examples = [
 
 // OUTPUT
 const responseSchema = Type.Object({
-  queuedId: Type.Optional(Type.String()),
+  queueId: Type.Optional(Type.String()),
   deployedAddress: Type.Optional(Type.String()),
 });
 
@@ -76,7 +76,7 @@ export async function deployPublished(fastify: FastifyInstance) {
       );
       const deployedAddress = await tx.simulate();
 
-      const queuedId = await queueTx({
+      const queueId = await queueTx({
         tx,
         chainId,
         extension: "deploy-published",
@@ -85,7 +85,7 @@ export async function deployPublished(fastify: FastifyInstance) {
       });
       reply.status(StatusCodes.OK).send({
         deployedAddress,
-        queuedId,
+        queueId,
       });
     },
   });

--- a/server/helpers/sharedApiSchemas.ts
+++ b/server/helpers/sharedApiSchemas.ts
@@ -134,13 +134,17 @@ export interface publishedDeploySchemaTypes extends RouteGenericInterface {
 }
 
 export const transactionWritesResponseSchema = Type.Object({
-  result: Type.String({
-    description: "Queue ID",
+  result: Type.Object({
+    queueId: Type.String({
+      description: "Queue ID",
+    }),
   }),
 });
 
 transactionWritesResponseSchema.example = {
-  result: "9eb88b00-f04f-409b-9df7-7dcc9003bc35",
+  result: {
+    queueId: "9eb88b00-f04f-409b-9df7-7dcc9003bc35",
+  },
 };
 
 /**

--- a/server/schemas/prebuilts/index.ts
+++ b/server/schemas/prebuilts/index.ts
@@ -93,7 +93,7 @@ export const prebuiltDeployContractParamSchema = Type.Object({
 
 export const prebuiltDeployResponseSchema = Type.Object({
   result: Type.Object({
-    queuedId: Type.Optional(Type.String()),
+    queueId: Type.Optional(Type.String()),
     deployedAddress: Type.Optional(Type.String()),
   }),
 });

--- a/test/benchmark/utils/config.ts
+++ b/test/benchmark/utils/config.ts
@@ -78,7 +78,7 @@ export const getBenchmarkConfiguration =
       );
 
       const {
-        result: { queuedId, deployedAddress },
+        result: { queueId, deployedAddress },
       } = await fetchApi({
         host: benchmarkConfig.host,
         apiKey: benchmarkConfig.apiKey,
@@ -100,7 +100,7 @@ export const getBenchmarkConfiguration =
       await awaitTx({
         host: benchmarkConfig.host,
         apiKey: benchmarkConfig.apiKey,
-        txnId: queuedId,
+        txnId: queueId,
       });
 
       contractAddress = deployedAddress;

--- a/test/benchmark/utils/transactions.ts
+++ b/test/benchmark/utils/transactions.ts
@@ -31,7 +31,8 @@ export const sendTxs = async (config: BenchmarkConfiguration) => {
           // This was one of the new field that was recently added
           onResponse: (status: number, body: string) => {
             if (status === 200) {
-              const parsedResult: { result?: string } = JSON.parse(body);
+              const parsedResult: { result?: { queueId: string } } =
+                JSON.parse(body);
               if (!parsedResult.result) {
                 logger.error(
                   `Response body does not contain a "result" field: ${body}`,
@@ -40,7 +41,7 @@ export const sendTxs = async (config: BenchmarkConfiguration) => {
                   error: "Response body does not contain a 'result' field",
                 });
               }
-              txnIds.push(parsedResult.result);
+              txnIds.push(parsedResult.result.queueId);
             } else {
               logger.error(
                 `Received status code ${status} from server. Body: ${body}`,


### PR DESCRIPTION
## Breaking Changes

- All write endpoints use `result.queueId` to return the queued transaction id instead of previous mix of `queueId` and `queuedId` inside `result`, or using `result` directly.