### PR TITLE
Add missing env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,12 @@ THIRDWEB_API_SECRET_KEY="<your-thirdweb-api-secret-key>"
 POSTGRES_CONNECTION_URL="postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 # The admin wallet that will be able to connect to Engine from the dashboard
 ADMIN_WALLET_ADDRESS="<your-admin-wallet-address>"
+# Encryption password for the wallet keys
+ENCRYPTION_PASSWORD="<your-encryption-password>"
+# The connection url for your running redis instance, defaults to localhost redis
+REDIS_URL="redis://localhost:6379/0"
 
-# =====[ Optional Configuration ]===== 
+# =====[ Optional Configuration ]=====
 
 # Optional configuration to override server host and port
 # PORT="3005"


### PR DESCRIPTION
## Changes

- Add missing env vars in .env.example

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add optional configuration settings for encryption, Redis connection, and server port override in the `.env.example` file.

### Detailed summary
- Added `ENCRYPTION_PASSWORD` for wallet keys encryption
- Added `REDIS_URL` for specifying Redis connection URL
- Uncommented optional configuration section for server host and port settings

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->