### PR TITLE
fix: reject deprecated chains

### DIFF
--- a/src/server/utils/chain.ts
+++ b/src/server/utils/chain.ts
@@ -43,18 +43,18 @@ export const getChainIdFromChain = async (input: string): Promise<number> => {
   if (!isNaN(inputId)) {
     // Fetch by chain ID.
     const chainData = await getChainByChainIdAsync(inputId);
-    if (chainData) {
+    if (chainData && chainData.status !== "deprecated") {
       return chainData.chainId;
     }
   } else {
     // Fetch by chain name.
     const chainData = await getChainBySlugAsync(inputSlug);
-    if (chainData) {
+    if (chainData && chainData.status !== "deprecated") {
       return chainData.chainId;
     }
   }
 
   throw new Error(
-    `Invalid chain. Please confirm this is a valid chain: https://thirdweb.com/${input}`,
+    `Invalid or deprecated chain. Please confirm this is a valid chain: https://thirdweb.com/${input}`,
   );
 };


### PR DESCRIPTION
## Changes

- Throw if accessing a deprecated chain

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the validation logic for fetching chain data by chain ID or name, ensuring that only non-deprecated chains are returned.

### Detailed summary
- Updated the logic to check if the fetched chain data is not deprecated before returning the chain ID.
- Improved error message to include information about deprecated chains.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->