### PR TITLE
fix: server crash when async fetch call times out

### DIFF
--- a/src/server/routes/transaction/sendSignedUserOp.ts
+++ b/src/server/routes/transaction/sendSignedUserOp.ts
@@ -2,7 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { deriveClientId } from "../../../utils/api-keys";
+import { thirdwebClientId } from "../../../utils/api-keys";
 import { env } from "../../../utils/env";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 import { getChainIdFromChain } from "../../utils/chain";
@@ -104,7 +104,7 @@ export async function sendSignedUserOp(fastify: FastifyInstance) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-client-id": deriveClientId(env.THIRDWEB_API_SECRET_KEY),
+          "x-client-id": thirdwebClientId,
           "x-secret-key": env.THIRDWEB_API_SECRET_KEY,
         },
         body: JSON.stringify({

--- a/src/utils/api-keys.ts
+++ b/src/utils/api-keys.ts
@@ -1,11 +1,6 @@
 import { sha256HexSync } from "@thirdweb-dev/crypto";
+import { env } from "./env";
 
-let clientId: string | undefined;
-
-export const deriveClientId = (secretKey: string): string => {
-  if (!clientId) {
-    const hashedSecretKey = sha256HexSync(secretKey);
-    clientId = hashedSecretKey.slice(0, 32);
-  }
-  return clientId;
-};
+export const thirdwebClientId = sha256HexSync(
+  env.THIRDWEB_API_SECRET_KEY,
+).slice(0, 32);

--- a/src/utils/api-keys.ts
+++ b/src/utils/api-keys.ts
@@ -1,7 +1,11 @@
 import { sha256HexSync } from "@thirdweb-dev/crypto";
 
+let clientId: string | undefined;
+
 export const deriveClientId = (secretKey: string): string => {
-  const hashedSecretKey = sha256HexSync(secretKey);
-  const derivedClientId = hashedSecretKey.slice(0, 32);
-  return derivedClientId;
+  if (!clientId) {
+    const hashedSecretKey = sha256HexSync(secretKey);
+    clientId = hashedSecretKey.slice(0, 32);
+  }
+  return clientId;
 };

--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -73,107 +73,101 @@ const createHeaderForRequest = (input: CreateHeaderForRequestParams) => {
 };
 
 export const withServerUsageReporting = (server: FastifyInstance) => {
+  // Skip reporting if CLIENT_ANALYTICS_URL is not set.
+  if (env.CLIENT_ANALYTICS_URL === "") {
+    return;
+  }
+
   server.addHook("onResponse", async (request, reply) => {
+    if (
+      URLS_LIST_TO_NOT_REPORT_USAGE.has(reply.request.routerPath) ||
+      reply.request.method === "OPTIONS"
+    ) {
+      return;
+    }
+
+    const derivedClientId = deriveClientId(env.THIRDWEB_API_SECRET_KEY);
+    const headers = createHeaderForRequest({
+      clientId: derivedClientId,
+    });
+
+    const requestParams = request?.params as Static<typeof EngineRequestParams>;
+
+    const chainId = requestParams?.chain
+      ? await getChainIdFromChain(requestParams.chain)
+      : "";
+
+    const requestBody: UsageEventSchema = {
+      source: "engine",
+      action: UsageEventTxActionEnum.APIRequest,
+      clientId: derivedClientId,
+      pathname: reply.request.routerPath,
+      chainId: chainId || undefined,
+      walletAddress: requestParams.walletAddress || undefined,
+      contractAddress: requestParams.contractAddress || undefined,
+      httpStatusCode: reply.statusCode,
+      msTotalDuration: Math.ceil(reply.getResponseTime()),
+    };
+
+    fetch(env.CLIENT_ANALYTICS_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(requestBody),
+    }).catch(); // Catch uncaught exceptions since this fetch call is non-blocking.
+  });
+};
+
+export const reportUsage = (usageParams: ReportUsageParams[]) => {
+  // If the CLIENT_ANALYTICS_URL is not set, then we don't want to report usage
+  if (env.CLIENT_ANALYTICS_URL === "") {
+    return;
+  }
+
+  usageParams.map(async (item) => {
     try {
-      // If the CLIENT_ANALYTICS_URL is not set, then we don't want to report usage
-      if (env.CLIENT_ANALYTICS_URL === "") {
-        return;
-      }
-
-      if (
-        URLS_LIST_TO_NOT_REPORT_USAGE.has(reply.request.routerPath) ||
-        reply.request.method === "OPTIONS"
-      ) {
-        return;
-      }
-
       const derivedClientId = deriveClientId(env.THIRDWEB_API_SECRET_KEY);
       const headers = createHeaderForRequest({
         clientId: derivedClientId,
       });
 
-      const requestParams = request?.params as Static<
-        typeof EngineRequestParams
-      >;
-
-      const chainId = requestParams?.chain
-        ? await getChainIdFromChain(requestParams.chain)
-        : "";
-
+      const chainId = item.input.chainId
+        ? parseInt(item.input.chainId)
+        : undefined;
       const requestBody: UsageEventSchema = {
         source: "engine",
-        action: UsageEventTxActionEnum.APIRequest,
+        action: item.action,
         clientId: derivedClientId,
-        pathname: reply.request.routerPath,
-        chainId: chainId || undefined,
-        walletAddress: requestParams.walletAddress || undefined,
-        contractAddress: requestParams.contractAddress || undefined,
-        httpStatusCode: reply.statusCode,
-        msTotalDuration: Math.ceil(reply.getResponseTime()),
+        chainId,
+        walletAddress: item.input.fromAddress || undefined,
+        contractAddress: item.input.toAddress || undefined,
+        transactionValue: item.input.value || undefined,
+        transactionHash: item.input.transactionHash || undefined,
+        userOpHash: item.input.userOpHash || undefined,
+        errorCode: item.input.onChainTxStatus
+          ? item.input.onChainTxStatus === 0
+            ? "EXECUTION_REVERTED"
+            : undefined
+          : item.error?.reason || undefined,
+        functionName: item.input.functionName || undefined,
+        extension: item.input.extension || undefined,
+        retryCount: item.input.retryCount || undefined,
+        provider: item.input.provider || undefined,
+        msSinceSend: item.input.msSinceSend || undefined,
+        msSinceQueue: item.input.msSinceQueue || undefined,
       };
 
       fetch(env.CLIENT_ANALYTICS_URL, {
         method: "POST",
         headers,
         body: JSON.stringify(requestBody),
+      }).catch(); // Catch uncaught exceptions since this fetch call is non-blocking.
+    } catch (e) {
+      logger({
+        service: "worker",
+        level: "error",
+        message: `Error:`,
+        error,
       });
-    } catch (e) {}
+    }
   });
-};
-
-export const reportUsage = (usageParams: ReportUsageParams[]) => {
-  try {
-    usageParams.map(async (item) => {
-      try {
-        // If the CLIENT_ANALYTICS_URL is not set, then we don't want to report usage
-        if (env.CLIENT_ANALYTICS_URL === "") {
-          return;
-        }
-
-        const derivedClientId = deriveClientId(env.THIRDWEB_API_SECRET_KEY);
-        const headers = createHeaderForRequest({
-          clientId: derivedClientId,
-        });
-
-        const chainId = item.input.chainId
-          ? parseInt(item.input.chainId)
-          : undefined;
-        const requestBody: UsageEventSchema = {
-          source: "engine",
-          action: item.action,
-          clientId: derivedClientId,
-          chainId,
-          walletAddress: item.input.fromAddress || undefined,
-          contractAddress: item.input.toAddress || undefined,
-          transactionValue: item.input.value || undefined,
-          transactionHash: item.input.transactionHash || undefined,
-          userOpHash: item.input.userOpHash || undefined,
-          errorCode: item.input.onChainTxStatus
-            ? item.input.onChainTxStatus === 0
-              ? "EXECUTION_REVERTED"
-              : undefined
-            : item.error?.reason || undefined,
-          functionName: item.input.functionName || undefined,
-          extension: item.input.extension || undefined,
-          retryCount: item.input.retryCount || undefined,
-          provider: item.input.provider || undefined,
-          msSinceSend: item.input.msSinceSend || undefined,
-          msSinceQueue: item.input.msSinceQueue || undefined,
-        };
-
-        fetch(env.CLIENT_ANALYTICS_URL, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(requestBody),
-        });
-      } catch (e) {}
-    });
-  } catch (error) {
-    logger({
-      service: "worker",
-      level: "error",
-      message: `Error:`,
-      error,
-    });
-  }
 };

