### PR TITLE
fix: Append env cors to make it backward compatible with db cors list

### DIFF
--- a/src/db/configuration/getConfiguration.ts
+++ b/src/db/configuration/getConfiguration.ts
@@ -185,9 +185,7 @@ export const getConfiguration = async (): Promise<Config> => {
         authDomain: "thirdweb.com",
         authWalletEncryptedJson: await createAuthWalletEncryptedJson(),
         minWalletBalance: "20000000000000000",
-        accessControlAllowOrigin: !!process.env.ACCESS_CONTROL_ALLOW_ORIGIN
-          ? process.env.ACCESS_CONTROL_ALLOW_ORIGIN
-          : mandatoryAllowedCorsUrls.join(","),
+        accessControlAllowOrigin: mandatoryAllowedCorsUrls.join(","),
         clearCacheCronSchedule: "*/30 * * * * *",
       },
       update: {},
@@ -200,9 +198,7 @@ export const getConfiguration = async (): Promise<Config> => {
     });
   } else if (!config.accessControlAllowOrigin) {
     config = await updateConfiguration({
-      accessControlAllowOrigin: !!process.env.ACCESS_CONTROL_ALLOW_ORIGIN
-        ? process.env.ACCESS_CONTROL_ALLOW_ORIGIN
-        : mandatoryAllowedCorsUrls.join(","),
+      accessControlAllowOrigin: mandatoryAllowedCorsUrls.join(","),
     });
   }
 

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -301,7 +301,7 @@ export const withAuth = async (server: FastifyInstance) => {
       }
 
       const authWebhooks = await getWebhook(WebhooksEventTypes.AUTH);
-      if (authWebhooks && authWebhooks.length > 0) {
+      if (authWebhooks.length > 0) {
         const authResponses = await Promise.all(
           authWebhooks.map((webhook) =>
             sendWebhookRequest(webhook, {

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -301,7 +301,7 @@ export const withAuth = async (server: FastifyInstance) => {
       }
 
       const authWebhooks = await getWebhook(WebhooksEventTypes.AUTH);
-      if (authWebhooks) {
+      if (authWebhooks && authWebhooks.length > 0) {
         const authResponses = await Promise.all(
           authWebhooks.map((webhook) =>
             sendWebhookRequest(webhook, {

--- a/src/server/middleware/cors/cors.ts
+++ b/src/server/middleware/cors/cors.ts
@@ -143,7 +143,14 @@ export const fastifyCors = async (
 ) => {
   const config = await getConfig();
 
-  const originArray = config.accessControlAllowOrigin.split(",") as string[];
+  const corsListConfig = config.accessControlAllowOrigin.split(",");
+  /**
+   * @deprecated
+   * Future versions will remove this env var.
+   */
+  const corsListEnv = process.env.ACCESS_CONTROL_ALLOW_ORIGIN?.split(",") ?? [];
+  const originArray = [...corsListConfig, ...corsListEnv];
+
   opts.origin = originArray.map(sanitizeOrigin);
 
   let hideOptionsRoute = true;

--- a/src/server/utils/webhook.ts
+++ b/src/server/utils/webhook.ts
@@ -122,7 +122,7 @@ export const sendWebhooks = async (webhooks: WebhookData[]) => {
 
     const webhookConfigs = await Promise.all([
       ...((await getWebhook(WebhooksEventTypes.ALL_TX)) || []),
-      ...(webhookStatus ? (await getWebhook(webhookStatus)) || [] : []),
+      ...(webhookStatus ? await getWebhook(webhookStatus) : []),
     ]);
 
     await Promise.all(
@@ -161,11 +161,11 @@ export const sendBalanceWebhook = async (
       return;
     }
 
-    const webhookConfig = await getWebhook(
+    const webhooks = await getWebhook(
       WebhooksEventTypes.BACKEND_WALLET_BALANCE,
     );
 
-    if (!webhookConfig) {
+    if (webhooks.length === 0) {
       logger({
         service: "server",
         level: "debug",
@@ -175,7 +175,7 @@ export const sendBalanceWebhook = async (
       return;
     }
 
-    webhookConfig.map(async (config) => {
+    webhooks.map(async (config) => {
       if (!config || !config.active) {
         logger({
           service: "server",

--- a/src/utils/cache/getWebhook.ts
+++ b/src/utils/cache/getWebhook.ts
@@ -12,10 +12,8 @@ export const getWebhook = async (
 ): Promise<SanitizedWebHooksSchema[]> => {
   const cacheKey = eventType;
 
-  if (retrieveFromCache) {
-    if (webhookCache.has(cacheKey) && webhookCache.get(cacheKey)) {
-      return webhookCache.get(cacheKey) as SanitizedWebHooksSchema[];
-    }
+  if (retrieveFromCache && webhookCache.has(cacheKey)) {
+    return webhookCache.get(cacheKey) as SanitizedWebHooksSchema[];
   }
 
   const webhookConfig = await getAllWebhooks();

--- a/src/utils/cache/getWebhook.ts
+++ b/src/utils/cache/getWebhook.ts
@@ -9,7 +9,7 @@ export const webhookCache = new Map<string, SanitizedWebHooksSchema[]>();
 export const getWebhook = async (
   eventType: WebhooksEventTypes,
   retrieveFromCache = true,
-): Promise<SanitizedWebHooksSchema[] | undefined> => {
+): Promise<SanitizedWebHooksSchema[]> => {
   const cacheKey = eventType;
 
   if (retrieveFromCache) {


### PR DESCRIPTION
## How this PR will be tested

- [x] Try to load an engine w/o env var into a thirdweb dashboard not hosted on thirdweb.com -> fail
- [x] Try to load an engine w/ env var (`ACCESS_CONTROL_ALLOW_ORIGIN=localhost:3000`) -> success
