### PR TITLE
Breaking change: Require Redis (for v1.0.0)

### DIFF
--- a/src/server/routes/chain/get.ts
+++ b/src/server/routes/chain/get.ts
@@ -23,18 +23,18 @@ const responseSchema = Type.Object({
 responseSchema.examples = [
   {
     result: {
-      name: "Mumbai",
+      name: "Polygon Amoy Testnet",
       chain: "Polygon",
-      rpc: ["https://mumbai.rpc.thirdweb.com/${THIRDWEB_API_SECRET_KEY}"],
+      rpc: ["https://80002.rpc.thirdweb.com/${THIRDWEB_API_SECRET_KEY}"],
       nativeCurrency: {
         name: "MATIC",
         symbol: "MATIC",
         decimals: 18,
       },
-      shortName: "maticmum",
-      chainId: 80001,
+      shortName: "polygonamoy",
+      chainId: 80002,
       testnet: true,
-      slug: "mumbai",
+      slug: "polygon-amoy-testnet",
     },
   },
 ];

--- a/src/server/routes/transaction/blockchain/getTxReceipt.ts
+++ b/src/server/routes/transaction/blockchain/getTxReceipt.ts
@@ -15,7 +15,7 @@ const requestSchema = Type.Object({
     pattern: "^0x([A-Fa-f0-9]{64})$",
   }),
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
 });

--- a/src/server/routes/transaction/blockchain/getUserOpReceipt.ts
+++ b/src/server/routes/transaction/blockchain/getUserOpReceipt.ts
@@ -16,7 +16,7 @@ const requestSchema = Type.Object({
     pattern: "^0x([A-Fa-f0-9]{64})$",
   }),
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
 });

--- a/src/server/schemas/prebuilts/index.ts
+++ b/src/server/schemas/prebuilts/index.ts
@@ -87,7 +87,7 @@ export const commonTrustedForwarderSchema = Type.Object({
 
 export const prebuiltDeployContractParamSchema = Type.Object({
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
 });

--- a/src/server/schemas/sharedApiSchemas.ts
+++ b/src/server/schemas/sharedApiSchemas.ts
@@ -17,7 +17,7 @@ export const baseReplyErrorSchema = Type.Object({
  */
 export const contractParamSchema = Type.Object({
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
   contractAddress: Type.String({
@@ -37,7 +37,7 @@ export const requestQuerystringSchema = Type.Object({
 
 export const prebuiltDeployParamSchema = Type.Object({
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
   contractType: Type.String({
@@ -48,7 +48,7 @@ export const prebuiltDeployParamSchema = Type.Object({
 
 export const publishedDeployParamSchema = Type.Object({
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
   publisher: Type.String({
@@ -176,7 +176,7 @@ transactionWritesResponseSchema.example = {
  */
 export const erc20ContractParamSchema = Type.Object({
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
   contractAddress: Type.String({
@@ -190,7 +190,7 @@ export const erc20ContractParamSchema = Type.Object({
  */
 export const erc1155ContractParamSchema = Type.Object({
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
   contractAddress: Type.String({
@@ -204,7 +204,7 @@ export const erc1155ContractParamSchema = Type.Object({
  */
 export const erc721ContractParamSchema = Type.Object({
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
   contractAddress: Type.String({
@@ -234,7 +234,7 @@ export enum Status {
 
 export const marketplaceV3ContractParamSchema = Type.Object({
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain ID or name",
   }),
   contractAddress: Type.String({

--- a/src/server/schemas/wallet/index.ts
+++ b/src/server/schemas/wallet/index.ts
@@ -23,7 +23,7 @@ export const walletWithAAHeaderSchema = Type.Object({
 
 export const walletParamSchema = Type.Object({
   chain: Type.String({
-    examples: ["mumbai"],
+    examples: ["80002"],
     description: "Chain name",
   }),
   walletAddress: Type.String({

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -71,7 +71,7 @@ export const env = createEnv({
       .number()
       .nonnegative()
       .default(0),
-    REDIS_URL: z.string().optional(),
+    REDIS_URL: z.string(),
   },
   clientPrefix: "NEVER_USED",
   client: {},

--- a/src/utils/redis/redis.ts
+++ b/src/utils/redis/redis.ts
@@ -2,47 +2,35 @@ import Redis from "ioredis";
 import { env } from "../env";
 import { logger } from "../logger";
 
-export let redis: Redis | null;
+export const redis = new Redis(env.REDIS_URL, {
+  maxRetriesPerRequest: null,
+});
 
-if (env.REDIS_URL) {
-  try {
-    redis = new Redis(env.REDIS_URL, {
-      maxRetriesPerRequest: null,
-    });
-
-    redis.on("error", (err) => () => {
-      logger({
-        level: "error",
-        message: `Redis error: ${err}`,
-        service: "worker",
-      });
-    });
-    redis.on("connect", () =>
-      logger({
-        level: "info",
-        message: "Redis connected",
-        service: "worker",
-      }),
-    );
-    redis.on("reconnecting", () =>
-      logger({
-        level: "info",
-        message: "Redis reconnecting",
-        service: "worker",
-      }),
-    );
-    redis.on("ready", () => {
-      logger({
-        level: "info",
-        message: "Redis ready",
-        service: "worker",
-      });
-    });
-  } catch (e) {
-    logger({
-      level: "error",
-      message: `Error initializing Redis: ${e}`,
-      service: "worker",
-    });
-  }
-}
+redis.on("error", (err) => () => {
+  logger({
+    level: "error",
+    message: `Redis error: ${err}`,
+    service: "worker",
+  });
+});
+redis.on("connect", () =>
+  logger({
+    level: "info",
+    message: "Redis connected",
+    service: "worker",
+  }),
+);
+redis.on("reconnecting", () =>
+  logger({
+    level: "info",
+    message: "Redis reconnecting",
+    service: "worker",
+  }),
+);
+redis.on("ready", () => {
+  logger({
+    level: "info",
+    message: "Redis ready",
+    service: "worker",
+  });
+});

--- a/src/worker/tasks/processTransactionReceiptsWorker.ts
+++ b/src/worker/tasks/processTransactionReceiptsWorker.ts
@@ -186,7 +186,7 @@ const getFormattedTransactionReceipts = async ({
         transactionIndex: receipt.transactionIndex,
         gasUsed: receipt.gasUsed.toString(),
         effectiveGasPrice: receipt.effectiveGasPrice.toString(),
-        status: receipt.status ? 1 : 0,
+        status: receipt.status === "success" ? 1 : 0,
       });
     }
 


### PR DESCRIPTION
- **BREAKING CHANGE**: Require `REDIS_URL` env var for v1.0.0 release. Engine will not start if this env var is unavailable.
- Update examples from Mumbai (deprecated) -> Amoy
- Fix incorrect tx `status` code (e.g. from reverted execution)

<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update chain IDs and names to use "80002" and "Polygon Amoy Testnet" respectively across various files.

### Detailed summary
- Updated chain IDs and names to "80002" and "Polygon Amoy Testnet" respectively.
- Changed status check in `processTransactionReceiptsWorker.ts` to use "success" string comparison.
- Modified `redis.ts` to export a constant `redis` and handle error, connect, and reconnect events.
- Adjusted various schemas to reflect the new chain ID and name "80002" and "Polygon Amoy Testnet".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->