### PR TITLE
Remove worker restarting

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,4 +1,3 @@
-import { logger } from "../utils/logger";
 import { deleteProcessedTx } from "./listeners/deleteProcessedTx";
 import { minedTxListener } from "./listeners/minedTxListener";
 import { queuedTxListener } from "./listeners/queuedTxListener";
@@ -23,25 +22,3 @@ const worker = async () => {
 };
 
 worker();
-
-process.on("unhandledRejection", (err) => {
-  logger({
-    service: "worker",
-    level: "fatal",
-    message: `unhandledRejection`,
-    error: err,
-  });
-
-  worker();
-});
-
-process.on("uncaughtException", (err) => {
-  logger({
-    service: "worker",
-    level: "fatal",
-    message: `uncaughtException`,
-    error: err,
-  });
-
-  worker();
-});


### PR DESCRIPTION
- Worker restarting flow should never get hit, as worker tasks are wrapped in `try/catch`
- Issues with worker processing are not because worker is not operating, but because `processTx` is not getting queued