### PR TITLE
fix: fetch chains from API to support newer chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@sinclair/typebox": "^0.31.28",
     "@t3-oss/env-core": "^0.6.0",
     "@thirdweb-dev/auth": "^4.1.0-nightly-c238fde8-20231020022304",
-    "@thirdweb-dev/chains": "^0.1.61-nightly-d2001ca4-20231209002129",
+    "@thirdweb-dev/chains": "^0.1.65",
     "@thirdweb-dev/sdk": "^4.0.23",
     "@thirdweb-dev/service-utils": "^0.4.2",
     "@thirdweb-dev/wallets": "^2.1.5",

--- a/src/server/utils/chain.ts
+++ b/src/server/utils/chain.ts
@@ -10,20 +10,26 @@ import { logger } from "../../utils/logger";
 /**
  * Given a valid chain name ('Polygon') or ID ('137'), return the numeric chain ID.
  */
-export const getChainIdFromChain = async (chain: string): Promise<number> => {
+export const getChainIdFromChain = async (input: string): Promise<number> => {
+  const inputSlug = input.toLowerCase();
+  // inputId may be NaN if a slug is provided ('Polygon').
+  const inputId = parseInt(input);
+
   const config = await getConfig();
 
   // Check if the chain ID exists in chainOverrides first.
   if (config.chainOverrides) {
     try {
-      const parsedChainOverrides = JSON.parse(config.chainOverrides);
-      const chainData: Static<typeof networkResponseSchema> | undefined =
-        parsedChainOverrides.find(
-          (chainData: Static<typeof networkResponseSchema>) =>
-            chainData.slug === chain,
-        );
-      if (chainData) {
-        return chainData.chainId;
+      const parsedChainOverrides: Static<typeof networkResponseSchema>[] =
+        JSON.parse(config.chainOverrides);
+
+      for (const chainData of parsedChainOverrides) {
+        if (
+          inputSlug === chainData.slug.toLowerCase() ||
+          inputId === chainData.chainId
+        ) {
+          return chainData.chainId;
+        }
       }
     } catch (e) {
       logger({
@@ -34,21 +40,21 @@ export const getChainIdFromChain = async (chain: string): Promise<number> => {
     }
   }
 
-  if (!isNaN(parseInt(chain))) {
+  if (!isNaN(inputId)) {
     // Fetch by chain ID.
-    const chainData = await getChainByChainIdAsync(parseInt(chain));
+    const chainData = await getChainByChainIdAsync(inputId);
     if (chainData) {
       return chainData.chainId;
     }
   } else {
     // Fetch by chain name.
-    const chainData = await getChainBySlugAsync(chain);
+    const chainData = await getChainBySlugAsync(inputSlug);
     if (chainData) {
       return chainData.chainId;
     }
   }
 
   throw new Error(
-    `Invalid chain. Please confirm this is a valid chain: https://thirdweb.com/${chain}`,
+    `Invalid chain. Please confirm this is a valid chain: https://thirdweb.com/${input}`,
   );
 };

--- a/src/tests/chain.test.ts
+++ b/src/tests/chain.test.ts
@@ -1,0 +1,82 @@
+import {
+  getChainByChainIdAsync,
+  getChainBySlugAsync,
+} from "@thirdweb-dev/chains";
+import { getChainIdFromChain } from "../server/utils/chain";
+import { getConfig } from "../utils/cache/getConfig";
+
+// Mock the external dependencies
+jest.mock("../utils/cache/getConfig");
+jest.mock("@thirdweb-dev/chains");
+
+const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>;
+const mockGetChainByChainIdAsync =
+  getChainByChainIdAsync as jest.MockedFunction<typeof getChainByChainIdAsync>;
+const mockGetChainBySlugAsync = getChainBySlugAsync as jest.MockedFunction<
+  typeof getChainBySlugAsync
+>;
+
+describe("getChainIdFromChain", () => {
+  beforeEach(() => {
+    // Clear all mock calls before each test
+    jest.clearAllMocks();
+  });
+
+  it("should return the chainId from chainOverrides if it exists", async () => {
+    // @ts-ignore
+    mockGetConfig.mockResolvedValueOnce({
+      chainOverrides: JSON.stringify([
+        {
+          slug: "Polygon",
+          chainId: 137,
+        },
+      ]),
+    });
+
+    const result = await getChainIdFromChain("Polygon");
+
+    expect(result).toBe(137);
+    expect(getChainByChainIdAsync).not.toHaveBeenCalled();
+    expect(getChainBySlugAsync).not.toHaveBeenCalled();
+  });
+
+  it("should return the chainId from getChainByChainIdAsync if chain is a valid numeric string", async () => {
+    // @ts-ignore
+    mockGetConfig.mockResolvedValueOnce({});
+    // @ts-ignore
+    mockGetChainByChainIdAsync.mockResolvedValueOnce({
+      name: "Mumbai",
+      chainId: 80001,
+    });
+
+    const result = await getChainIdFromChain("80001");
+
+    expect(result).toBe(80001);
+    expect(getChainByChainIdAsync).toHaveBeenCalledWith(80001);
+    expect(getChainBySlugAsync).not.toHaveBeenCalled();
+  });
+
+  it("should return the chainId from getChainBySlugAsync if chain is a valid string", async () => {
+    // @ts-ignore
+    mockGetConfig.mockResolvedValueOnce({});
+    // @ts-ignore
+    mockGetChainBySlugAsync.mockResolvedValueOnce({
+      chainId: 137,
+    });
+
+    const result = await getChainIdFromChain("Polygon");
+
+    expect(result).toBe(137);
+    expect(getChainBySlugAsync).toHaveBeenCalledWith("Polygon");
+    expect(getChainByChainIdAsync).not.toHaveBeenCalled();
+  });
+
+  it("should throw an error for an invalid chain", async () => {
+    // @ts-ignore
+    mockGetConfig.mockResolvedValueOnce({});
+
+    await expect(getChainIdFromChain("InvalidChain")).rejects.toThrow(
+      "Invalid chain. Please confirm this is a valid chain",
+    );
+  });
+});

--- a/src/tests/chain.test.ts
+++ b/src/tests/chain.test.ts
@@ -10,6 +10,7 @@ jest.mock("../utils/cache/getConfig");
 jest.mock("@thirdweb-dev/chains");
 
 const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>;
+
 const mockGetChainByChainIdAsync =
   getChainByChainIdAsync as jest.MockedFunction<typeof getChainByChainIdAsync>;
 const mockGetChainBySlugAsync = getChainBySlugAsync as jest.MockedFunction<
@@ -20,6 +21,60 @@ describe("getChainIdFromChain", () => {
   beforeEach(() => {
     // Clear all mock calls before each test
     jest.clearAllMocks();
+  });
+
+  it("should return the chainId from chainOverrides if it exists by slug", async () => {
+    // @ts-ignore
+    mockGetConfig.mockResolvedValueOnce({
+      chainOverrides: JSON.stringify([
+        {
+          slug: "Polygon",
+          chainId: 137,
+        },
+      ]),
+    });
+
+    const result = await getChainIdFromChain("Polygon");
+
+    expect(result).toBe(137);
+    expect(getChainByChainIdAsync).not.toHaveBeenCalled();
+    expect(getChainBySlugAsync).not.toHaveBeenCalled();
+  });
+
+  it("should return the chainId from chainOverrides if it exists by slug, case-insensitive", async () => {
+    // @ts-ignore
+    mockGetConfig.mockResolvedValueOnce({
+      chainOverrides: JSON.stringify([
+        {
+          slug: "Polygon",
+          chainId: 137,
+        },
+      ]),
+    });
+
+    const result = await getChainIdFromChain("polygon");
+
+    expect(result).toBe(137);
+    expect(getChainByChainIdAsync).not.toHaveBeenCalled();
+    expect(getChainBySlugAsync).not.toHaveBeenCalled();
+  });
+
+  it("should return the chainId from chainOverrides if it exists by ID", async () => {
+    // @ts-ignore
+    mockGetConfig.mockResolvedValueOnce({
+      chainOverrides: JSON.stringify([
+        {
+          slug: "Polygon",
+          chainId: 137,
+        },
+      ]),
+    });
+
+    const result = await getChainIdFromChain("137");
+
+    expect(result).toBe(137);
+    expect(getChainByChainIdAsync).not.toHaveBeenCalled();
+    expect(getChainBySlugAsync).not.toHaveBeenCalled();
   });
 
   it("should return the chainId from chainOverrides if it exists", async () => {
@@ -45,14 +100,14 @@ describe("getChainIdFromChain", () => {
     mockGetConfig.mockResolvedValueOnce({});
     // @ts-ignore
     mockGetChainByChainIdAsync.mockResolvedValueOnce({
-      name: "Mumbai",
-      chainId: 80001,
+      name: "Polygon",
+      chainId: 137,
     });
 
-    const result = await getChainIdFromChain("80001");
+    const result = await getChainIdFromChain("137");
 
-    expect(result).toBe(80001);
-    expect(getChainByChainIdAsync).toHaveBeenCalledWith(80001);
+    expect(result).toBe(137);
+    expect(getChainByChainIdAsync).toHaveBeenCalledWith(137);
     expect(getChainBySlugAsync).not.toHaveBeenCalled();
   });
 
@@ -61,13 +116,14 @@ describe("getChainIdFromChain", () => {
     mockGetConfig.mockResolvedValueOnce({});
     // @ts-ignore
     mockGetChainBySlugAsync.mockResolvedValueOnce({
+      name: "Polygon",
       chainId: 137,
     });
 
     const result = await getChainIdFromChain("Polygon");
 
     expect(result).toBe(137);
-    expect(getChainBySlugAsync).toHaveBeenCalledWith("Polygon");
+    expect(getChainBySlugAsync).toHaveBeenCalledWith("polygon");
     expect(getChainByChainIdAsync).not.toHaveBeenCalled();
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3435,10 +3435,10 @@
   resolved "https://registry.yarnpkg.com/@thirdweb-dev/chains/-/chains-0.1.62.tgz#d7a5c8bc71d3dac68c7da44b13b5ea7113a01151"
   integrity sha512-BLJEub6SIDfwktqLhFkeurVQbJp/RZeJLhzjjwxSWE4Kb1K7rv/nNkwRFXd3Hhc46DPJvrHuG3oBwkZgWxWgQw==
 
-"@thirdweb-dev/chains@^0.1.61-nightly-d2001ca4-20231209002129":
-  version "0.1.61-nightly-d2001ca4-20231209002129"
-  resolved "https://registry.yarnpkg.com/@thirdweb-dev/chains/-/chains-0.1.61-nightly-d2001ca4-20231209002129.tgz#366a284ae2fa2f81167b0e4941be1b3d74c05838"
-  integrity sha512-nQfCDMg9YY/7CS7S2X6Cu1U+RksS3lLUDoNQQyoo1S6pVBygYyzezgFNmX5TxB0S1VMwvM+rmSVk6ENbwr7B5Q==
+"@thirdweb-dev/chains@^0.1.65":
+  version "0.1.65"
+  resolved "https://registry.yarnpkg.com/@thirdweb-dev/chains/-/chains-0.1.65.tgz#a298e39d1c16b787008ace29b616bccc9b96d253"
+  integrity sha512-csxBZnnjSEAISjlQrYJP/FV4buUlqHb7NF4vX/15hYc31J6Z4vJPRWcsd2WhzPj9YXR5sgSJcu6ro2C6s4jmOA==
 
 "@thirdweb-dev/contracts-js@1.3.16":
   version "1.3.16"


### PR DESCRIPTION
## Changes

Since the chains package is a stale snapshot, newer chains are not discoverable by Engine.
Switching to the new async methods queries chains data from DB.

Performance impact should be minimal because the SDK caches chains by ID/slug forever after the initial request.

## How this PR will be tested

- [ ] Make a request to a newer chain like 80085.
