### PR TITLE
fix: Treat `effectiveGasPrice` from the receipt as optional

### DIFF
--- a/src/server/routes/transaction/blockchain/getTxReceipt.ts
+++ b/src/server/routes/transaction/blockchain/getTxReceipt.ts
@@ -138,7 +138,7 @@ export async function getTxHashReceipt(fastify: FastifyInstance) {
               ...receipt,
               gasUsed: receipt.gasUsed.toHexString(),
               cumulativeGasUsed: receipt.cumulativeGasUsed.toHexString(),
-              effectiveGasPrice: receipt.effectiveGasPrice.toHexString(),
+              effectiveGasPrice: receipt.effectiveGasPrice?.toHexString(),
             }
           : null,
       });

--- a/src/worker/tasks/processTransactionReceiptsWorker.ts
+++ b/src/worker/tasks/processTransactionReceiptsWorker.ts
@@ -185,7 +185,7 @@ const getFormattedTransactionReceipts = async ({
         functionName,
         transactionIndex: receipt.transactionIndex,
         gasUsed: receipt.gasUsed.toString(),
-        effectiveGasPrice: receipt.effectiveGasPrice.toString(),
+        effectiveGasPrice: receipt.effectiveGasPrice?.toString() ?? "",
         status: receipt.status === "success" ? 1 : 0,
       });
     }

--- a/src/worker/tasks/updateMinedTx.ts
+++ b/src/worker/tasks/updateMinedTx.ts
@@ -154,7 +154,7 @@ export const updateMinedTx = async () => {
                 onChainTxStatus: txWithReceipt.receipt.status,
                 transactionHash: txWithReceipt.receipt.transactionHash,
                 transactionType: txWithReceipt.receipt.type,
-                gasPrice: txWithReceipt.receipt.effectiveGasPrice.toString(),
+                gasPrice: txWithReceipt.receipt.effectiveGasPrice?.toString(),
                 gasLimit: txWithReceipt.response?.gasLimit?.toString(),
                 maxFeePerGas: txWithReceipt.response?.maxFeePerGas?.toString(),
                 maxPriorityFeePerGas:


### PR DESCRIPTION
Treat `effectiveGasPrice` as optional from a transaction receipt response.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the handling of `effectiveGasPrice` in different parts of the codebase to handle potential `null` values.

### Detailed summary
- Updated `effectiveGasPrice` handling in `getTxReceipt.ts`, `processTransactionReceiptsWorker.ts`, and `updateMinedTx.ts`
- Added optional chaining and nullish coalescing operators to prevent errors from potential `null` values

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->