### PR TITLE
Add cancel-listing endpoint to API docs

### DIFF
--- a/src/server/routes/contract/extensions/marketplaceV3/index.ts
+++ b/src/server/routes/contract/extensions/marketplaceV3/index.ts
@@ -28,6 +28,7 @@ import { englishAuctionsCreateAuction } from "./englishAuctions/write/createAuct
 import { englishAuctionsExecuteSale } from "./englishAuctions/write/executeSale";
 import { englishAuctionsMakeBid } from "./englishAuctions/write/makeBid";
 
+import { directListingsCancelListing } from "./directListings/write/cancelListing";
 import { englishAuctionsGetWinner } from "./englishAuctions/read/getWinner";
 import { offersGetAll } from "./offers/read/getAll";
 import { offersGetAllValid } from "./offers/read/getAllValid";
@@ -74,6 +75,7 @@ export const marketplaceV3Routes = async (fastify: FastifyInstance) => {
   await fastify.register(directListingsApproveBuyerForReservedListing);
   await fastify.register(directListingsRevokeBuyerApprovalForReservedListing);
   await fastify.register(directListingsRevokeCurrencyApprovalForListing);
+  await fastify.register(directListingsCancelListing);
 
   // English Auctions
   await fastify.register(englishAuctionsBuyoutAuction);


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)
