### PR TITLE
Better response code+message when queueId cannot be found 

### DIFF
--- a/src/db/transactions/getTxById.ts
+++ b/src/db/transactions/getTxById.ts
@@ -1,13 +1,20 @@
+import { Static } from "@sinclair/typebox";
 import { PrismaTransaction } from "../../schema/prisma";
+import { transactionResponseSchema } from "../../server/schemas/transaction";
 import { getPrismaWithPostgresTx } from "../client";
 import { cleanTxs } from "./cleanTxs";
 
 interface GetTxByIdParams {
-  pgtx?: PrismaTransaction;
   queueId: string;
+  pgtx?: PrismaTransaction;
 }
 
-export const getTxById = async ({ pgtx, queueId }: GetTxByIdParams) => {
+export const getTxById = async ({
+  pgtx,
+  queueId,
+}: GetTxByIdParams): Promise<Static<
+  typeof transactionResponseSchema
+> | null> => {
   const prisma = getPrismaWithPostgresTx(pgtx);
 
   const tx = await prisma.transactions.findUnique({
@@ -15,10 +22,8 @@ export const getTxById = async ({ pgtx, queueId }: GetTxByIdParams) => {
       id: queueId,
     },
   });
-
   if (!tx) {
-    // TODO: Defined error types
-    throw new Error(`Transaction with queueId ${queueId} not found!`);
+    return null;
   }
 
   const [cleanedTx] = cleanTxs([tx]);

--- a/src/server/routes/transaction/status.ts
+++ b/src/server/routes/transaction/status.ts
@@ -76,6 +76,7 @@ export async function checkTxStatus(fastify: FastifyInstance) {
       },
     },
     handler: async (request, reply) => {
+      console.log("hello world");
       const { queueId } = request.params;
       const returnData = await getTxById({ queueId });
 
@@ -99,7 +100,10 @@ export async function checkTxStatus(fastify: FastifyInstance) {
       request.log.info(`Websocket Connection Established for ${queueId}`);
       findOrAddWSConnectionInSharedState(connection, queueId, request);
 
-      const returnData = await getTxById({ queueId: queueId });
+      const returnData = await getTxById({ queueId });
+      if (!returnData) {
+        throw new Error(`Transaction ${queueId} not found.`);
+      }
 
       const { message, closeConnection } =
         await getStatusMessageAndConnectionStatus(returnData);

--- a/src/server/routes/transaction/status.ts
+++ b/src/server/routes/transaction/status.ts
@@ -76,7 +76,6 @@ export async function checkTxStatus(fastify: FastifyInstance) {
       },
     },
     handler: async (request, reply) => {
-      console.log("hello world");
       const { queueId } = request.params;
       const returnData = await getTxById({ queueId });
 

--- a/src/server/routes/transaction/status.ts
+++ b/src/server/routes/transaction/status.ts
@@ -101,9 +101,6 @@ export async function checkTxStatus(fastify: FastifyInstance) {
       findOrAddWSConnectionInSharedState(connection, queueId, request);
 
       const returnData = await getTxById({ queueId });
-      if (!returnData) {
-        throw new Error(`Transaction ${queueId} not found.`);
-      }
 
       const { message, closeConnection } =
         await getStatusMessageAndConnectionStatus(returnData);

--- a/src/server/utils/transaction.ts
+++ b/src/server/utils/transaction.ts
@@ -20,6 +20,11 @@ export const cancelTransactionAndUpdate = async ({
   accountAddress,
 }: CancelTransactionAndUpdateParams) => {
   const txData = await getTxById({ queueId });
+  if (!txData) {
+    return {
+      message: `Transaction ${queueId} not found.`,
+    };
+  }
 
   let error = null;
   let transferTransactionResult: TransactionResponse | null = null;

--- a/src/server/utils/webhook.ts
+++ b/src/server/utils/webhook.ts
@@ -81,6 +81,9 @@ const sendWebhookRequest = async (
 export const sendTxWebhook = async (data: TxWebookParams): Promise<void> => {
   try {
     const txData = await getTxById({ queueId: data.id });
+    if (!txData) {
+      throw new Error(`Transaction ${data.id} not found.`);
+    }
 
     let webhookConfig: SanitizedWebHooksSchema[] | undefined =
       await getWebhookConfig(WebhooksEventTypes.ALL_TX);

--- a/src/server/utils/websocket.ts
+++ b/src/server/utils/websocket.ts
@@ -126,13 +126,16 @@ type CustomStatusAndConnectionType = {
 };
 
 export const getStatusMessageAndConnectionStatus = async (
-  data: Static<typeof transactionResponseSchema>,
+  data: Static<typeof transactionResponseSchema> | null,
 ): Promise<CustomStatusAndConnectionType> => {
   let message =
     "Request is queued. Waiting for transaction to be picked up by worker.";
   let closeConnection = false;
 
-  if (data.status === TransactionStatusEnum.Mined) {
+  if (!data) {
+    message = `Transaction not found. Make sure the provided ID is correct.`;
+    closeConnection = true;
+  } else if (data.status === TransactionStatusEnum.Mined) {
     message = "Transaction mined. Closing connection.";
     closeConnection = true;
   } else if (data.status === TransactionStatusEnum.Errored) {
@@ -149,12 +152,12 @@ export const getStatusMessageAndConnectionStatus = async (
 };
 
 export const formatSocketMessage = async (
-  data: Static<typeof transactionResponseSchema>,
+  data: Static<typeof transactionResponseSchema> | null,
   message: string,
 ): Promise<string> => {
   const returnData = JSON.stringify({
-    result: JSON.stringify(data),
-    queueId: data.queueId,
+    result: data ? JSON.stringify(data) : undefined,
+    queueId: data?.queueId,
     message,
   });
   return returnData;

--- a/src/worker/listeners/updateTxListener.ts
+++ b/src/worker/listeners/updateTxListener.ts
@@ -35,6 +35,10 @@ export const updateTxListener = async (): Promise<void> => {
       const returnData = await getTxById({
         queueId: parsedPayload.identifier,
       });
+      if (!returnData) {
+        throw new Error(`Transaction ${parsedPayload.identifier} not found.`);
+      }
+
       const { message, closeConnection } =
         await getStatusMessageAndConnectionStatus(returnData);
       userSubscription.socket.send(

--- a/src/worker/listeners/updateTxListener.ts
+++ b/src/worker/listeners/updateTxListener.ts
@@ -35,9 +35,6 @@ export const updateTxListener = async (): Promise<void> => {
       const returnData = await getTxById({
         queueId: parsedPayload.identifier,
       });
-      if (!returnData) {
-        throw new Error(`Transaction ${parsedPayload.identifier} not found.`);
-      }
 
       const { message, closeConnection } =
         await getStatusMessageAndConnectionStatus(returnData);


### PR DESCRIPTION
- Instead of returning 500, return 404 and/or appropriate error messages when the transaction cannot be found with the provided queue ID