--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -118,7 +118,7 @@ export const withServerUsageReporting = (server: FastifyInstance) => {
 };
 
 export const reportUsage = (usageParams: ReportUsageParams[]) => {
-  // If the CLIENT_ANALYTICS_URL is not set, then we don't want to report usage
+  // Skip reporting if CLIENT_ANALYTICS_URL is not set.
   if (env.CLIENT_ANALYTICS_URL === "") {
     return;
   }

--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -5,7 +5,7 @@ import { FastifyInstance } from "fastify";
 import { contractParamSchema } from "../server/schemas/sharedApiSchemas";
 import { walletParamSchema } from "../server/schemas/wallet";
 import { getChainIdFromChain } from "../server/utils/chain";
-import { deriveClientId } from "./api-keys";
+import { thirdwebClientId } from "./api-keys";
 import { env } from "./env";
 import { logger } from "./logger";
 
@@ -86,9 +86,8 @@ export const withServerUsageReporting = (server: FastifyInstance) => {
       return;
     }
 
-    const derivedClientId = deriveClientId(env.THIRDWEB_API_SECRET_KEY);
     const headers = createHeaderForRequest({
-      clientId: derivedClientId,
+      clientId: thirdwebClientId,
     });
 
     const requestParams = request?.params as Static<typeof EngineRequestParams>;
@@ -100,7 +99,7 @@ export const withServerUsageReporting = (server: FastifyInstance) => {
     const requestBody: UsageEventSchema = {
       source: "engine",
       action: UsageEventTxActionEnum.APIRequest,
-      clientId: derivedClientId,
+      clientId: thirdwebClientId,
       pathname: reply.request.routerPath,
       chainId: chainId || undefined,
       walletAddress: requestParams.walletAddress || undefined,
@@ -113,7 +112,7 @@ export const withServerUsageReporting = (server: FastifyInstance) => {
       method: "POST",
       headers,
       body: JSON.stringify(requestBody),
-    }).catch(); // Catch uncaught exceptions since this fetch call is non-blocking.
+    }).catch(() => {}); // Catch uncaught exceptions since this fetch call is non-blocking.
   });
 };
 
