### PR TITLE
fix: use toHexString() for gas values

### DIFF
--- a/src/server/routes/transaction/blockchain/getTxReceipt.ts
+++ b/src/server/routes/transaction/blockchain/getTxReceipt.ts
@@ -136,9 +136,9 @@ export async function getTxHashReceipt(fastify: FastifyInstance) {
         result: receipt
           ? {
               ...receipt,
-              gasUsed: receipt.gasUsed.toString(),
-              cumulativeGasUsed: receipt.cumulativeGasUsed.toString(),
-              effectiveGasPrice: receipt.effectiveGasPrice.toString(),
+              gasUsed: receipt.gasUsed.toHexString(),
+              cumulativeGasUsed: receipt.cumulativeGasUsed.toHexString(),
+              effectiveGasPrice: receipt.effectiveGasPrice.toHexString(),
             }
           : null,
       });


### PR DESCRIPTION
## Changes

- in `GET /transaction/:chain/tx-hash/:txHash`, return gas values in hex string instead of numeric string