### PR TITLE
Updated: Backend-wallet `send-transaction` to allow tx-overrides

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thirdweb-dev/engine",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/thirdweb-dev-engine.cjs.js",
   "module": "dist/thirdweb-dev-engine.esm.js",
   "files": [

--- a/src/server/routes/backend-wallet/sendTransaction.ts
+++ b/src/server/routes/backend-wallet/sendTransaction.ts
@@ -30,6 +30,17 @@ const requestBodySchema = Type.Object({
   ...txOverridesWithoutValue.properties,
 });
 
+requestBodySchema.examples = [
+  {
+    toAddress: "0x7a0ce8524bea337f0bee853b68fabde145dac0a0",
+    data: "0x449a52f800000000000000000000000043cae0d7fe86c713530e679ce02574743b2ee9fc0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+    value: "0x00",
+    txOverrides: {
+      gas: "50000",
+    },
+  },
+];
+
 export async function sendTransaction(fastify: FastifyInstance) {
   fastify.route<{
     Params: Static<typeof ParamsSchema>;

--- a/src/server/routes/backend-wallet/sendTransaction.ts
+++ b/src/server/routes/backend-wallet/sendTransaction.ts
@@ -7,6 +7,7 @@ import {
   standardResponseSchema,
   transactionWritesResponseSchema,
 } from "../../schemas/sharedApiSchemas";
+import { txOverridesWithoutValue } from "../../schemas/txOverrides";
 import { walletHeaderSchema } from "../../schemas/wallet";
 import { getChainIdFromChain } from "../../utils/chain";
 
@@ -26,15 +27,8 @@ const requestBodySchema = Type.Object({
   value: Type.String({
     examples: ["10000000"],
   }),
+  ...txOverridesWithoutValue.properties,
 });
-
-requestBodySchema.examples = [
-  {
-    toAddress: "0x7a0ce8524bea337f0bee853b68fabde145dac0a0",
-    data: "0x449a52f800000000000000000000000043cae0d7fe86c713530e679ce02574743b2ee9fc0000000000000000000000000000000000000000000000000de0b6b3a7640000",
-    value: "0x00",
-  },
-];
 
 export async function sendTransaction(fastify: FastifyInstance) {
   fastify.route<{
@@ -61,7 +55,7 @@ export async function sendTransaction(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { toAddress, data, value } = request.body;
+      const { toAddress, data, value, txOverrides } = request.body;
       const { simulateTx } = request.query;
       const {
         "x-backend-wallet-address": fromAddress,
@@ -77,6 +71,7 @@ export async function sendTransaction(fastify: FastifyInstance) {
         value,
         simulateTx,
         idempotencyKey,
+        ...txOverrides,
       });
 
       reply.status(StatusCodes.OK).send({

--- a/src/server/schemas/txOverrides.ts
+++ b/src/server/schemas/txOverrides.ts
@@ -30,3 +30,28 @@ export const txOverrides = Type.Object({
     }),
   ),
 });
+
+export const txOverridesWithoutValue = Type.Object({
+  txOverrides: Type.Optional(
+    Type.Object({
+      gas: Type.Optional(
+        Type.String({
+          examples: ["530000"],
+          description: "Gas limit for the transaction",
+        }),
+      ),
+      maxFeePerGas: Type.Optional(
+        Type.String({
+          examples: ["1000000000"],
+          description: "Maximum fee per gas",
+        }),
+      ),
+      maxPriorityFeePerGas: Type.Optional(
+        Type.String({
+          examples: ["1000000000"],
+          description: "Maximum priority fee per gas",
+        }),
+      ),
+    }),
+  ),
+});


### PR DESCRIPTION
Bumped up Engine SDK Version to `v0.0.7`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates version to 0.0.7, adds `txOverridesWithoutValue` schema, and includes `txOverrides` in `sendTransaction` requests.

### Detailed summary
- Updated package version to 0.0.7
- Added `txOverridesWithoutValue` schema to help with end-point's which allow passing `value` as body param
- Included `txOverrides` in `sendTransaction` requests

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->