### PR TITLE
feat: Add update token metadata endpoints

### DIFF
--- a/src/server/routes/contract/extensions/erc1155/index.ts
+++ b/src/server/routes/contract/extensions/erc1155/index.ts
@@ -27,6 +27,7 @@ import { erc1155SignatureMint } from "./write/signatureMint";
 import { erc1155transfer } from "./write/transfer";
 import { erc1155transferFrom } from "./write/transferFrom";
 import { erc1155UpdateClaimConditions } from "./write/updateClaimConditions";
+import { erc1155UpdateTokeneMetadata } from "./write/updateTokenMetadata";
 
 export const erc1155Routes = async (fastify: FastifyInstance) => {
   // GET
@@ -60,4 +61,5 @@ export const erc1155Routes = async (fastify: FastifyInstance) => {
   await fastify.register(erc1155SetClaimCondition);
   await fastify.register(erc1155SetBatchClaimConditions);
   await fastify.register(erc1155UpdateClaimConditions);
+  await fastify.register(erc1155UpdateTokeneMetadata);
 };

--- a/src/server/routes/contract/extensions/erc1155/index.ts
+++ b/src/server/routes/contract/extensions/erc1155/index.ts
@@ -27,7 +27,7 @@ import { erc1155SignatureMint } from "./write/signatureMint";
 import { erc1155transfer } from "./write/transfer";
 import { erc1155transferFrom } from "./write/transferFrom";
 import { erc1155UpdateClaimConditions } from "./write/updateClaimConditions";
-import { erc1155UpdateTokeneMetadata } from "./write/updateTokenMetadata";
+import { erc1155UpdateTokenMetadata } from "./write/updateTokenMetadata";
 
 export const erc1155Routes = async (fastify: FastifyInstance) => {
   // GET
@@ -61,5 +61,5 @@ export const erc1155Routes = async (fastify: FastifyInstance) => {
   await fastify.register(erc1155SetClaimCondition);
   await fastify.register(erc1155SetBatchClaimConditions);
   await fastify.register(erc1155UpdateClaimConditions);
-  await fastify.register(erc1155UpdateTokeneMetadata);
+  await fastify.register(erc1155UpdateTokenMetadata);
 };

--- a/src/server/routes/contract/extensions/erc1155/write/updateTokenMetadata.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/updateTokenMetadata.ts
@@ -16,12 +16,14 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUT
 const requestSchema = contractParamSchema;
 const requestBodySchema = Type.Object({
-  tokenId: Type.String(),
+  tokenId: Type.String({
+    description: "Token ID to update metadata",
+  }),
   metadata: nftMetadataInputSchema,
 });
 
 // LOGIC
-export async function erc1155UpdateTokeneMetadata(fastify: FastifyInstance) {
+export async function erc1155UpdateTokenMetadata(fastify: FastifyInstance) {
   fastify.route<{
     Params: Static<typeof requestSchema>;
     Reply: Static<typeof transactionWritesResponseSchema>;
@@ -29,7 +31,7 @@ export async function erc1155UpdateTokeneMetadata(fastify: FastifyInstance) {
     Querystring: Static<typeof requestQuerystringSchema>;
   }>({
     method: "POST",
-    url: "/contract/:chain/:contractAddress/erc1155/metadata/update",
+    url: "/contract/:chain/:contractAddress/erc1155/token/update",
     schema: {
       summary: "Update token metadata",
       description: "Update the metadata for an ERC1155 token.",

--- a/src/server/routes/contract/extensions/erc1155/write/updateTokenMetadata.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/updateTokenMetadata.ts
@@ -1,0 +1,81 @@
+import { Static, Type } from "@sinclair/typebox";
+import { FastifyInstance } from "fastify";
+import { StatusCodes } from "http-status-codes";
+import { queueTx } from "../../../../../../db/transactions/queueTx";
+import { getContract } from "../../../../../../utils/cache/getContract";
+import { nftMetadataInputSchema } from "../../../../../schemas/nft";
+import {
+  contractParamSchema,
+  requestQuerystringSchema,
+  standardResponseSchema,
+  transactionWritesResponseSchema,
+} from "../../../../../schemas/sharedApiSchemas";
+import { walletAuthSchema } from "../../../../../schemas/wallet";
+import { getChainIdFromChain } from "../../../../../utils/chain";
+
+// INPUT
+const requestSchema = contractParamSchema;
+const requestBodySchema = Type.Object({
+  tokenId: Type.String(),
+  metadata: nftMetadataInputSchema,
+});
+
+// LOGIC
+export async function erc1155UpdateTokeneMetadata(fastify: FastifyInstance) {
+  fastify.route<{
+    Params: Static<typeof requestSchema>;
+    Reply: Static<typeof transactionWritesResponseSchema>;
+    Body: Static<typeof requestBodySchema>;
+    Querystring: Static<typeof requestQuerystringSchema>;
+  }>({
+    method: "POST",
+    url: "/contract/:chain/:contractAddress/erc1155/metadata/update",
+    schema: {
+      summary: "Update token metadata",
+      description: "Update the metadata for an ERC1155 token.",
+      tags: ["ERC1155"],
+      operationId: "updateTokenMetadata",
+      params: requestSchema,
+      body: requestBodySchema,
+      headers: walletAuthSchema,
+      querystring: requestQuerystringSchema,
+      response: {
+        ...standardResponseSchema,
+        [StatusCodes.OK]: transactionWritesResponseSchema,
+      },
+    },
+    handler: async (request, reply) => {
+      const { chain, contractAddress } = request.params;
+      const { simulateTx } = request.query;
+      const { tokenId, metadata } = request.body;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
+      const accountAddress = request.headers["x-account-address"] as string;
+      const chainId = await getChainIdFromChain(chain);
+      const contract = await getContract({
+        chainId,
+        contractAddress,
+        walletAddress,
+        accountAddress,
+      });
+
+      const tx = await contract.erc1155.updateMetadata.prepare(
+        tokenId,
+        metadata,
+      );
+      const queueId = await queueTx({
+        tx,
+        chainId,
+        simulateTx,
+        extension: "erc1155",
+      });
+
+      reply.status(StatusCodes.OK).send({
+        result: {
+          queueId,
+        },
+      });
+    },
+  });
+}

--- a/src/server/routes/contract/extensions/erc721/index.ts
+++ b/src/server/routes/contract/extensions/erc721/index.ts
@@ -26,7 +26,7 @@ import { erc721SignatureMint } from "./write/signatureMint";
 import { erc721transfer } from "./write/transfer";
 import { erc721transferFrom } from "./write/transferFrom";
 import { erc721UpdateClaimConditions } from "./write/updateClaimConditions";
-import { erc721UpdateTokeneMetadata } from "./write/updateTokenMetadata";
+import { erc721UpdateTokenMetadata } from "./write/updateTokenMetadata";
 
 export const erc721Routes = async (fastify: FastifyInstance) => {
   // GET
@@ -59,5 +59,5 @@ export const erc721Routes = async (fastify: FastifyInstance) => {
   await fastify.register(erc721SetClaimConditions);
   await fastify.register(erc721UpdateClaimConditions);
   await fastify.register(erc721SignaturePrepare);
-  await fastify.register(erc721UpdateTokeneMetadata);
+  await fastify.register(erc721UpdateTokenMetadata);
 };

--- a/src/server/routes/contract/extensions/erc721/index.ts
+++ b/src/server/routes/contract/extensions/erc721/index.ts
@@ -26,6 +26,7 @@ import { erc721SignatureMint } from "./write/signatureMint";
 import { erc721transfer } from "./write/transfer";
 import { erc721transferFrom } from "./write/transferFrom";
 import { erc721UpdateClaimConditions } from "./write/updateClaimConditions";
+import { erc721UpdateTokeneMetadata } from "./write/updateTokenMetadata";
 
 export const erc721Routes = async (fastify: FastifyInstance) => {
   // GET
@@ -58,4 +59,5 @@ export const erc721Routes = async (fastify: FastifyInstance) => {
   await fastify.register(erc721SetClaimConditions);
   await fastify.register(erc721UpdateClaimConditions);
   await fastify.register(erc721SignaturePrepare);
+  await fastify.register(erc721UpdateTokeneMetadata);
 };

--- a/src/server/routes/contract/extensions/erc721/write/updateTokenMetadata.ts
+++ b/src/server/routes/contract/extensions/erc721/write/updateTokenMetadata.ts
@@ -1,0 +1,81 @@
+import { Static, Type } from "@sinclair/typebox";
+import { FastifyInstance } from "fastify";
+import { StatusCodes } from "http-status-codes";
+import { queueTx } from "../../../../../../db/transactions/queueTx";
+import { getContract } from "../../../../../../utils/cache/getContract";
+import { nftMetadataInputSchema } from "../../../../../schemas/nft";
+import {
+  contractParamSchema,
+  requestQuerystringSchema,
+  standardResponseSchema,
+  transactionWritesResponseSchema,
+} from "../../../../../schemas/sharedApiSchemas";
+import { walletAuthSchema } from "../../../../../schemas/wallet";
+import { getChainIdFromChain } from "../../../../../utils/chain";
+
+// INPUT
+const requestSchema = contractParamSchema;
+const requestBodySchema = Type.Object({
+  tokenId: Type.String(),
+  metadata: nftMetadataInputSchema,
+});
+
+// LOGIC
+export async function erc721UpdateTokeneMetadata(fastify: FastifyInstance) {
+  fastify.route<{
+    Params: Static<typeof requestSchema>;
+    Reply: Static<typeof transactionWritesResponseSchema>;
+    Body: Static<typeof requestBodySchema>;
+    Querystring: Static<typeof requestQuerystringSchema>;
+  }>({
+    method: "POST",
+    url: "/contract/:chain/:contractAddress/erc721/metadata/update",
+    schema: {
+      summary: "Update token metadata",
+      description: "Update the metadata for an ERC721 token.",
+      tags: ["ERC721"],
+      operationId: "updateTokenMetadata",
+      params: requestSchema,
+      body: requestBodySchema,
+      headers: walletAuthSchema,
+      querystring: requestQuerystringSchema,
+      response: {
+        ...standardResponseSchema,
+        [StatusCodes.OK]: transactionWritesResponseSchema,
+      },
+    },
+    handler: async (request, reply) => {
+      const { chain, contractAddress } = request.params;
+      const { simulateTx } = request.query;
+      const { tokenId, metadata } = request.body;
+      const walletAddress = request.headers[
+        "x-backend-wallet-address"
+      ] as string;
+      const accountAddress = request.headers["x-account-address"] as string;
+      const chainId = await getChainIdFromChain(chain);
+      const contract = await getContract({
+        chainId,
+        contractAddress,
+        walletAddress,
+        accountAddress,
+      });
+
+      const tx = await contract.erc721.updateMetadata.prepare(
+        tokenId,
+        metadata,
+      );
+      const queueId = await queueTx({
+        tx,
+        chainId,
+        simulateTx,
+        extension: "erc721",
+      });
+
+      reply.status(StatusCodes.OK).send({
+        result: {
+          queueId,
+        },
+      });
+    },
+  });
+}

--- a/src/server/routes/contract/extensions/erc721/write/updateTokenMetadata.ts
+++ b/src/server/routes/contract/extensions/erc721/write/updateTokenMetadata.ts
@@ -16,12 +16,14 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUT
 const requestSchema = contractParamSchema;
 const requestBodySchema = Type.Object({
-  tokenId: Type.String(),
+  tokenId: Type.String({
+    description: "Token ID to update metadata",
+  }),
   metadata: nftMetadataInputSchema,
 });
 
 // LOGIC
-export async function erc721UpdateTokeneMetadata(fastify: FastifyInstance) {
+export async function erc721UpdateTokenMetadata(fastify: FastifyInstance) {
   fastify.route<{
     Params: Static<typeof requestSchema>;
     Reply: Static<typeof transactionWritesResponseSchema>;

--- a/src/server/routes/contract/extensions/erc721/write/updateTokenMetadata.ts
+++ b/src/server/routes/contract/extensions/erc721/write/updateTokenMetadata.ts
@@ -31,7 +31,7 @@ export async function erc721UpdateTokenMetadata(fastify: FastifyInstance) {
     Querystring: Static<typeof requestQuerystringSchema>;
   }>({
     method: "POST",
-    url: "/contract/:chain/:contractAddress/erc721/metadata/update",
+    url: "/contract/:chain/:contractAddress/erc721/token/update",
     schema: {
       summary: "Update token metadata",
       description: "Update the metadata for an ERC721 token.",


### PR DESCRIPTION
## Changes

- Add `POST /contract/:chain/:contractAddress/erc721/token/update`
- Add `POST /contract/:chain/:contractAddress/erc1155/token/update`

Updates token metadata. Example usage:
```curl
curl \
    -H "Authorization: Bearer <REDACTED>" \
    -H "Content-Type: application/json" \
    -H "x-backend-wallet-address: 0x4a1677844da684c840f1780817601fd3db715286" \
    -d '{"tokenId": "0", "metadata": {"name":"Updated NFT title"}}' \
    "http://localhost:3005/contract/80001/0x4B9008ef0176dA2909296B4764344cd2a5E46610/erc721/token/update"
```