### PR TITLE
fix: Updated minedTx flow + removed deleteAllNonce on start-up

### DIFF
--- a/src/db/transactions/getSentTxs.ts
+++ b/src/db/transactions/getSentTxs.ts
@@ -22,7 +22,7 @@ export const getSentTxs = async ({ pgtx }: GetSentTxsParams = {}): Promise<
     AND "minedAt" IS NULL
     AND "errorMessage" IS NULL
     AND "retryCount" < ${config.maxTxsToUpdate}
-    ORDER BY "sentAt" ASC
+    ORDER BY "nonce" ASC
     LIMIT ${config.maxTxsToUpdate}
     FOR UPDATE SKIP LOCKED
   `;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,7 +3,6 @@ import fastify, { FastifyInstance } from "fastify";
 import * as fs from "fs";
 import path from "path";
 import { URL } from "url";
-import { deleteAllWalletNonces } from "../db/wallets/deleteAllWalletNonces";
 import { clearCacheCron } from "../utils/cron/clearCacheCron";
 import { env } from "../utils/env";
 import { logger } from "../utils/logger";
@@ -34,10 +33,6 @@ interface HttpsObject {
 }
 
 export const initServer = async () => {
-  // Reset any server state that is safe to reset.
-  // This allows the server to start in a predictable state.
-  await deleteAllWalletNonces({});
-
   // Enables the server to run on https://localhost:PORT, if ENABLE_HTTPS is provided.
   let httpsObject: HttpsObject | undefined = undefined;
   if (env.ENABLE_HTTPS) {

--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -47,6 +47,7 @@ export enum UsageEventTxActionEnum {
   SendTx = "send_tx",
   CancelTx = "cancel_tx",
   APIRequest = "api_request",
+  ErrorTx = "error_tx",
 }
 
 interface UsageEventSchema extends Omit<UsageEvent, "action"> {

--- a/src/worker/tasks/retryTx.ts
+++ b/src/worker/tasks/retryTx.ts
@@ -98,7 +98,7 @@ export const retryTx = async () => {
               retryCount: tx.retryCount + 1 || 0,
               provider: provider.connection.url || undefined,
             },
-            action: UsageEventTxActionEnum.NotSendTx,
+            action: UsageEventTxActionEnum.ErrorTx,
           });
 
           reportUsage(reportUsageForQueueIds);

--- a/src/worker/tasks/updateMinedTx.ts
+++ b/src/worker/tasks/updateMinedTx.ts
@@ -96,7 +96,7 @@ export const updateMinedTx = async () => {
                         provider: provider.connection.url || undefined,
                         msSinceSend: Date.now() - tx.sentAt!.getTime(),
                       },
-                      action: UsageEventTxActionEnum.NotSendTx,
+                      action: UsageEventTxActionEnum.ErrorTx,
                     });
                   }
                 }


### PR DESCRIPTION
Updated minedTx Flow:
 - Added try-catch to handle error on `cancelTransactionAndUpdate()`. On Error, mark the transaction as Errored.

Removed `deleteAllNonce()` on start-up:
 - This was causing nonce desync on restart as it was deleting nonce table information.