### PR TITLE
fix: Use latest eth_getLogs block as toBlock

### DIFF
--- a/src/server/routes/configuration/cors/add.ts
+++ b/src/server/routes/configuration/cors/add.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { updateConfiguration } from "../../../../db/configuration/updateConfiguration";
+import { dedupeArray } from "../../../../utils/array";
 import { getConfig } from "../../../../utils/cache/getConfig";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 import { mandatoryAllowedCorsUrls } from "../../../utils/cors-urls";
@@ -54,12 +55,10 @@ export async function addUrlToCorsConfiguration(fastify: FastifyInstance) {
       });
 
       await updateConfiguration({
-        accessControlAllowOrigin: [
-          ...new Set([
-            ...urlsToAdd,
-            ...oldConfig.accessControlAllowOrigin.split(","),
-          ]),
-        ].join(","),
+        accessControlAllowOrigin: dedupeArray([
+          ...urlsToAdd,
+          ...oldConfig.accessControlAllowOrigin.split(","),
+        ]).join(","),
       });
 
       // Fetch and return the updated configuration

--- a/src/server/routes/configuration/cors/remove.ts
+++ b/src/server/routes/configuration/cors/remove.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { updateConfiguration } from "../../../../db/configuration/updateConfiguration";
+import { dedupeArray } from "../../../../utils/array";
 import { getConfig } from "../../../../utils/cache/getConfig";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 import { mandatoryAllowedCorsUrls } from "../../../utils/cors-urls";
@@ -61,9 +62,7 @@ export async function removeUrlToCorsConfiguration(fastify: FastifyInstance) {
         .filter((url) => !urlsToRemove.includes(url));
 
       await updateConfiguration({
-        accessControlAllowOrigin: [...new Set([...newAllowOriginsList])].join(
-          ",",
-        ),
+        accessControlAllowOrigin: dedupeArray(newAllowOriginsList).join(","),
       });
 
       // Fetch and return the updated configuration

--- a/src/server/routes/configuration/cors/set.ts
+++ b/src/server/routes/configuration/cors/set.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { updateConfiguration } from "../../../../db/configuration/updateConfiguration";
+import { dedupeArray } from "../../../../utils/array";
 import { getConfig } from "../../../../utils/cache/getConfig";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 import { mandatoryAllowedCorsUrls } from "../../../utils/cors-urls";
@@ -44,13 +45,11 @@ export async function setUrlsToCorsConfiguration(fastify: FastifyInstance) {
     handler: async (req, res) => {
       const urls = req.body.urls.map((url) => url.trim());
 
-      // Add required domains and dedupe.
-      const dedupe = Array.from(
-        new Set([...urls, ...mandatoryAllowedCorsUrls]),
-      );
-
       await updateConfiguration({
-        accessControlAllowOrigin: dedupe.join(","),
+        accessControlAllowOrigin: dedupeArray([
+          ...urls,
+          ...mandatoryAllowedCorsUrls,
+        ]).join(","),
       });
 
       // Fetch and return the updated configuration

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,3 @@
+export const dedupeArray = <T>(array: T[]): T[] => {
+  return [...new Set(array)];
+};

--- a/src/worker/tasks/chainIndexer.ts
+++ b/src/worker/tasks/chainIndexer.ts
@@ -14,6 +14,8 @@ import { getSdk } from "../../utils/cache/getSdk";
 import { logger } from "../../utils/logger";
 import { getContractId } from "../utils/contractId";
 
+const NUM_BLOCKS_TO_RECHECK = 2;
+
 export interface GetSubscribedContractsLogsParams {
   chainId: number;
   contractAddresses: string[];
@@ -278,6 +280,12 @@ export const createChainIndexerTask = async (
           let lastIndexedBlock;
           try {
             lastIndexedBlock = await getBlockForIndexing({ chainId, pgtx });
+
+            // RPC may provide incomplete data for new blocks from the previous scan.
+            // Re-check the last few blocks to capture any missing onchain data.
+            if (lastIndexedBlock > 0) {
+              lastIndexedBlock -= NUM_BLOCKS_TO_RECHECK;
+            }
           } catch (error) {
             // row is locked, return
             return;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a `dedupeArray` utility function to remove duplicates in arrays across multiple files for improved code readability and maintenance.

### Detailed summary
- Added `dedupeArray` utility function to remove duplicates in arrays for cleaner code.
- Replaced array deduplication logic with `dedupeArray` function in `removeUrlToCorsConfiguration`, `addUrlToCorsConfiguration`, `setUrlsToCorsConfiguration`, and `chainIndexer.ts` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->