### PR TITLE
update send signed transaction to v5 to support zksync transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "pino-pretty": "^10.0.0",
     "prisma": "5.14.0-dev.61",
     "superjson": "^2.2.1",
-    "thirdweb": "^5.1.0",
+    "thirdweb": "^5.25.1",
     "uuid": "^9.0.1",
     "viem": "^1.14.0",
     "zod": "^3.21.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8084,11 +8084,6 @@ isomorphic-ws@^4.0.1:
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
   integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
 
-isows@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.3.tgz#93c1cf0575daf56e7120bab5c8c448b0809d0d74"
-  integrity sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==
-
 isows@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.4.tgz#810cd0d90cc4995c26395d2aa4cfa4037ebdf061"
@@ -11148,10 +11143,10 @@ thirdweb@5.24.0-nightly-4abd5591068bfa9217ec65e5830fba0cd14d11b9-20240522224005:
     uqr "0.1.2"
     viem "2.10.9"
 
-thirdweb@^5.1.0:
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/thirdweb/-/thirdweb-5.18.1.tgz#55d7ce851b5c5205ffe26ed29824740b4a27b2ff"
-  integrity sha512-YbtVw0Zcnzlcmrjcaq9FIGavSkfgiAiYonOvAmneLgKblsi1C0HscVh4gxcpwJoOWL4zg5JBRcOo1X81pWn4DA==
+thirdweb@^5.25.1:
+  version "5.25.1"
+  resolved "https://registry.yarnpkg.com/thirdweb/-/thirdweb-5.25.1.tgz#889157f13d0caa59b5373cf60a13de5b67ace34b"
+  integrity sha512-WGPkA50UgzX8aw4x6Hkrb5XUrJ+x5ulCJ0VV9fjit7tz8mUPhKXQPlsenlCahFJWY381tR+vNXMhVMjFVeKHQA==
   dependencies:
     "@coinbase/wallet-sdk" "4.0.0-rc.2"
     "@emotion/react" "11.11.4"
@@ -11159,6 +11154,7 @@ thirdweb@^5.1.0:
     "@google/model-viewer" "2.1.1"
     "@noble/curves" "1.4.0"
     "@noble/hashes" "1.4.0"
+    "@passwordless-id/webauthn" "^1.6.1"
     "@radix-ui/react-dialog" "1.0.5"
     "@radix-ui/react-focus-scope" "1.0.4"
     "@radix-ui/react-icons" "1.3.0"
@@ -11168,10 +11164,11 @@ thirdweb@^5.1.0:
     abitype "1.0.0"
     fast-text-encoding "^1.0.6"
     fuse.js "7.0.0"
+    input-otp "^1.2.4"
     mipd "0.0.7"
     node-libs-browser "2.2.1"
     uqr "0.1.2"
-    viem "2.9.18"
+    viem "2.10.9"
 
 thread-stream@^0.15.1:
   version "0.15.2"
@@ -11696,20 +11693,6 @@ viem@2.10.9:
     "@scure/bip39" "1.2.1"
     abitype "1.0.0"
     isows "1.0.4"
-    ws "8.13.0"
-
-viem@2.9.18:
-  version "2.9.18"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.9.18.tgz#5f24982fd4f186e90f1ed304e05054ebb4f263b9"
-  integrity sha512-QULuau6DWDVRjGDVIUPuUybqiYu8mxscvwkKQ7dqNRl6w/t8RWs92aJZSQpqEULoERlKYyFFlj7cz4mWFEchsg==
-  dependencies:
-    "@adraffy/ens-normalize" "1.10.0"
-    "@noble/curves" "1.2.0"
-    "@noble/hashes" "1.3.2"
-    "@scure/bip32" "1.3.2"
-    "@scure/bip39" "1.2.1"
-    abitype "1.0.0"
-    isows "1.0.3"
     ws "8.13.0"
 
 viem@^1.14.0:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `thirdweb` package version, refactors the `sendSignedTransaction` function, and improves error handling.

### Detailed summary
- Updated `thirdweb` package to version `5.25.1`
- Refactored `sendSignedTransaction` function in `sendSignedTx.ts`
- Improved error handling for invalid hex strings

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->