### PR TITLE
fix: revert simulations to only use the prepared tx

### DIFF
--- a/src/db/transactions/queueTxRaw.ts
+++ b/src/db/transactions/queueTxRaw.ts
@@ -12,13 +12,13 @@ type QueueTxRawParams = Omit<
   simulateTx?: boolean;
 } & (
     | {
-        fromAddress: string;
-        signerAddress?: never;
-      }
+      fromAddress: string;
+      signerAddress?: never;
+    }
     | {
-        fromAddress?: never;
-        signerAddress: string;
-      }
+      fromAddress?: never;
+      signerAddress: string;
+    }
   );
 
 export const queueTxRaw = async ({
@@ -35,14 +35,9 @@ export const queueTxRaw = async ({
 
   if (!walletDetails) {
     throw new Error(
-      `No backend wallet found with address ${
-        tx.fromAddress || tx.signerAddress
+      `No backend wallet found with address ${tx.fromAddress || tx.signerAddress
       }`,
     );
-  }
-
-  if (shouldSimulate) {
-    await simulateTx({ txRaw: tx });
   }
 
   return prisma.transactions.create({

--- a/src/db/transactions/queueTxRaw.ts
+++ b/src/db/transactions/queueTxRaw.ts
@@ -1,6 +1,5 @@
 import type { Prisma } from "@prisma/client";
 import { PrismaTransaction } from "../../schema/prisma";
-import { simulateTx } from "../../server/utils/simulateTx";
 import { getPrismaWithPostgresTx } from "../client";
 import { getWalletDetails } from "../wallets/getWalletDetails";
 
@@ -22,7 +21,6 @@ type QueueTxRawParams = Omit<
   );
 
 export const queueTxRaw = async ({
-  simulateTx: shouldSimulate,
   pgtx,
   ...tx
 }: QueueTxRawParams) => {


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)
