### PR TITLE
Engine Version as Env Var on Docker Image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: thirdweb/engine:nightly
+          build-args: |
+            ENGINE_VERSION=nightly

--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -31,3 +31,5 @@ jobs:
           tags: |
             thirdweb/engine:${{ github.ref_name }}
             thirdweb/engine:latest
+          build-args: |
+            ENGINE_VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ CMD [ "sh", "-c", "yarn prisma:setup:dev && yarn dev:worker" ]
 # Production Node Modules stage
 FROM node:18.15.0-alpine AS prod-dependencies
 
-# Setting Docker Tag
+# Setting ENV variables for image information
 ENV ENGINE_VERSION=$DOCKER_TAG
 
 # Install build dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,9 @@ CMD [ "sh", "-c", "yarn prisma:setup:dev && yarn dev:worker" ]
 # Production Node Modules stage
 FROM node:18.15.0-alpine AS prod-dependencies
 
+# Setting Docker Tag
+ENV ENGINE_VERSION=$DOCKER_TAG
+
 # Install build dependencies
 RUN apk add --no-cache g++ make py3-pip openssl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,8 @@ CMD [ "sh", "-c", "yarn prisma:setup:dev && yarn dev:worker" ]
 FROM node:18.15.0-alpine AS prod-dependencies
 
 # Setting ENV variables for image information
-ENV ENGINE_VERSION=$ENGINE_VERSION
+ARG ENGINE_VERSION
+ENV ENGINE_VERSION=${ENGINE_VERSION}
 
 # Install build dependencies
 RUN apk add --no-cache g++ make py3-pip openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ CMD [ "sh", "-c", "yarn prisma:setup:dev && yarn dev:worker" ]
 FROM node:18.15.0-alpine AS prod-dependencies
 
 # Setting ENV variables for image information
-ENV ENGINE_VERSION=$DOCKER_TAG
+ENV ENGINE_VERSION=$ENGINE_VERSION
 
 # Install build dependencies
 RUN apk add --no-cache g++ make py3-pip openssl

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -5,6 +5,7 @@ import { isDatabaseHealthy } from "../../db/client";
 
 const ReplySchemaOk = Type.Object({
   status: Type.String(),
+  engineVersion: Type.Optional(Type.String()),
 });
 
 const ReplySchemaError = Type.Object({
@@ -39,6 +40,7 @@ export async function healthCheck(fastify: FastifyInstance) {
 
       res.status(StatusCodes.OK).send({
         status: "OK",
+        engineVersion: process.env.ENGINE_VERSION || undefined,
       });
     },
   });


### PR DESCRIPTION
## Changes

- Updated the Github workflow to set the `tag` as the ENGINE_VERSION during the build process and exposing this value on `/health` end-point