### PR TITLE
Updated SDK Version + ABI is optional

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thirdweb-dev/engine",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "dist/thirdweb-dev-engine.cjs.js",
   "module": "dist/thirdweb-dev-engine.esm.js",
   "files": [

--- a/src/server/routes/contract/write/write.ts
+++ b/src/server/routes/contract/write/write.ts
@@ -31,7 +31,7 @@ const writeRequestBodySchema = Type.Object({
     ]),
   ),
   ...txOverrides.properties,
-  abi: Type.Array(abiSchema),
+  abi: Type.Optional(Type.Array(abiSchema)),
 });
 
 // LOGIC


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the contract write route to make ABI optional and increases the version of the SDK package to 0.0.9.

### Detailed summary
- Updated contract write route to make ABI optional
- Increased SDK package version to 0.0.9

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->