### PR TITLE
Added Tx simulation

### DIFF
--- a/src/db/transactions/queueTx.ts
+++ b/src/db/transactions/queueTx.ts
@@ -24,6 +24,9 @@ export const queueTx = async ({
   deployedContractAddress,
   deployedContractType,
 }: QueueTxParams) => {
+  // Simulate transaction
+  await tx.simulate();
+
   const prisma = getPrismaWithPostgresTx(pgtx);
 
   // TODO: We need a much safer way of detecting if the transaction should be a user operation

--- a/src/db/transactions/queueTx.ts
+++ b/src/db/transactions/queueTx.ts
@@ -1,4 +1,8 @@
-import type { DeployTransaction, Transaction } from "@thirdweb-dev/sdk";
+import type {
+  DeployTransaction,
+  Transaction,
+  TransactionError,
+} from "@thirdweb-dev/sdk";
 import { ERC4337EthersSigner } from "@thirdweb-dev/wallets/dist/declarations/src/evm/connectors/smart-wallet/lib/erc4337-signer";
 import { BigNumber } from "ethers";
 import type { ContractExtension } from "../../schema/extension";
@@ -25,7 +29,14 @@ export const queueTx = async ({
   deployedContractType,
 }: QueueTxParams) => {
   // Simulate transaction
-  await tx.simulate();
+  try {
+    if (!deployedContractAddress) {
+      await tx.simulate();
+    }
+  } catch (e) {
+    const message = (e as TransactionError)?.reason || (e as any).message || e;
+    throw new Error(`Transaction simulation failed with reason: ${message}`);
+  }
 
   const prisma = getPrismaWithPostgresTx(pgtx);
 


### PR DESCRIPTION
## Changes

- Transaction simulation was missing.
   - Looks like this was missed though a `TODO` to move simulation is there, on `queueTx()`.
- Added it in `queueTx()` 

