### PR TITLE
[Breaking] Remove simulation on queueTx

### DIFF
--- a/src/db/transactions/queueTx.ts
+++ b/src/db/transactions/queueTx.ts
@@ -1,8 +1,4 @@
-import type {
-  DeployTransaction,
-  Transaction,
-  TransactionError,
-} from "@thirdweb-dev/sdk";
+import type { DeployTransaction, Transaction } from "@thirdweb-dev/sdk";
 import { ERC4337EthersSigner } from "@thirdweb-dev/wallets/dist/declarations/src/evm/connectors/smart-wallet/lib/erc4337-signer";
 import { BigNumber } from "ethers";
 import type { ContractExtension } from "../../schema/extension";
@@ -28,18 +24,6 @@ export const queueTx = async ({
   deployedContractAddress,
   deployedContractType,
 }: QueueTxParams) => {
-  try {
-    if (!deployedContractAddress) {
-      await tx.simulate();
-    }
-  } catch (err: any) {
-    const errorMessage =
-      (err as TransactionError)?.reason || (err as any).message || err;
-    throw new Error(
-      `Transaction simulation failed with reason: ${errorMessage}`,
-    );
-  }
-
   // TODO: We need a much safer way of detecting if the transaction should be a user operation
   const isUserOp = !!(tx.getSigner as ERC4337EthersSigner).erc4337provider;
   const txData = {


### PR DESCRIPTION
Not really breaking, but removing a behavior that may be expected.

We shouldn't do simulation on enqueue, we do simulation on worker anyway, and at scale, this simulation makes the request speed of our API very slow.

Instead, users should have the same flow in all cases (including errors) - write endpoints ALWAYS return a `queueId`, even errors are instant, and they check status of that `queueId` to get the error.

Currently, we still do simulation in contract deployment endpoints in order to get `deployedAddress` - might need to move off that as well.