### PR TITLE
OpenAPI : Server Url Removed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,11 +30,9 @@ POSTGRES_CONNECTION_URL="postgresql://postgres:postgres@localhost:5432/postgres?
 # ---------------
 # Defaults PORT to 3005
 # Defaults HOST to 0.0.0.0
-# Defaults OPENAPI_BASE_ORIGIN to http://localhost:3005
 # ---------------
 PORT=3005
 HOST="0.0.0.0"
-OPENAPI_BASE_ORIGIN=http://localhost:3005
 
 # CONFIGURATION OPTIONS [Optional]
 # ----------------------

--- a/docs/1-user-guide.md
+++ b/docs/1-user-guide.md
@@ -12,7 +12,6 @@
 | `HOST`                    | Host name of the API Server                                                                                         | `localhost`                                                          | ❌       |
 | `PORT`                    | Port number of the API Server                                                                                       | `3005`                                                               | ❌       |
 | `CHAIN_OVERRIDES`         | Pass your own RPC urls to override the default ones. This can be file or an URL. See example override-rpc-urls.json |                                                                      | ❌       |
-| `OPENAPI_BASE_ORIGIN`     | Base URL for Open API Specification. Should be the Base URL of your App.                                            | `http://localhost:3005`                                              | ❌       |
 
 ### Setup Instructions
 

--- a/docs/addons/faqs.md
+++ b/docs/addons/faqs.md
@@ -9,10 +9,6 @@
 
 _`tx_overrides` is an optional parameter that can be passed in the body of write (on-chain transactions) end-points. It is used to override the gas values & `value` property of the blockchain transaction. If you do not pass this parameter, the default values are used._
 
-### How to set Open API Base URL?
-
-_Set the `OPENAPI_BASE_ORIGIN` environment variable to the base URL of your app. This is used to generate the Open API Specification and allows Swagger UI interaction. The default value is `http://localhost:3005`._
-
 ### How to set the RPC URLs?
 
 _Set the `CHAIN_OVERRIDES` environment variable to the path of the JSON file or URL (file hosted somewhere on the internet) containing the RPC URLs. The default value is `./chain-overrides.json`. Check the [example file](../chain-overrides.example.json) for the format._

--- a/server/helpers/openapi.ts
+++ b/server/helpers/openapi.ts
@@ -1,7 +1,6 @@
 import swagger from "@fastify/swagger";
 import fastifySwaggerUI from "@fastify/swagger-ui";
 import { FastifyInstance } from "fastify";
-import { env } from "../../src/utils/env";
 
 // fastify-swagger v8 requires the swagger-ui & openapi specs
 // to be separate unlike old implementation
@@ -19,11 +18,6 @@ export const openapi = async (server: FastifyInstance) => {
           url: "http://www.apache.org/licenses/LICENSE-2.0.html",
         },
       },
-      servers: [
-        {
-          url: env.OPENAPI_BASE_ORIGIN,
-        },
-      ],
       components: {
         securitySchemes: {
           bearerAuth: {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -52,7 +52,6 @@ export const env = createEnv({
       .default(
         "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable",
       ),
-    OPENAPI_BASE_ORIGIN: z.string().default("http://localhost:3005"),
     PORT: z.coerce.number().default(3005),
     HOST: z.string().default("0.0.0.0"),
     ACCESS_CONTROL_ALLOW_ORIGIN: z.string().default("*"),
@@ -67,7 +66,6 @@ export const env = createEnv({
     POSTGRES_CONNECTION_URL: process.env.POSTGRES_CONNECTION_URL,
     PORT: process.env.PORT,
     HOST: process.env.HOST,
-    OPENAPI_BASE_ORIGIN: process.env.OPENAPI_BASE_ORIGIN,
     ACCESS_CONTROL_ALLOW_ORIGIN: process.env.ACCESS_CONTROL_ALLOW_ORIGIN,
   },
   onValidationError: (error: ZodError) => {


### PR DESCRIPTION
## Changes

- OpenAPI Server URL removed, because if not provided it uses the relative path.