### PR TITLE
Increase transaction & user operation throughput & processing speed

### DIFF
--- a/test/benchmark/load.ts
+++ b/test/benchmark/load.ts
@@ -22,12 +22,13 @@ interface TimedResult extends TaskResult {
 
 const chain = `arbitrum-goerli`;
 const host = `https://engine-load-testing-small-s4ym.zeet-nftlabs.zeet.app`;
+// const host = `http://127.0.0.1:3005`;
 const deployerWalletAddress = `0x43CAe0d7fe86C713530E679Ce02574743b2Ee9FC`;
 const tokenAddress = `0x7A0CE8524bea337f0beE853B68fAbDE145dAC0A0`;
 const accountFactoryAddress = `0xD48f9d337626a991e5c86c38768DA09428Fa549B`;
 const thirdwebApiSecretKey = process.env.THIRDWEB_API_SECRET_KEY as string;
-const loadTestBatchSize = parseInt(process.env.LOAD_TEST_BATCH_SIZE || "2");
-const loadTestBatches = parseInt(process.env.LOAD_TEST_BATCHES || "60");
+const loadTestBatchSize = parseInt(process.env.LOAD_TEST_BATCH_SIZE || "30");
+const loadTestBatches = parseInt(process.env.LOAD_TEST_BATCHES || "1");
 
 const main = async () => {
   const { time: totalTime } = await time(async () => {


### PR DESCRIPTION
- Check for cancellation at the beginning of a batch (we should move toward cancellations in a `cancelledAt` field now)
- Send all user operations in parallel since they use multi-dimensional nonce
- Split transactions into batches by `walletAddress` & `chainId`, send all transactions per batch at once optimistically incrementing nonce, and then update nonce in database once.