### PR TITLE
chore: hide experimental contract subscription APIs

### DIFF
--- a/src/server/routes/contract/events/getContractEventLogs.ts
+++ b/src/server/routes/contract/events/getContractEventLogs.ts
@@ -93,6 +93,7 @@ export async function getContractEventLogs(fastify: FastifyInstance) {
         ...standardResponseSchema,
         [StatusCodes.OK]: responseSchema,
       },
+      hide: true,
     },
     handler: async (request, reply) => {
       const { chain, contractAddress } = request.params;

--- a/src/server/routes/contract/events/getEventLogsByTimestamp.ts
+++ b/src/server/routes/contract/events/getEventLogsByTimestamp.ts
@@ -70,6 +70,7 @@ export async function getEventLogs(fastify: FastifyInstance) {
         ...standardResponseSchema,
         [StatusCodes.OK]: responseSchema,
       },
+      hide: true,
     },
     handler: async (request, reply) => {
       const {

--- a/src/server/routes/contract/events/paginateEventLogs.ts
+++ b/src/server/routes/contract/events/paginateEventLogs.ts
@@ -73,6 +73,7 @@ export async function pageEventLogs(fastify: FastifyInstance) {
         ...standardResponseSchema,
         [StatusCodes.OK]: responseSchema,
       },
+      hide: true,
     },
     handler: async (request, reply) => {
       const { cursor, pageSize, topics, contractAddresses } = request.query;

--- a/src/server/routes/contract/transactions/getTransactionReceipts.ts
+++ b/src/server/routes/contract/transactions/getTransactionReceipts.ts
@@ -69,6 +69,7 @@ export async function getContractTransactionReceipts(fastify: FastifyInstance) {
         ...standardResponseSchema,
         [StatusCodes.OK]: responseSchema,
       },
+      hide: true,
     },
     handler: async (request, reply) => {
       const { chain, contractAddress } = request.params;

--- a/src/server/routes/contract/transactions/getTransactionReceiptsByTimestamp.ts
+++ b/src/server/routes/contract/transactions/getTransactionReceiptsByTimestamp.ts
@@ -61,6 +61,7 @@ export async function getContractTransactionReceiptsByTimestamp(
         ...standardResponseSchema,
         [StatusCodes.OK]: responseSchema,
       },
+      hide: true,
     },
     handler: async (request, reply) => {
       const { contractAddresses, fromBlockTimestamp, toBlockTimestamp } =

--- a/src/server/routes/contract/transactions/paginateTransactionReceipts.ts
+++ b/src/server/routes/contract/transactions/paginateTransactionReceipts.ts
@@ -69,6 +69,7 @@ export async function pageTransactionReceipts(fastify: FastifyInstance) {
         ...standardResponseSchema,
         [StatusCodes.OK]: responseSchema,
       },
+      hide: true,
     },
     handler: async (request, reply) => {
       const { cursor, pageSize, contractAddresses } = request.query;

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -273,11 +273,13 @@ export const withRoutes = async (fastify: FastifyInstance) => {
   await fastify.register(getLatestBlock);
 
   // Contract Transactions
+  // @deprecated
   await fastify.register(getContractTransactionReceipts);
   await fastify.register(getContractTransactionReceiptsByTimestamp);
   await fastify.register(pageTransactionReceipts);
 
   // Contract Event Logs
+  // @deprecated
   await fastify.register(getContractEventLogs);
   await fastify.register(getEventLogs);
   await fastify.register(pageEventLogs);


### PR DESCRIPTION
Hides experimental contract subscription APIs from Swagger. They will be changed in a future commit.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to deprecate certain routes related to contract transactions and event logs in the server.

### Detailed summary
- Added `hide: true` to certain route configurations
- Deprecated specific routes for contract transactions and event logs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->