### PR TITLE
chore: Return 4xx if invalid contract or chain in API call

### DIFF
--- a/src/server/routes/backend-wallet/transfer.ts
+++ b/src/server/routes/backend-wallet/transfer.ts
@@ -90,10 +90,10 @@ export async function transfer(fastify: FastifyInstance) {
 
         const balance = await sdk.getBalance(walletAddress);
 
-        if (balance.value.lt(normalizedValue)) {
+        if (balance.value.lte(normalizedValue)) {
           throw createCustomError(
             "Insufficient balance",
-            StatusCodes.BAD_GATEWAY,
+            StatusCodes.BAD_REQUEST,
             "INSUFFICIENT_BALANCE",
           );
         }

--- a/src/utils/cache/getContract.ts
+++ b/src/utils/cache/getContract.ts
@@ -1,3 +1,5 @@
+import { StatusCodes } from "http-status-codes";
+import { createCustomError } from "../../server/middleware/error";
 import { getSdk } from "./getSdk";
 
 interface GetContractParams {
@@ -15,6 +17,14 @@ export const getContract = async ({
 }: GetContractParams) => {
   const sdk = await getSdk({ chainId, walletAddress, accountAddress });
 
-  // We don't need to maintain cache for contracts because sdk handles it already
-  return sdk.getContract(contractAddress);
+  try {
+    // SDK already handles caching.
+    return sdk.getContract(contractAddress);
+  } catch (e) {
+    throw createCustomError(
+      `Contract metadata could not be resolved: ${e}`,
+      StatusCodes.BAD_REQUEST,
+      "INVALID_CONTRACT",
+    );
+  }
 };

--- a/src/utils/cache/getContract.ts
+++ b/src/utils/cache/getContract.ts
@@ -19,7 +19,7 @@ export const getContract = async ({
 
   try {
     // SDK already handles caching.
-    return sdk.getContract(contractAddress);
+    return await sdk.getContract(contractAddress);
   } catch (e) {
     throw createCustomError(
       `Contract metadata could not be resolved: ${e}`,


### PR DESCRIPTION
Don't return 5xx if an API call is made with an invalid contract or chain

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves error handling and caching in backend-wallet transfer and chain resolution. 

### Detailed summary
- Updated comparison from `lt` to `lte` in balance check
- Improved error handling in `getContract` with custom error creation
- Enhanced chain resolution with error handling and deprecation check

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->