### PR TITLE
Added GH Workflow to publish to NPM

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -24,19 +24,20 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
+        working-directory: ./sdk
         run: yarn install
 
       - name: Get version from package.json
         id: package_version
-        run: echo "PACKAGE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV
+        run: echo "PACKAGE_VERSION=$(jq -r '.version' ./sdk/package.json)" >> $GITHUB_ENV
 
       - name: Use version
-        run: echo "The version from package.json is $PACKAGE_VERSION"
+        run: echo "SDK version is $PACKAGE_VERSION"
 
       - name: Build
         run: yarn build
 
       - name: Push to npm
-        run: npm publish ./dist --tag ${{ github.event.inputs.npm_tag }}
+        run: npm publish ./sdk --tag ${{ github.event.inputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -38,6 +38,7 @@ jobs:
         run: yarn generate:sdk
 
       - name: Push to npm
-        run: npm publish ./sdk --tag ${{ github.event.inputs.npm_tag }}
+        working-directory: ./sdk
+        run: npm publish --tag ${{ github.event.inputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -1,0 +1,42 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      npm_tag:
+        description: "Release type latest"
+        required: true
+        default: "latest"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: "main"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14" # Use Node.js version 14
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Get version from package.json
+        id: package_version
+        run: echo "PACKAGE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV
+
+      - name: Use version
+        run: echo "The version from package.json is $PACKAGE_VERSION"
+
+      - name: Build
+        run: yarn build
+
+      - name: Push to npm
+        run: npm publish ./dist --tag ${{ github.event.inputs.npm_tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo "SDK version is $PACKAGE_VERSION"
 
       - name: Build
-        run: yarn build
+        run: yarn generate:sdk
 
       - name: Push to npm
         run: npm publish ./sdk --tag ${{ github.event.inputs.npm_tag }}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thirdweb-dev/engine",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/thirdweb-dev-engine.cjs.js",
   "module": "dist/thirdweb-dev-engine.esm.js",
   "files": [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of `@thirdweb-dev/engine` to `0.0.6` and adds a GitHub workflow for publishing to npm with specific version tagging.

### Detailed summary
- Updated package version to `0.0.6`
- Added GitHub workflow for npm publishing
- Workflow includes steps for version retrieval, building, and publishing to npm with specific tag

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->