### PR TITLE
updated bull-mq port & engineTier in health check response

### DIFF
--- a/docker-compose-infra.yml
+++ b/docker-compose-infra.yml
@@ -34,7 +34,7 @@ services:
     image: deadly0/bull-board:latest
     restart: always
     ports:
-      - 3000:3000
+      - 3333:3000
     environment:
       REDIS_HOST: redis
       REDIS_PORT: 6379

--- a/src/server/routes/system/health.ts
+++ b/src/server/routes/system/health.ts
@@ -10,6 +10,7 @@ type EngineFeature = "KEYPAIR_AUTH" | "CONTRACT_SUBSCRIPTIONS";
 const ReplySchemaOk = Type.Object({
   status: Type.String(),
   engineVersion: Type.Optional(Type.String()),
+  engineTier: Type.Optional(Type.String()),
   features: Type.Array(
     Type.Union([
       Type.Literal("KEYPAIR_AUTH"),
@@ -52,6 +53,7 @@ export async function healthCheck(fastify: FastifyInstance) {
       res.status(StatusCodes.OK).send({
         status: "OK",
         engineVersion: process.env.ENGINE_VERSION,
+        engineTier: process.env.ENGINE_TIER,
         features: getFeatures(),
       });
     },

--- a/src/server/routes/system/health.ts
+++ b/src/server/routes/system/health.ts
@@ -53,7 +53,7 @@ export async function healthCheck(fastify: FastifyInstance) {
       res.status(StatusCodes.OK).send({
         status: "OK",
         engineVersion: process.env.ENGINE_VERSION,
-        engineTier: process.env.ENGINE_TIER,
+        engineTier: process.env.ENGINE_TIER ?? "SELF_HOSTED",
         features: getFeatures(),
       });
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Docker port configuration and adds a new environment variable for engine tier in the health check route.

### Detailed summary
- Changed Docker port from 3000 to 3333
- Added `engineTier` environment variable in health check route
- Set default value for `engineTier` as "SELF_HOSTED"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->