### PR TITLE
fix: stringify event log value arg

### DIFF
--- a/src/worker/tasks/processEventLogsWorker.ts
+++ b/src/worker/tasks/processEventLogsWorker.ts
@@ -231,7 +231,7 @@ const formatDecodedLog = async (args: {
     if (name && name in logArgs) {
       res[name] = {
         type,
-        value: (logArgs[name] as any).toString(),
+        value: JSON.stringify(logArgs[name]),
       };
     }
   }

--- a/src/worker/tasks/processEventLogsWorker.ts
+++ b/src/worker/tasks/processEventLogsWorker.ts
@@ -231,7 +231,7 @@ const formatDecodedLog = async (args: {
     if (name && name in logArgs) {
       res[name] = {
         type,
-        value: JSON.stringify(logArgs[name]),
+        value: logArgToString(logArgs[name]),
       };
     }
   }
@@ -272,6 +272,19 @@ const getBlockTimestamps = async (
     res[dedupe[i]] = blocks[i];
   }
   return res;
+};
+
+const logArgToString = (arg: any): string => {
+  if (arg === null) {
+    return "";
+  }
+  if (typeof arg === "object") {
+    return Object.values(arg).map(logArgToString).join(",");
+  }
+  if (Array.isArray(arg)) {
+    return arg.map(logArgToString).join(",");
+  }
+  return arg.toString();
 };
 
 // Worker


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `processEventLogsWorker.ts` file to convert log argument values to JSON strings.

### Detailed summary
- Updated the value assignment to convert log argument values to JSON strings instead of using `toString()`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->