### PR TITLE
add support for chainless domain relayer

### DIFF
--- a/src/constants/relayer.ts
+++ b/src/constants/relayer.ts
@@ -56,6 +56,66 @@ export const ForwarderAbi = [
   },
 ];
 
+export const ForwarderAbiEIP712ChainlessDomain = [
+  { inputs: [], stateMutability: "nonpayable", type: "constructor" },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "from", type: "address" },
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "value", type: "uint256" },
+          { internalType: "uint256", name: "gas", type: "uint256" },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "bytes", name: "data", type: "bytes" },
+          { internalType: "uint256", name: "chainid", type: "uint256" },
+        ],
+        internalType: "struct ForwarderChainlessDomain.ForwardRequest",
+        name: "req",
+        type: "tuple",
+      },
+      { internalType: "bytes", name: "signature", type: "bytes" },
+    ],
+    name: "execute",
+    outputs: [
+      { internalType: "bool", name: "", type: "bool" },
+      { internalType: "bytes", name: "", type: "bytes" },
+    ],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "from", type: "address" }],
+    name: "getNonce",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "from", type: "address" },
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "value", type: "uint256" },
+          { internalType: "uint256", name: "gas", type: "uint256" },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "bytes", name: "data", type: "bytes" },
+          { internalType: "uint256", name: "chainid", type: "uint256" },
+        ],
+        internalType: "struct ForwarderChainlessDomain.ForwardRequest",
+        name: "req",
+        type: "tuple",
+      },
+      { internalType: "bytes", name: "signature", type: "bytes" },
+    ],
+    name: "verify",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
 export const ERC2771ContextAbi = [
   {
     inputs: [

--- a/src/server/routes/relayer/index.ts
+++ b/src/server/routes/relayer/index.ts
@@ -6,6 +6,7 @@ import {
   ERC20PermitAbi,
   ERC2771ContextAbi,
   ForwarderAbi,
+  ForwarderAbiEIP712ChainlessDomain,
   NativeMetaTransaction,
 } from "../../../constants/relayer";
 import { getRelayerById } from "../../../db/relayer/getRelayerById";
@@ -30,6 +31,7 @@ const BodySchema = Type.Union([
       gas: Type.String(),
       nonce: Type.String(),
       data: Type.String(),
+      chainid: Type.Optional(Type.String()),
     }),
     signature: Type.String(),
     forwarderAddress: Type.String(),
@@ -252,9 +254,14 @@ export async function relayTransaction(fastify: FastifyInstance) {
         return;
       }
 
+      const isForwarderEIP712ChainlessDomain = !!request.chainid;
+      const forwarderAbi = isForwarderEIP712ChainlessDomain
+        ? ForwarderAbiEIP712ChainlessDomain
+        : ForwarderAbi;
+
       const forwarder = await sdk.getContractFromAbi(
         forwarderAddress,
-        ForwarderAbi,
+        forwarderAbi,
       );
 
       const valid = await forwarder.call("verify", [


### PR DESCRIPTION
## Changes

- added support for chainless domain forwarders
- add 'chainid' in relayer interface to use chainless domain forwarders

## How this PR will be tested

- [x] should successfully relay transaction with chainless domain forwarder
- [ ] should not cause relayer regressions

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)
