### PR TITLE
Contract Deployment: Deploy options support

### DIFF
--- a/src/server/routes/contract/royalties/read/getDefaultRoyaltyInfo.ts
+++ b/src/server/routes/contract/royalties/read/getDefaultRoyaltyInfo.ts
@@ -2,7 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../utils/cache/getContract";
-import { RoyaltySchema } from "../../../../schemas/contract";
+import { royaltySchema } from "../../../../schemas/contract";
 import {
   contractParamSchema,
   standardResponseSchema,
@@ -13,7 +13,7 @@ const requestSchema = contractParamSchema;
 
 // OUTPUT
 const responseSchema = Type.Object({
-  result: RoyaltySchema,
+  result: royaltySchema,
 });
 
 responseSchema.examples = [

--- a/src/server/routes/contract/royalties/read/getTokenRoyaltyInfo.ts
+++ b/src/server/routes/contract/royalties/read/getTokenRoyaltyInfo.ts
@@ -2,7 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../utils/cache/getContract";
-import { RoyaltySchema } from "../../../../schemas/contract";
+import { royaltySchema } from "../../../../schemas/contract";
 import {
   contractParamSchema,
   standardResponseSchema,
@@ -15,7 +15,7 @@ const requestSchema = Type.Object({
 });
 // OUTPUT
 const responseSchema = Type.Object({
-  result: RoyaltySchema,
+  result: royaltySchema,
 });
 
 responseSchema.examples = [

--- a/src/server/routes/contract/royalties/write/setDefaultRoyaltyInfo.ts
+++ b/src/server/routes/contract/royalties/write/setDefaultRoyaltyInfo.ts
@@ -3,7 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../utils/cache/getContract";
-import { RoyaltySchema } from "../../../../schemas/contract";
+import { royaltySchema } from "../../../../schemas/contract";
 import {
   contractParamSchema,
   requestQuerystringSchema,
@@ -17,7 +17,7 @@ import { getChainIdFromChain } from "../../../../utils/chain";
 // INPUTS
 const requestSchema = contractParamSchema;
 const requestBodySchema = Type.Object({
-  ...RoyaltySchema.properties,
+  ...royaltySchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 

--- a/src/server/routes/contract/royalties/write/setTokenRoyaltyInfo.ts
+++ b/src/server/routes/contract/royalties/write/setTokenRoyaltyInfo.ts
@@ -3,7 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../utils/cache/getContract";
-import { RoyaltySchema } from "../../../../schemas/contract";
+import { royaltySchema } from "../../../../schemas/contract";
 import {
   contractParamSchema,
   requestQuerystringSchema,
@@ -17,7 +17,7 @@ import { getChainIdFromChain } from "../../../../utils/chain";
 // INPUTS
 const requestSchema = contractParamSchema;
 const requestBodySchema = Type.Object({
-  ...RoyaltySchema.properties,
+  ...royaltySchema.properties,
   token_id: Type.String({
     description: "The token ID to set the royalty info for.",
   }),

--- a/src/server/routes/deploy/prebuilt.ts
+++ b/src/server/routes/deploy/prebuilt.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../db/transactions/queueTx";
 import { getSdk } from "../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../schemas/contract";
 import {
   prebuiltDeployParamSchema,
   standardResponseSchema,
@@ -18,11 +19,7 @@ const requestBodySchema = Type.Object({
   contractMetadata: Type.Any({
     description: "Arguments for the deployment.",
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -70,7 +67,14 @@ export async function deployPrebuilt(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain, contractType } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -83,6 +87,11 @@ export async function deployPrebuilt(fastify: FastifyInstance) {
         contractType,
         contractMetadata,
         version,
+        {
+          saltForProxyDeploy,
+          forceDirectDeploy,
+          compilerOptions,
+        },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/edition.ts
+++ b/src/server/routes/deploy/prebuilts/edition.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonPlatformFeeSchema,
@@ -29,11 +30,7 @@ const requestBodySchema = Type.Object({
     ...commonPrimarySaleSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -75,7 +72,14 @@ export async function deployPrebuiltEdition(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -88,6 +92,11 @@ export async function deployPrebuiltEdition(fastify: FastifyInstance) {
         "edition",
         contractMetadata,
         version,
+        {
+          saltForProxyDeploy,
+          forceDirectDeploy,
+          compilerOptions,
+        },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/editionDrop.ts
+++ b/src/server/routes/deploy/prebuilts/editionDrop.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonPlatformFeeSchema,
@@ -31,11 +32,7 @@ const requestBodySchema = Type.Object({
     ...commonPrimarySaleSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -75,7 +72,14 @@ export async function deployPrebuiltEditionDrop(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -88,6 +92,11 @@ export async function deployPrebuiltEditionDrop(fastify: FastifyInstance) {
         "edition-drop",
         contractMetadata,
         version,
+        {
+          saltForProxyDeploy,
+          forceDirectDeploy,
+          compilerOptions,
+        },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/marketplaceV3.ts
+++ b/src/server/routes/deploy/prebuilts/marketplaceV3.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonPlatformFeeSchema,
@@ -23,11 +24,7 @@ const requestBodySchema = Type.Object({
     ...commonPlatformFeeSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -66,7 +63,14 @@ export async function deployPrebuiltMarketplaceV3(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -79,6 +83,11 @@ export async function deployPrebuiltMarketplaceV3(fastify: FastifyInstance) {
         "marketplace-v3",
         contractMetadata,
         version,
+        {
+          saltForProxyDeploy,
+          forceDirectDeploy,
+          compilerOptions,
+        },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/multiwrap.ts
+++ b/src/server/routes/deploy/prebuilts/multiwrap.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonRoyaltySchema,
@@ -25,11 +26,7 @@ const requestBodySchema = Type.Object({
     ...commonSymbolSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -69,7 +66,14 @@ export async function deployPrebuiltMultiwrap(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -82,6 +86,11 @@ export async function deployPrebuiltMultiwrap(fastify: FastifyInstance) {
         "multiwrap",
         contractMetadata,
         version,
+        {
+          saltForProxyDeploy,
+          forceDirectDeploy,
+          compilerOptions,
+        },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/nftCollection.ts
+++ b/src/server/routes/deploy/prebuilts/nftCollection.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonPlatformFeeSchema,
@@ -29,11 +30,7 @@ const requestBodySchema = Type.Object({
     ...commonPrimarySaleSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -72,7 +69,14 @@ export async function deployPrebuiltNFTCollection(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -85,6 +89,11 @@ export async function deployPrebuiltNFTCollection(fastify: FastifyInstance) {
         "nft-collection",
         contractMetadata,
         version,
+        {
+          saltForProxyDeploy,
+          forceDirectDeploy,
+          compilerOptions,
+        },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/nftDrop.ts
+++ b/src/server/routes/deploy/prebuilts/nftDrop.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonPlatformFeeSchema,
@@ -31,11 +32,7 @@ const requestBodySchema = Type.Object({
     ...commonPrimarySaleSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -75,7 +72,14 @@ export async function deployPrebuiltNFTDrop(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -88,6 +92,11 @@ export async function deployPrebuiltNFTDrop(fastify: FastifyInstance) {
         "nft-drop",
         contractMetadata,
         version,
+        {
+          saltForProxyDeploy,
+          forceDirectDeploy,
+          compilerOptions,
+        },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/pack.ts
+++ b/src/server/routes/deploy/prebuilts/pack.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonPlatformFeeSchema,
@@ -27,11 +28,7 @@ const requestBodySchema = Type.Object({
     ...commonPlatformFeeSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -71,7 +68,14 @@ export async function deployPrebuiltPack(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -84,6 +88,11 @@ export async function deployPrebuiltPack(fastify: FastifyInstance) {
         "pack",
         contractMetadata,
         version,
+        {
+          saltForProxyDeploy,
+          forceDirectDeploy,
+          compilerOptions,
+        },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/signatureDrop.ts
+++ b/src/server/routes/deploy/prebuilts/signatureDrop.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonPlatformFeeSchema,
@@ -31,11 +32,7 @@ const requestBodySchema = Type.Object({
     ...commonPrimarySaleSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -76,7 +73,14 @@ export async function deployPrebuiltSignatureDrop(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -89,6 +93,7 @@ export async function deployPrebuiltSignatureDrop(fastify: FastifyInstance) {
         "signature-drop",
         contractMetadata,
         version,
+        { saltForProxyDeploy, forceDirectDeploy, compilerOptions },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/split.ts
+++ b/src/server/routes/deploy/prebuilts/split.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonTrustedForwarderSchema,
@@ -23,11 +24,7 @@ const requestBodySchema = Type.Object({
     recipients: Type.Array(splitRecipientInputSchema),
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -75,7 +72,14 @@ export async function deployPrebuiltSplit(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -88,6 +92,7 @@ export async function deployPrebuiltSplit(fastify: FastifyInstance) {
         "split",
         contractMetadata,
         version,
+        { saltForProxyDeploy, forceDirectDeploy, compilerOptions },
       );
       const deployedAddress = await tx.simulate();
       const queueId = await queueTx({

--- a/src/server/routes/deploy/prebuilts/token.ts
+++ b/src/server/routes/deploy/prebuilts/token.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonPlatformFeeSchema,
@@ -27,11 +28,7 @@ const requestBodySchema = Type.Object({
     ...commonPrimarySaleSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -72,7 +69,14 @@ export async function deployPrebuiltToken(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -85,6 +89,7 @@ export async function deployPrebuiltToken(fastify: FastifyInstance) {
         "token",
         contractMetadata,
         version,
+        { saltForProxyDeploy, forceDirectDeploy, compilerOptions },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/tokenDrop.ts
+++ b/src/server/routes/deploy/prebuilts/tokenDrop.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonPlatformFeeSchema,
@@ -29,11 +30,7 @@ const requestBodySchema = Type.Object({
     ...commonPrimarySaleSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -74,7 +71,14 @@ export async function deployPrebuiltTokenDrop(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -87,6 +91,7 @@ export async function deployPrebuiltTokenDrop(fastify: FastifyInstance) {
         "token-drop",
         contractMetadata,
         version,
+        { saltForProxyDeploy, forceDirectDeploy, compilerOptions },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/routes/deploy/prebuilts/vote.ts
+++ b/src/server/routes/deploy/prebuilts/vote.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../db/transactions/queueTx";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { contractDeployBasicSchema } from "../../../schemas/contract";
 import {
   commonContractSchema,
   commonTrustedForwarderSchema,
@@ -23,11 +24,7 @@ const requestBodySchema = Type.Object({
     ...voteSettingsInputSchema.properties,
     ...commonTrustedForwarderSchema.properties,
   }),
-  version: Type.Optional(
-    Type.String({
-      description: "Version of the contract to deploy. Defaults to latest.",
-    }),
-  ),
+  ...contractDeployBasicSchema.properties,
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -66,7 +63,14 @@ export async function deployPrebuiltVote(fastify: FastifyInstance) {
     },
     handler: async (request, reply) => {
       const { chain } = request.params;
-      const { contractMetadata, version, txOverrides } = request.body;
+      const {
+        contractMetadata,
+        version,
+        txOverrides,
+        saltForProxyDeploy,
+        forceDirectDeploy,
+        compilerOptions,
+      } = request.body;
       const chainId = await getChainIdFromChain(chain);
       const {
         "x-backend-wallet-address": walletAddress,
@@ -79,6 +83,7 @@ export async function deployPrebuiltVote(fastify: FastifyInstance) {
         "vote",
         contractMetadata,
         version,
+        { saltForProxyDeploy, forceDirectDeploy, compilerOptions },
       );
       const deployedAddress = await tx.simulate();
 

--- a/src/server/schemas/contract/index.ts
+++ b/src/server/schemas/contract/index.ts
@@ -95,11 +95,28 @@ export const eventsQuerystringSchema = Type.Object(
   },
 );
 
-export const RoyaltySchema = Type.Object({
+export const royaltySchema = Type.Object({
   seller_fee_basis_points: Type.Number({
     description: "The royalty fee in BPS (basis points). 100 = 1%.",
   }),
   fee_recipient: Type.String({
     description: "The wallet address that will receive the royalty fees.",
   }),
+});
+
+export const contractDeployBasicSchema = Type.Object({
+  version: Type.Optional(
+    Type.String({
+      description: "Version of the contract to deploy. Defaults to latest.",
+    }),
+  ),
+  forceDirectDeploy: Type.Optional(Type.Boolean()),
+  saltForProxyDeploy: Type.Optional(Type.String()),
+  compilerOptions: Type.Optional(
+    Type.Object({
+      compilerType: Type.Enum(Type.Literal("solc"), Type.Literal("zksolc")),
+      compilerVersion: Type.Optional(Type.String()),
+      evmVersion: Type.Optional(Type.String()),
+    }),
+  ),
 });


### PR DESCRIPTION
Request Body for Contract Deploy updated with :
- `forceDirectDeploy`
- `saltForProxyDeploy`
- `compilerOptions`
   - `compilerType` : `solc` /`zksolc`
   - `compilerVersion`
   - `evmVersion`

<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the variable name `RoyaltySchema` to `royaltySchema` for consistency in multiple files.

### Detailed summary
- Renamed `RoyaltySchema` to `royaltySchema` for consistency in multiple files.
- Added `contractDeployBasicSchema` to handle contract deployment details.

> The following files were skipped due to too many changes: `src/server/routes/deploy/prebuilts/nftDrop.ts`, `src/server/routes/deploy/prebuilts/tokenDrop.ts`, `src/server/routes/deploy/prebuilts/editionDrop.ts`, `src/server/routes/deploy/prebuilts/signatureDrop.ts`, `src/server/routes/deploy/prebuilts/marketplaceV3.ts`, `src/server/routes/deploy/prebuilts/nftCollection.ts`, `src/server/routes/deploy/prebuilts/split.ts`, `src/server/routes/deploy/published.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->