@@ -125,9 +124,8 @@ export const reportUsage = (usageParams: ReportUsageParams[]) => {
 
   usageParams.map(async (item) => {
     try {
-      const derivedClientId = deriveClientId(env.THIRDWEB_API_SECRET_KEY);
       const headers = createHeaderForRequest({
-        clientId: derivedClientId,
+        clientId: thirdwebClientId,
       });
 
       const chainId = item.input.chainId
@@ -136,7 +134,7 @@ export const reportUsage = (usageParams: ReportUsageParams[]) => {
       const requestBody: UsageEventSchema = {
         source: "engine",
         action: item.action,
-        clientId: derivedClientId,
+        clientId: thirdwebClientId,
         chainId,
         walletAddress: item.input.fromAddress || undefined,
         contractAddress: item.input.toAddress || undefined,
@@ -160,7 +158,7 @@ export const reportUsage = (usageParams: ReportUsageParams[]) => {
         method: "POST",
         headers,
         body: JSON.stringify(requestBody),
-      }).catch(); // Catch uncaught exceptions since this fetch call is non-blocking.
+      }).catch(() => {}); // Catch uncaught exceptions since this fetch call is non-blocking.
     } catch (e) {
       logger({
         service: "worker",


### PR DESCRIPTION
## Changes

- Catch exceptions in async fetch calls.
- Cache deriving clientId. It never changes for the duration of a service.