### PR TITLE
RPC Override Fix

### DIFF
--- a/server/utilities/validator.ts
+++ b/server/utilities/validator.ts
@@ -86,3 +86,15 @@ export const checkAndReturnNFTSignaturePayload = <
 
   return updatedPayload;
 };
+
+export const isValidHttpUrl = (urlString: string): boolean => {
+  let url;
+
+  try {
+    url = new URL(urlString);
+  } catch (_) {
+    return false;
+  }
+
+  return url.protocol === "http:" || url.protocol === "https:";
+};


### PR DESCRIPTION
## Changes

- Implementation to retrieve the RPC Override data via the ENV Var (`CHAIN_OVERRIDES`) got removed during the port to Prisma.
- SDK Update also done to support this, else it was broken from SDK side too. Added a [PR](https://github.com/thirdweb-dev/js/pull/1746) for same.