### PR TITLE
feat: Add subscription delay envvar

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -67,6 +67,10 @@ export const env = createEnv({
     SDK_BATCH_TIME_LIMIT: z.coerce.number().default(0),
     SDK_BATCH_SIZE_LIMIT: z.coerce.number().default(100),
     ENABLE_KEYPAIR_AUTH: boolSchema("false"),
+    CONTRACT_SUBSCRIPTIONS_DELAY_SECONDS: z.coerce
+      .number()
+      .nonnegative()
+      .default(0),
   },
   clientPrefix: "NEVER_USED",
   client: {},
@@ -88,6 +92,8 @@ export const env = createEnv({
     SDK_BATCH_TIME_LIMIT: process.env.SDK_BATCH_TIME_LIMIT,
     SDK_BATCH_SIZE_LIMIT: process.env.SDK_BATCH_SIZE_LIMIT,
     ENABLE_KEYPAIR_AUTH: process.env.ENABLE_KEYPAIR_AUTH,
+    CONTRACT_SUBSCRIPTIONS_DELAY_SECONDS:
+      process.env.CONTRACT_SUBSCRIPTIONS_DELAY_SECONDS,
   },
   onValidationError: (error: ZodError) => {
     console.error(

--- a/src/worker/tasks/chainIndexer.ts
+++ b/src/worker/tasks/chainIndexer.ts
@@ -268,10 +268,13 @@ const indexTransactionReceipts = async ({
   }
 };
 
-export const createChainIndexerTask = async (
-  chainId: number,
-  maxBlocksToIndex: number,
-) => {
+export const createChainIndexerTask = async (args: {
+  chainId: number;
+  maxBlocksToIndex: number;
+  toBlockOffset: number;
+}) => {
+  const { chainId, maxBlocksToIndex, toBlockOffset } = args;
+
   const chainIndexerTask = async () => {
     try {
       await prisma.$transaction(
@@ -287,7 +290,8 @@ export const createChainIndexerTask = async (
           const sdk = await getSdk({ chainId });
 
           const provider = sdk.getProvider();
-          const currentBlockNumber = await provider.getBlockNumber();
+          const currentBlockNumber =
+            (await provider.getBlockNumber()) - toBlockOffset;
 
           // check if up-to-date
           if (lastIndexedBlock >= currentBlockNumber) {

--- a/src/worker/tasks/chainIndexer.ts
+++ b/src/worker/tasks/chainIndexer.ts
@@ -300,8 +300,8 @@ export const createChainIndexerTask = async (args: {
 
           // limit max block numbers
           let toBlockNumber = currentBlockNumber;
-          if (currentBlockNumber - (lastIndexedBlock + 1) > maxBlocksToIndex) {
-            toBlockNumber = lastIndexedBlock + 1 + maxBlocksToIndex;
+          if (currentBlockNumber - lastIndexedBlock > maxBlocksToIndex) {
+            toBlockNumber = lastIndexedBlock + maxBlocksToIndex;
           }
 
           const subscribedContracts = await getContractSubscriptionsByChainId(
@@ -319,14 +319,14 @@ export const createChainIndexerTask = async (args: {
             indexContractEvents({
               pgtx,
               chainId,
-              fromBlockNumber: lastIndexedBlock + 1,
+              fromBlockNumber: lastIndexedBlock,
               toBlockNumber,
               subscribedContractAddresses,
             }),
             indexTransactionReceipts({
               pgtx,
               chainId,
-              fromBlockNumber: lastIndexedBlock + 1,
+              fromBlockNumber: lastIndexedBlock,
               toBlockNumber,
               subscribedContractAddresses,
             }),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a new environment variable `CONTRACT_SUBSCRIPTIONS_DELAY_SECONDS` and utilize it to compute block offsets in the chain indexer tasks.

### Detailed summary
- Added `CONTRACT_SUBSCRIPTIONS_DELAY_SECONDS` environment variable
- Used the variable to calculate block offsets in chain indexer tasks
- Refactored `createChainIndexerTask` function to accept block offset parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->