### PR TITLE
feat: Support v5 SDK format for signatureGenerate endpoints

### DIFF
--- a/src/server/routes/contract/extensions/erc1155/read/signatureGenerate.ts
+++ b/src/server/routes/contract/extensions/erc1155/read/signatureGenerate.ts
@@ -1,30 +1,86 @@
 import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { getContract } from "../../../../../../utils/cache/getContract";
+import { Address, Hex, defineChain, getContract } from "thirdweb";
+import { NFTInput } from "thirdweb/dist/types/utils/nft/parseNft";
+import { generateMintSignature } from "thirdweb/extensions/erc1155";
+import { getAccount } from "../../../../../../utils/account";
+import { getContract as getContractV4 } from "../../../../../../utils/cache/getContract";
+import { thirdwebClient } from "../../../../../../utils/sdk";
+import { createCustomError } from "../../../../../middleware/error";
+import { thirdwebSdkVersionSchema } from "../../../../../schemas/httpHeaders/thirdwebSdkVersion";
 import {
   ercNFTResponseType,
+  nftInputSchema,
   signature1155InputSchema,
   signature1155OutputSchema,
 } from "../../../../../schemas/nft";
 import {
-  erc721ContractParamSchema,
+  erc1155ContractParamSchema,
   standardResponseSchema,
 } from "../../../../../schemas/sharedApiSchemas";
 import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
 import { checkAndReturnNFTSignaturePayload } from "../../../../../utils/validator";
 
-// INPUTS
-const requestSchema = erc721ContractParamSchema;
-const requestBodySchema = signature1155InputSchema;
+// v4 sdk
+const requestBodySchemaV4 = signature1155InputSchema;
+const responseSchemaV4 = Type.Object({
+  payload: signature1155OutputSchema,
+  signature: Type.String(),
+});
 
