### PR TITLE
Added querystring to fastify route

### DIFF
--- a/src/server/routes/contract/subscriptions/getLatestBlock.ts
+++ b/src/server/routes/contract/subscriptions/getLatestBlock.ts
@@ -33,6 +33,7 @@ export async function getLatestBlock(fastify: FastifyInstance) {
       description: "Get latest indexed block for a chain",
       tags: ["Contract-Subscriptions"],
       operationId: "getLatestBlock",
+      querystring: chainRequestQuerystringSchema,
       response: {
         ...standardResponseSchema,
         [StatusCodes.OK]: responseSchema,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a `querystring` property to the `getLatestBlock` route in the Contract-Subscriptions module.

### Detailed summary
- Added `querystring` property with `chainRequestQuerystringSchema` to the `getLatestBlock` route.
- Defined response schemas for the route.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->