### PR TITLE
updated the logs to print the correct delay

### DIFF
--- a/src/worker/tasks/processTransactionReceiptsWorker.ts
+++ b/src/worker/tasks/processTransactionReceiptsWorker.ts
@@ -154,7 +154,7 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
         insertedReceipts.length
       } receipts on chain: ${chainId}, block: ${insertedReceipts.map(
         (receipt) => receipt.blockNumber,
-      )} after ${job.delay / 1000}s.`,
+      )} after ${job.opts.delay / 1000}s.`,
     });
   }
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the delay property in the `processTransactionReceiptsWorker.ts` file to use `job.opts.delay` instead of `job.delay`.

### Detailed summary
- Updated delay property to use `job.opts.delay` instead of `job.delay`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->