-// OUTPUT
-const responseSchema = Type.Object({
-  result: Type.Object({
-    payload: signature1155OutputSchema,
-    signature: Type.String(),
+// v5 sdk
+const requestBodySchemaV5 = Type.Intersect([
+  Type.Object({
+    contractType: Type.Optional(
+      Type.Union([
+        Type.Literal("TokenERC1155"),
+        Type.Literal("SignatureMintERC1155"),
+      ]),
+    ),
+    to: Type.String(),
+    quantity: Type.String(),
+    royaltyRecipient: Type.Optional(Type.String()),
+    royaltyBps: Type.Optional(Type.Number()),
+    primarySaleRecipient: Type.Optional(Type.String()),
+    pricePerToken: Type.Optional(Type.String()),
+    pricePerTokenWei: Type.Optional(Type.String()),
+    currency: Type.Optional(Type.String()),
+    validityStartTimestamp: Type.Integer(),
+    validityEndTimestamp: Type.Optional(Type.Integer()),
+    uid: Type.Optional(Type.String()),
   }),
+  Type.Union([
+    Type.Object({ metadata: Type.Union([nftInputSchema, Type.String()]) }),
+    Type.Object({ tokenId: Type.String() }),
+  ]),
+]);
+const responseSchemaV5 = Type.Object({
+  payload: Type.Object({
+    to: Type.String(),
+    royaltyRecipient: Type.String(),
+    royaltyBps: Type.String(),
+    primarySaleRecipient: Type.String(),
+    tokenId: Type.String(),
+    uri: Type.String(),
+    quantity: Type.String(),
+    pricePerToken: Type.String(),
+    currency: Type.String(),
+    validityStartTimestamp: Type.Integer(),
+    validityEndTimestamp: Type.Integer(),
+    uid: Type.String(),
+  }),
+  signature: Type.String(),
+});
+
+const requestSchema = erc1155ContractParamSchema;
+const requestBodySchema = Type.Union([
+  requestBodySchemaV4,
+  requestBodySchemaV5,
+]);
+const responseSchema = Type.Object({
+  result: Type.Union([responseSchemaV4, responseSchemaV5]),
 });
 
 responseSchema.example = {
@@ -43,12 +99,15 @@ export async function erc1155SignatureGenerate(fastify: FastifyInstance) {
     schema: {
       summary: "Generate signature",
       description:
-        "Generate a signature granting access for another wallet to mint tokens from this ERC-721 contract. This method is typically called by the token contract owner.",
+        "Generate a signature granting access for another wallet to mint tokens from this ERC-1155 contract. This method is typically called by the token contract owner.",
       tags: ["ERC1155"],
       operationId: "signatureGenerate",
       params: requestSchema,
       body: requestBodySchema,
-      headers: walletWithAAHeaderSchema,
+      headers: {
+        ...walletWithAAHeaderSchema.properties,
+        ...thirdwebSdkVersionSchema.properties,
+      },
       response: {
         ...standardResponseSchema,
         [StatusCodes.OK]: responseSchema,
@@ -57,24 +116,112 @@ export async function erc1155SignatureGenerate(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contractAddress } = request.params;
       const {
+        "x-backend-wallet-address": walletAddress,
+        "x-account-address": accountAddress,
+      } = request.headers as Static<typeof walletWithAAHeaderSchema>;
+      const { "x-thirdweb-sdk-version": sdkVersion } =
+        request.headers as Static<typeof thirdwebSdkVersionSchema>;
+
+      const chainId = await getChainIdFromChain(chain);
+
+      // Use v5 SDK if "x-thirdweb-sdk-version" header is set.
+      if (sdkVersion === "5") {
+        const args = request.body as Static<typeof requestBodySchemaV5>;
+        const {
+          contractType,
+          to,
+          quantity,
+          royaltyRecipient,
+          royaltyBps,
+          primarySaleRecipient,
+          pricePerToken,
+          pricePerTokenWei,
+          currency,
+          validityStartTimestamp,
+          validityEndTimestamp,
+          uid,
+        } = args;
+
+        let nftInput: { metadata: NFTInput | string } | { tokenId: bigint };
+        if ("metadata" in args) {
+          nftInput = { metadata: args.metadata };
+        } else if ("tokenId" in args) {
+          nftInput = { tokenId: BigInt(args.tokenId) };
+        } else {
+          throw createCustomError(
+            `Missing "metadata" or "tokenId".`,
+            StatusCodes.BAD_REQUEST,
+            "MISSING_PARAMETERS",
+          );
+        }
+
+        const contract = getContract({
+          client: thirdwebClient,
+          chain: defineChain(chainId),
+          address: contractAddress,
+        });
+        const account = await getAccount({
+          chainId,
+          from: walletAddress as Address,
+          accountAddress: accountAddress as Address,
+        });
+
+        const { payload, signature } = await generateMintSignature({
+          contract,
+          account,
+          contractType,
+          mintRequest: {
+            to,
+            quantity: BigInt(quantity),
+            royaltyRecipient,
+            royaltyBps,
+            primarySaleRecipient,
+            pricePerToken,
+            pricePerTokenWei: pricePerTokenWei
+              ? BigInt(pricePerTokenWei)
+              : undefined,
+            currency,
+            validityStartTimestamp: new Date(validityStartTimestamp * 1000),
+            validityEndTimestamp: validityEndTimestamp
+              ? new Date(validityEndTimestamp * 1000)
+              : undefined,
+            uid: uid as Hex | undefined,
+            ...nftInput,
+          },
+        });
+
+        return reply.status(StatusCodes.OK).send({
+          result: {
+            payload: {
+              ...payload,
+              royaltyBps: payload.royaltyBps.toString(),
+              tokenId: payload.tokenId.toString(),
+              quantity: payload.quantity.toString(),
+              pricePerToken: payload.pricePerToken.toString(),
+              validityStartTimestamp: Number(payload.validityStartTimestamp),
+              validityEndTimestamp: Number(payload.validityEndTimestamp),
+            },
+            signature,
+          },
+        });
+      }
+
+      // Use v4 SDK.
+      const {
         to,
         currencyAddress,
         metadata,
         mintEndTime,
         mintStartTime,
-        price,
+        price = "0",
         primarySaleRecipient,
         quantity,
         royaltyBps,
         royaltyRecipient,
         uid,
-      } = request.body;
-      const {
-        "x-backend-wallet-address": walletAddress,
-        "x-account-address": accountAddress,
-      } = request.headers as Static<typeof walletWithAAHeaderSchema>;
-      const chainId = await getChainIdFromChain(chain);
-      const contract = await getContract({
+      } = request.body as Static<typeof requestBodySchemaV4>;
+
+      const contract = await getContractV4({
         chainId,
         contractAddress,
         walletAddress,

--- a/src/server/routes/contract/extensions/erc20/read/signatureGenerate.ts
+++ b/src/server/routes/contract/extensions/erc20/read/signatureGenerate.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../../../schemas/erc20";
 import { thirdwebSdkVersionSchema } from "../../../../../schemas/httpHeaders/thirdwebSdkVersion";
 import {
-  erc721ContractParamSchema,
+  erc20ContractParamSchema,
   standardResponseSchema,
 } from "../../../../../schemas/sharedApiSchemas";
 import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
@@ -59,7 +59,7 @@ const responseSchemaV5 = Type.Object({
   signature: Type.String(),
 });
 
-const requestSchema = erc721ContractParamSchema;
+const requestSchema = erc20ContractParamSchema;
 const requestBodySchema = Type.Union([
   requestBodySchemaV4,
   requestBodySchemaV5,

--- a/src/server/routes/contract/extensions/erc20/read/signatureGenerate.ts
+++ b/src/server/routes/contract/extensions/erc20/read/signatureGenerate.ts
@@ -185,7 +185,7 @@ export async function erc20SignatureGenerate(fastify: FastifyInstance) {
         currencyAddress,
         mintEndTime,
         mintStartTime,
-        price,
+        price = "0",
         primarySaleRecipient,
         quantity,
         uid,

--- a/src/server/routes/contract/extensions/erc20/read/signatureGenerate.ts
+++ b/src/server/routes/contract/extensions/erc20/read/signatureGenerate.ts
@@ -1,10 +1,12 @@
 import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { defineChain, getContract } from "thirdweb";
+import { Address, Hex, defineChain, getContract } from "thirdweb";
 import { generateMintSignature } from "thirdweb/extensions/erc20";
+import { getAccount } from "../../../../../../utils/account";
 import { getContract as getContractV4 } from "../../../../../../utils/cache/getContract";
 import { thirdwebClient } from "../../../../../../utils/sdk";
+import { createCustomError } from "../../../../../middleware/error";
 import {
   erc20ResponseType,
   signature20InputSchema,
@@ -19,16 +21,51 @@ import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
 import { checkAndReturnERC20SignaturePayload } from "../../../../../utils/validator";
 
-// INPUTS
-const requestSchema = erc721ContractParamSchema;
-const requestBodySchema = signature20InputSchema;
+// v4 sdk
+const requestBodySchemaV4 = signature20InputSchema;
+const responseSchemaV4 = Type.Object({
+  payload: signature20OutputSchema,
+  signature: Type.String(),
+});
 
-// OUTPUT
-const responseSchema = Type.Object({
-  result: Type.Object({
-    payload: signature20OutputSchema,
-    signature: Type.String(),
+// v5 sdk
+const requestBodySchemaV5 = Type.Intersect([
+  Type.Object({
+    to: Type.String(),
+    primarySaleRecipient: Type.Optional(Type.String()),
+    price: Type.Optional(Type.String()),
+    priceInWei: Type.Optional(Type.String()),
+    currency: Type.Optional(Type.String()),
+    validityStartTimestamp: Type.Integer(),
+    validityEndTimestamp: Type.Optional(Type.Integer()),
+    uid: Type.Optional(Type.String()),
   }),
+  Type.Union([
+    Type.Object({ quantity: Type.String() }),
+    Type.Object({ quantityWei: Type.String() }),
+  ]),
+]);
+const responseSchemaV5 = Type.Object({
+  payload: Type.Object({
+    to: Type.String(),
+    primarySaleRecipient: Type.String(),
+    quantity: Type.String(),
+    price: Type.String(),
+    currency: Type.String(),
+    validityStartTimestamp: Type.Integer(),
+    validityEndTimestamp: Type.Integer(),
+    uid: Type.String(),
+  }),
+  signature: Type.String(),
+});
+
+const requestSchema = erc721ContractParamSchema;
+const requestBodySchema = Type.Union([
+  requestBodySchemaV4,
+  requestBodySchemaV5,
+]);
+const responseSchema = Type.Object({
+  result: Type.Union([responseSchemaV4, responseSchemaV5]),
 });
 
 responseSchema.example = {
@@ -64,6 +101,86 @@ export async function erc20SignatureGenerate(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contractAddress } = request.params;
       const {
+        "x-backend-wallet-address": walletAddress,
+        "x-account-address": accountAddress,
+      } = request.headers as Static<typeof walletWithAAHeaderSchema>;
+      const { "x-thirdweb-sdk-version": sdkVersion } =
+        request.headers as Static<typeof thirdwebSdkVersionSchema>;
+
+      const chainId = await getChainIdFromChain(chain);
+
+      // Use v5 SDK if "x-thirdweb-sdk-version" header is set.
+      if (sdkVersion === "5") {
+        const args = request.body as Static<typeof requestBodySchemaV5>;
+        const {
+          to,
+          primarySaleRecipient,
+          price,
+          priceInWei,
+          currency,
+          validityStartTimestamp,
+          validityEndTimestamp,
+          uid,
+        } = args;
+
+        let quantityInput: { quantity: string } | { quantityWei: bigint };
+        if ("quantity" in args) {
+          quantityInput = { quantity: args.quantity };
+        } else if ("quantityWei" in args) {
+          quantityInput = { quantityWei: BigInt(args.quantityWei) };
+        } else {
+          throw createCustomError(
+            `Missing "quantity" or "quantityWei".`,
+            StatusCodes.BAD_REQUEST,
+            "MISSING_PARAMETERS",
+          );
+        }
+
+        const contract = getContract({
+          client: thirdwebClient,
+          chain: defineChain(chainId),
+          address: contractAddress,
+        });
+        const account = await getAccount({
+          chainId,
+          from: walletAddress as Address,
+          accountAddress: accountAddress as Address,
+        });
+
+        const { payload, signature } = await generateMintSignature({
+          contract,
+          account,
+          mintRequest: {
+            to,
+            primarySaleRecipient,
+            price,
+            priceInWei: priceInWei ? BigInt(priceInWei) : undefined,
+            currency: currency as Address | undefined,
+            validityStartTimestamp: new Date(validityStartTimestamp * 1000),
+            validityEndTimestamp: validityEndTimestamp
+              ? new Date(validityEndTimestamp * 1000)
+              : undefined,
+            uid: uid as Hex | undefined,
+            ...quantityInput,
+          },
+        });
+
+        return reply.status(StatusCodes.OK).send({
+          result: {
+            payload: {
+              ...payload,
+              quantity: payload.quantity.toString(),
+              price: payload.price.toString(),
+              validityStartTimestamp: Number(payload.validityStartTimestamp),
+              validityEndTimestamp: Number(payload.validityEndTimestamp),
+            },
+            signature,
+          },
+        });
+      }
+
+      // Use v4 SDK.
+      const {
         to,
         currencyAddress,
         mintEndTime,
@@ -72,15 +189,7 @@ export async function erc20SignatureGenerate(fastify: FastifyInstance) {
         primarySaleRecipient,
         quantity,
         uid,
-      } = request.body;
-      const {
-        "x-backend-wallet-address": walletAddress,
-        "x-account-address": accountAddress,
-        "x-thirdweb-sdk-version": sdkVersion,
-      } = request.headers as Static<typeof walletWithAAHeaderSchema> &
-        Static<typeof thirdwebSdkVersionSchema>;
-
-      const chainId = await getChainIdFromChain(chain);
+      } = request.body as Static<typeof requestBodySchemaV4>;
 
       const contract = await getContractV4({
         chainId,
@@ -88,23 +197,6 @@ export async function erc20SignatureGenerate(fastify: FastifyInstance) {
         walletAddress,
         accountAddress,
       });
-
-      if (sdkVersion === "5") {
-        const contract = getContract({
-          client: thirdwebClient,
-          chain: defineChain(chainId),
-          address: contractAddress,
-        });
-        const { payload, signature } = await generateMintSignature({
-          account,
-          contract,
-          mintRequest: {
-            to: "0x...",
-            quantity: "10",
-          },
-        });
-        return;
-      }
 
       const payload = checkAndReturnERC20SignaturePayload<
         Static<typeof signature20InputSchema>,

--- a/src/server/routes/contract/extensions/erc721/read/signatureGenerate.ts
+++ b/src/server/routes/contract/extensions/erc721/read/signatureGenerate.ts
@@ -43,10 +43,6 @@ const requestBodySchemaV5 = Type.Intersect([
     validityEndTimestamp: Type.Optional(Type.Integer()),
     uid: Type.Optional(Type.String()),
   }),
-  Type.Union([
-    Type.Object({ quantity: Type.String() }),
-    Type.Object({ quantityWei: Type.String() }),
-  ]),
 ]);
 const responseSchemaV5 = Type.Object({
   payload: Type.Object({

--- a/src/server/schemas/erc20/index.ts
+++ b/src/server/schemas/erc20/index.ts
@@ -44,7 +44,6 @@ export const signature20InputSchema = Type.Object({
     Type.String({
       description:
         "If you want the user to pay for minting the tokens, you can specify the price per token. Defaults to 0.",
-      default: "0",
     }),
   ),
   mintStartTime: Type.Optional(
@@ -92,7 +91,6 @@ export const signature20OutputSchema = Type.Object({
   price: Type.String({
     description:
       "If you want the user to pay for minting the tokens, you can specify the price per token. Defaults to 0.",
-    default: "0",
   }),
   mintStartTime: Type.Number({
     description:

--- a/src/server/schemas/httpHeaders/thirdwebSdkVersion.ts
+++ b/src/server/schemas/httpHeaders/thirdwebSdkVersion.ts
@@ -1,0 +1,10 @@
+import { Type } from "@sinclair/typebox";
+
+export const thirdwebSdkVersionSchema = Type.Object({
+  "x-thirdweb-sdk-version": Type.Optional(
+    Type.String({
+      description: "Override the thirdweb sdk version used.",
+      examples: ["5"],
+    }),
+  ),
+});

--- a/src/server/schemas/httpHeaders/thirdwebSdkVersion.ts
+++ b/src/server/schemas/httpHeaders/thirdwebSdkVersion.ts
@@ -3,8 +3,7 @@ import { Type } from "@sinclair/typebox";
 export const thirdwebSdkVersionSchema = Type.Object({
   "x-thirdweb-sdk-version": Type.Optional(
     Type.String({
-      description: "Override the thirdweb sdk version used.",
-      examples: ["5"],
+      description: `Override the thirdweb sdk version used. Example: "5" for v5 SDK compatibility.`,
     }),
   ),
 });

--- a/src/server/schemas/nft/index.ts
+++ b/src/server/schemas/nft/index.ts
@@ -1,6 +1,19 @@
 import { Static, Type } from "@sinclair/typebox";
 import { BigNumber } from "ethers";
 
+// NFTInput format compatible with v5 SDK
+export const nftInputSchema = Type.Partial(
+  Type.Object({
+    name: Type.String(),
+    description: Type.String(),
+    image: Type.String(),
+    animation_url: Type.String(),
+    external_url: Type.String(),
+    background_color: Type.String(),
+    properties: Type.Any(),
+  }),
+);
+
 export const nftMetadataInputSchema = Type.Object({
   name: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
   description: Type.Optional(Type.Union([Type.String(), Type.Null()])),
@@ -100,7 +113,6 @@ export const signature721InputSchema = Type.Object({
     Type.String({
       description:
         "If you want the user to pay for minting the tokens, you can specify the price per token. Defaults to 0.",
-      default: "0",
     }),
   ),
   mintStartTime: Type.Optional(
@@ -215,7 +227,6 @@ export const signature1155InputSchema = Type.Object({
     Type.String({
       description:
         "If you want the user to pay for minting the tokens, you can specify the price per token. Defaults to 0.",
-      default: "0",
     }),
   ),
   mintStartTime: Type.Optional(

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,0 +1,69 @@
+import { EVMWallet } from "@thirdweb-dev/wallets";
+import { Address } from "thirdweb";
+import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+import { Account } from "thirdweb/wallets";
+import { getWalletDetails } from "../db/wallets/getWalletDetails";
+import { WalletType } from "../schema/wallet";
+import { getAwsKmsWallet } from "../server/utils/wallets/getAwsKmsWallet";
+import { getGcpKmsWallet } from "../server/utils/wallets/getGcpKmsWallet";
+import { getLocalWallet } from "../server/utils/wallets/getLocalWallet";
+
+export const _accountsCache = new Map<string, Account>();
+
+export const getAccount = async (args: {
+  chainId: number;
+  from: Address;
+  accountAddress?: Address;
+}): Promise<Account> => {
+  const { chainId, from, accountAddress } = args;
+
+  // Get from cache.
+  const cacheKey = getAccountCacheKey({ chainId, from, accountAddress });
+  const cached = _accountsCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const walletDetails = await getWalletDetails({
+    address: from,
+  });
+  if (!walletDetails) {
+    throw new Error(`Backend wallet not found: ${from}`);
+  }
+
+  let wallet: EVMWallet;
+  switch (walletDetails.type) {
+    case WalletType.awsKms:
+      wallet = await getAwsKmsWallet({
+        awsKmsKeyId: walletDetails.awsKmsKeyId!,
+      });
+      break;
+    case WalletType.gcpKms:
+      wallet = await getGcpKmsWallet({
+        gcpKmsKeyId: walletDetails.gcpKmsKeyId!,
+        gcpKmsKeyVersionId: walletDetails.gcpKmsKeyVersionId!,
+      });
+      break;
+    case WalletType.local:
+      wallet = await getLocalWallet({ chainId, walletAddress: from });
+      break;
+    default:
+      throw new Error(`Wallet type not supported: ${walletDetails.type}`);
+  }
+
+  const signer = await wallet.getSigner();
+  const account = await ethers5Adapter.signer.fromEthers({ signer });
+
+  // Set cache.
+  _accountsCache.set(cacheKey, account);
+  return account;
+};
+
+const getAccountCacheKey = (args: {
+  chainId: number;
+  from: Address;
+  accountAddress?: Address;
+}) =>
+  args.accountAddress
+    ? `${args.chainId}-${args.from}-${args.accountAddress}`
+    : `${args.chainId}-${args.from}`;


### PR DESCRIPTION
Adds an experimental `x-thirdweb-sdk-version` flag to the signatureGenerate endpoints. This enables Engine to generate signature payloads compatible with thirdweb v5 SDK.

Tested these variations of generating a signature w/ Engine and signature minting with the thirdweb SDK:
- erc20, v4
- erc721, v4
- erc1155, v4
- erc20, v5
- erc721, v5
- erc1155, v5

---

v4 input:
```json
{
  "to": "0xa5B8492D8223D255dB279C7c3ebdA34Be5eC9D85",
  "quantity": "1",
  "primarySaleRecipient": "0x0000000000000000000000000000000000000000",
  "currencyAddress": "0x0000000000000000000000000000000000000000",
  "mintStartTime": "1719367192000"
}
```

v4 output:
```json
{
  "result": {
    "payload": {
      "to": "0xa5B8492D8223D255dB279C7c3ebdA34Be5eC9D85",
      "quantity": "1",
      "primarySaleRecipient": "0x0000000000000000000000000000000000000000",
      "uid": "0x3539323164373132376638623465383538663566303630363732613430356664",
      "currencyAddress": "0x0000000000000000000000000000000000000000",
      "price": "0",
      "mintStartTime": 1719367192,
      "mintEndTime": 2034727806
    },
    "signature": "0xea0372db75bd673bed3dfa23db34c5f8a15bb96ac8ce3e0b7093f642629b395c278a7f246f967ee2633279f77d17b5eaf747c7e4be3e89e9527dce500e7813561b"
  }
}
```

v5 input:
```json
{
    "to": "0xa5B8492D8223D255dB279C7c3ebdA34Be5eC9D85",
    "validityStartTimestamp": "1719367192",
    "quantity": "2"
}
```

v5 output:
```json
{
  "result": {
    "payload": {
      "to": "0xa5B8492D8223D255dB279C7c3ebdA34Be5eC9D85",
      "primarySaleRecipient": "0x4Ff9aa707AE1eAeb40E581DF2cf4e14AffcC553d",
      "quantity": "2000000000000000000",
      "price": "0",
      "currency": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
      "validityStartTimestamp": 1719367192,
      "validityEndTimestamp": 2034727648,
      "uid": "0x2036295f2d551adb572ad5aa721ea541b822baa487a50049354827d31c4cbd4d"
    },
    "signature": "0xcf299de9448d38d8ca8d98b163892611173be664f559bc6f6da60f663ba60c9b4286cc01a3b0f56cca8cc502956c018af37d3a8ac8ed8d54aa7724d837c5376e1c"
  }
}
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates schemas and adds support for v5 SDK in ERC20 contract signature generation.

### Detailed summary
- Added `thirdwebSdkVersionSchema` for v5 SDK compatibility
- Updated schemas for ERC20 contract signature generation
- Implemented v5 SDK support in `erc20SignatureGenerate` handler

> The following files were skipped due to too many changes: `src/server/routes/contract/extensions/erc20/read/signatureGenerate.ts`, `src/server/routes/contract/extensions/erc721/read/signatureGenerate.ts`, `src/server/routes/contract/extensions/erc1155/read/signatureGenerate.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->