### PR TITLE
Adds signTypedData Route to Sign EIP712 Messages with Backend Wallets

### DIFF
--- a/src/server/routes/backend-wallet/signTypedData.ts
+++ b/src/server/routes/backend-wallet/signTypedData.ts
@@ -1,0 +1,53 @@
+import type { TypedDataSigner } from "@ethersproject/abstract-signer";
+import { Static, Type } from "@sinclair/typebox";
+import { FastifyInstance } from "fastify";
+import { StatusCodes } from "http-status-codes";
+import { getWallet } from "../../../utils/cache/getWallet";
+import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
+import { walletAuthSchema } from "../../schemas/wallet";
+
+const BodySchema = Type.Object({
+  domain: Type.Object({}, { additionalProperties: true }),
+  types: Type.Object({}, { additionalProperties: true }),
+  value: Type.Object({}, { additionalProperties: true }),
+  isBytes: Type.Optional(Type.Boolean()),
+});
+
+const ReplySchema = Type.Object({
+  result: Type.String(),
+});
+
+export async function signTypedData(fastify: FastifyInstance) {
+  fastify.route<{
+    Body: Static<typeof BodySchema>;
+    Reply: Static<typeof ReplySchema>;
+  }>({
+    method: "POST",
+    url: "/backend-wallet/sign-typed-data",
+    schema: {
+      summary: "Sign a EIP-712 message",
+      description: "Send a EIP-712 message",
+      tags: ["Backend Wallet"],
+      operationId: "signTypedData",
+      body: BodySchema,
+      headers: Type.Omit(walletAuthSchema, ["x-account-address"]),
+      response: {
+        ...standardResponseSchema,
+        [StatusCodes.OK]: ReplySchema,
+      },
+    },
+    handler: async (req, res) => {
+      const { domain, value, types, isBytes } = req.body;
+      const walletAddress = req.headers["x-backend-wallet-address"] as string;
+
+      const wallet = await getWallet({ chainId: 1, walletAddress });
+
+      const signer = (await wallet.getSigner()) as unknown as TypedDataSigner;
+      const result = await signer._signTypedData(domain, types, value);
+
+      res.status(200).send({
+        result: result,
+      });
+    },
+  });
+}

--- a/src/server/routes/backend-wallet/signTypedData.ts
+++ b/src/server/routes/backend-wallet/signTypedData.ts
@@ -10,7 +10,6 @@ const BodySchema = Type.Object({
   domain: Type.Object({}, { additionalProperties: true }),
   types: Type.Object({}, { additionalProperties: true }),
   value: Type.Object({}, { additionalProperties: true }),
-  isBytes: Type.Optional(Type.Boolean()),
 });
 
 const ReplySchema = Type.Object({
@@ -37,7 +36,7 @@ export async function signTypedData(fastify: FastifyInstance) {
       },
     },
     handler: async (req, res) => {
-      const { domain, value, types, isBytes } = req.body;
+      const { domain, value, types } = req.body;
       const walletAddress = req.headers["x-backend-wallet-address"] as string;
 
       const wallet = await getWallet({ chainId: 1, walletAddress });

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -85,6 +85,7 @@ import { grantPermissions } from "./auth/permissions/grant";
 import { revokePermissions } from "./auth/permissions/revoke";
 import { signMessage } from "./backend-wallet/signMessage";
 import { signTransaction } from "./backend-wallet/signTransaction";
+import { signTypedData } from "./backend-wallet/signTypedData";
 import { getAuthConfiguration } from "./configuration/auth/get";
 import { updateAuthConfiguration } from "./configuration/auth/update";
 
@@ -102,6 +103,7 @@ import { revokeRelayer } from "./relayer/revoke";
 import { getAllTransactions } from "./backend-wallet/getTransactions";
 import { resetBackendWalletNonces } from "./backend-wallet/resetNonces";
 import { sendTransactionBatch } from "./backend-wallet/sendTransactionBatch";
+import { simulateTransaction } from "./backend-wallet/simulateTransaction";
 import { withdraw } from "./backend-wallet/withdraw";
 import { home } from "./home";
 import { updateRelayer } from "./relayer/update";
@@ -110,7 +112,6 @@ import { queueStatus } from "./system/queue";
 import { checkGroupStatus } from "./transaction/group";
 import { sendSignedTransaction } from "./transaction/sendSignedTx";
 import { sendSignedUserOp } from "./transaction/sendSignedUserOp";
-import { simulateTransaction } from "./backend-wallet/simulateTransaction";
 
 export const withRoutes = async (fastify: FastifyInstance) => {
   // Backend Wallets
@@ -125,6 +126,7 @@ export const withRoutes = async (fastify: FastifyInstance) => {
   await fastify.register(sendTransactionBatch);
   await fastify.register(signTransaction);
   await fastify.register(signMessage);
+  await fastify.register(signTypedData);
   await fastify.register(getAllTransactions);
   await fastify.register(resetBackendWalletNonces);
   await fastify.register(getBackendWalletNonce);


### PR DESCRIPTION
## Changes
- Farcaster and other off-chain protocols rely heavily on EIP-712 signatures to verify user actions
- Adds a `/sign-typed-data` route so backend wallets can easily sign typed, structured messages

## How this PR will be tested
- [ ] Submit the example input to `/backend-wallet/sign-typed-data`
- [ ] Verify output by directly calling `signTypedData` in ethers v6

Example input:
```
{
"domain": {
    "name": "Ether Mail",
    "version": "1",
    "chainId": 1,
    "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
},
"types": {
    "Person": [
        { "name": "name", "type": "string" },
        { "name": "wallet", "type": "address" }
    ],
    "Mail": [
        { "name": "from", "type": "Person" },
        { "name": "to", "type": "Person" },
        { "name": "contents", "type": "string" }
    ]
},
"value": {
    "from": {
        "name": "Cow",
        "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
    },
    "to": {
        "name": "Bob",
        "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
    },
    "contents": "Hello, Bob!"
}}
```

