### PR TITLE
fix: API response body schema has no type `number`

### DIFF
--- a/src/server/schemas/sharedApiSchemas.ts
+++ b/src/server/schemas/sharedApiSchemas.ts
@@ -57,7 +57,7 @@ export const publishedDeployParamSchema = Type.Object({
  */
 const replyBodySchema = Type.Object({
   result: Type.Optional(
-    Type.Union([Type.String(), Type.Object({}), Type.Array(Type.Any())]),
+    Type.Union([Type.Number(), Type.String(), Type.Object({}), Type.Array(Type.Any())]),
   ),
 });
 


### PR DESCRIPTION
APIs may return `number` type response. The schema only accepts if the response is in the type of string, object, or array. This causes internal server errors.

This PR fixes #339 

## Changes

Type `number` has been added to the response body schema list.

## How this PR will be tested

- [ ] Run the Engine.
- [ ] Try to make a GET request to the `/contract/:chain/:contractAddress/read` API to call a contract's `decimals` function without arguments.
Request Params: "{"chain":"mumbai","contractAddress":"<ERC20_CONTRACT_ADDRESS>"}"
Request Querystring: "{"functionName":"decimals"}"
Result: Returns 200 with "{ result: 18 }" in the response body.

## Output

```
{ result: 18 }
```