### PR TITLE
adding auth headers to webhook

### DIFF
--- a/server/controller/tx-update-listener.ts
+++ b/server/controller/tx-update-listener.ts
@@ -24,13 +24,18 @@ export const startTxUpdatesNotificationListener = async (): Promise<void> => {
         // Send webhook
         if (env.WEBHOOK_URL.length > 0) {
           const txData = await getTxById({ queueId: parsedPayload.id });
+          let headers: { Accept: string, "Content-Type": string, Authorization?: string } = {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          };
+
+          if (process.env.WEBHOOK_AUTH_BEARER_TOKEN) {
+            headers["Authorization"] = `Bearer ${process.env.WEBHOOK_AUTH_BEARER_TOKEN}`;
+          }
+
           const response = await fetch(env.WEBHOOK_URL, {
             method: "POST",
-            headers: {
-              "Authorization": `Bearer ${env.THIRDWEB_API_SECRET_KEY}`,
-              Accept: "application/json",
-              "Content-Type": "application/json",
-            },
+            headers,
             body: JSON.stringify(txData),
           });
 

--- a/server/controller/tx-update-listener.ts
+++ b/server/controller/tx-update-listener.ts
@@ -27,6 +27,7 @@ export const startTxUpdatesNotificationListener = async (): Promise<void> => {
           const response = await fetch(env.WEBHOOK_URL, {
             method: "POST",
             headers: {
+              "Authorization": `Bearer ${env.THIRDWEB_API_SECRET_KEY}`,
               Accept: "application/json",
               "Content-Type": "application/json",
             },

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -80,6 +80,7 @@ export const env = createEnv({
         }
         return "";
       }),
+    WEBHOOK_AUTH_BEARER_TOKEN: z.string().default(""),
   },
   clientPrefix: "NEVER_USED",
   client: {},
@@ -137,6 +138,7 @@ export const env = createEnv({
       process.env.MAX_BLOCKS_ELAPSED_BEFORE_RETRY,
     MAX_WAIT_TIME_BEFORE_RETRY: process.env.MAX_WAIT_TIME_BEFORE_RETRY,
     WEBHOOK_URL: process.env.WEBHOOK_URL,
+    WEBHOOK_AUTH_BEARER_TOKEN: process.env.WEBHOOK_AUTH_BEARER_TOKEN
   },
   onValidationError: (error: ZodError) => {
     console.error(

--- a/src/worker/listeners/queuedTxListener.ts
+++ b/src/worker/listeners/queuedTxListener.ts
@@ -37,6 +37,7 @@ export const queuedTxListener = async (): Promise<void> => {
         const response = await fetch(env.WEBHOOK_URL, {
           method: "POST",
           headers: {
+            "Authorization": `Bearer ${env.THIRDWEB_API_SECRET_KEY}`,
             Accept: "application/json",
             "Content-Type": "application/json",
           },

--- a/src/worker/listeners/queuedTxListener.ts
+++ b/src/worker/listeners/queuedTxListener.ts
@@ -34,13 +34,18 @@ export const queuedTxListener = async (): Promise<void> => {
       if (env.WEBHOOK_URL.length > 0) {
         const parsedPayload = JSON.parse(msg.payload);
         const txData = await getTxById({ queueId: parsedPayload.id });
+
+        let headers: { Accept: string, "Content-Type": string, Authorization?: string } = {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        };
+
+        if (process.env.WEBHOOK_AUTH_BEARER_TOKEN) {
+          headers["Authorization"] = `Bearer ${process.env.WEBHOOK_AUTH_BEARER_TOKEN}`;
+        }
         const response = await fetch(env.WEBHOOK_URL, {
           method: "POST",
-          headers: {
-            "Authorization": `Bearer ${env.THIRDWEB_API_SECRET_KEY}`,
-            Accept: "application/json",
-            "Content-Type": "application/json",
-          },
+          headers,
           body: JSON.stringify(txData),
         });
 


### PR DESCRIPTION
## Changes
- added auth header to queuedTxListener webhook
- added auth header to tx-update-listener webhook

## How this PR will be tested
- tested authorization locally with checkouts migration

## Output
- webhook header contains authorization bearer token with THIRDWEB_API_SECRET_KEY
