### PR TITLE
CICD for beta-nightly image

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,43 @@
+name: Build on beta branch
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: beta # checkout the main branch to build nightly
+
+      - name: Check Disk Space Before Build
+        run: df -h
+
+      - name: Docker Prune
+        run: docker system prune -af
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          target: prod
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: thirdweb/engine:beta-nightly
+          build-args: |
+            ENGINE_VERSION=beta-nightly
+
+      - name: Check Disk Space After Build
+        run: df -h


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a GitHub Actions workflow to build and push a Docker image for the beta branch.

### Detailed summary
- Added a GitHub Actions workflow `beta.yml` for building on the beta branch
- Workflow triggered by manual workflow dispatch
- Includes steps to check disk space, prune Docker, set up Docker Buildx, login to DockerHub, build and push Docker image
- Docker image built for linux/amd64 and linux/arm64 platforms
- Image tagged as `thirdweb/engine:beta-nightly` with build arguments specifying ENGINE_VERSION as `beta-nightly`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->