### PR TITLE
Optional ABI param for getContract

### DIFF
--- a/src/server/routes/contract/write/write.ts
+++ b/src/server/routes/contract/write/write.ts
@@ -69,7 +69,7 @@ export async function writeToContract(fastify: FastifyInstance) {
       body: writeRequestBodySchema,
     },
     handler: async (request, reply) => {
-      const { chain, contractAddress } = request.params;
+      const { chain, contractAddress, abi } = request.params;
       const { simulateTx } = request.query;
       const { functionName, args, txOverrides } = request.body;
       const walletAddress = request.headers[
@@ -82,6 +82,7 @@ export async function writeToContract(fastify: FastifyInstance) {
         contractAddress,
         walletAddress,
         accountAddress,
+        abi,
       });
 
       const tx = await contract.prepare(functionName, args, txOverrides);

--- a/src/server/schemas/sharedApiSchemas.ts
+++ b/src/server/schemas/sharedApiSchemas.ts
@@ -24,6 +24,11 @@ export const contractParamSchema = Type.Object({
     examples: ["0xc8be6265C06aC376876b4F62670adB3c4d72EABA"],
     description: "Contract address on the chain",
   }),
+  abi: Type.Optional(
+    Type.String({
+      description: "Optional ABI of the contract",
+    }),
+  ),
 });
 
 export const requestQuerystringSchema = Type.Object({

--- a/src/utils/cache/getContract.ts
+++ b/src/utils/cache/getContract.ts
@@ -1,3 +1,4 @@
+import { ContractInterface } from "ethers";
 import { getSdk } from "./getSdk";
 
 interface GetContractParams {
@@ -5,6 +6,7 @@ interface GetContractParams {
   walletAddress?: string;
   accountAddress?: string;
   contractAddress: string;
+  abi?: ContractInterface;
 }
 
 export const getContract = async ({
@@ -12,9 +14,12 @@ export const getContract = async ({
   walletAddress,
   contractAddress,
   accountAddress,
+  abi,
 }: GetContractParams) => {
   const sdk = await getSdk({ chainId, walletAddress, accountAddress });
 
   // We don't need to maintain cache for contracts because sdk handles it already
-  return sdk.getContract(contractAddress);
+  return abi
+    ? sdk.getContract(contractAddress, abi)
+    : sdk.getContract(contractAddress);
 };


### PR DESCRIPTION
Provide option to pass ABI as a contract param. 

This will be helpful in cases where the contract is not verified or the ABI can't be resolved by the SDK for certain type of proxies. If the user has the ABI, can pass that as contract param.
