### PR TITLE
Update: Using Debian image (18.20-slim)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,7 @@ RUN apt-get install -y g++ make python3-pip && \
     yarn build && \
     yarn copy-files && \
     rm -rf node_modules && \
-    yarn install --production=true --frozen-lockfile --network-timeout 1000000 && \
-    apt del build-dependencies
+    yarn install --production=true --frozen-lockfile --network-timeout 1000000
 
 
 ##############################

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get -y update && apt-get -y upgrade
 
 # Install tini & build dependencies
 RUN apt-get install -y g++ make python3-pip openssl
+
 # Set the working directory
 WORKDIR /app
 
@@ -70,8 +71,11 @@ FROM node:18.20-slim AS prod
 ARG ENGINE_VERSION
 ENV ENGINE_VERSION=${ENGINE_VERSION}
 
-# Install tini
-# RUN apt-get install -y tini
+# Upgrade packages
+RUN apt-get -y update && apt-get -y upgrade
+
+# Install openssl
+RUN apt-get install -y openssl
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM node:18.19-alpine AS base
-
-# Install tini & build dependencies
-RUN apk add --no-cache tini && \
-    apk --no-cache --virtual build-dependencies add g++ make py3-pip openssl
+FROM node:18.20-slim AS base
 
 # Upgrade packages
-RUN apk update && apk upgrade
+RUN apt-get -y update && apt-get -y upgrade
 
+# Install tini & build dependencies
+RUN apt-get install -y g++ make python3-pip openssl
 # Set the working directory
 WORKDIR /app
 
@@ -30,7 +28,7 @@ RUN openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 \
 WORKDIR /app
 
 # Clean up build dependencies
-RUN apk del build-dependencies
+# RUN apt del build-dependencies
 
 ##############################
 ##############################
@@ -40,9 +38,6 @@ FROM base AS local
 EXPOSE 3005
 ENV NODE_ENV="local"
 RUN npm install -g nodemon
-
-# Use tini as entrypoint to handle killing processes
-ENTRYPOINT ["/sbin/tini", "--"]
 
 CMD [ "sh", "-c","yarn prisma:setup:dev && yarn dev:run" ]
 
@@ -54,29 +49,30 @@ FROM base AS prod-dependencies
 
 WORKDIR /app
 
+# Upgrade packages
+RUN apt-get -y update && apt-get -y upgrade
+
 # Build the project
-RUN apk --no-cache --virtual build-dependencies add g++ make py3-pip && \
+RUN apt-get install -y g++ make python3-pip && \
     yarn build && \
     yarn copy-files && \
     rm -rf node_modules && \
     yarn install --production=true --frozen-lockfile --network-timeout 1000000 && \
-    apk del build-dependencies
+    apt del build-dependencies
 
-# Upgrade packages
-RUN apk update && apk upgrade
 
 ##############################
 ##############################
 
 # Production stage
-FROM node:18.19-alpine AS prod
+FROM node:18.20-slim AS prod
 
 # Setting ENV variables for image information
 ARG ENGINE_VERSION
 ENV ENGINE_VERSION=${ENGINE_VERSION}
 
 # Install tini
-RUN apk add --no-cache tini
+# RUN apt-get install -y tini
 
 # Set the working directory
 WORKDIR /app
@@ -96,6 +92,4 @@ COPY --from=prod-dependencies /app/node_modules ./node_modules
 COPY --from=prod-dependencies /app/dist ./dist
 COPY --from=base /app/src/https ./dist/https
 
-# Use tini as entrypoint to handle killing processes
-ENTRYPOINT ["/sbin/tini", "--"]
 CMD [ "yarn", "start"]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Dockerfile to switch package management from Alpine to Debian for better compatibility and installs dependencies using `apt`.

### Detailed summary
- Replaced Alpine base image with `node:18.20-slim`
- Switched package management commands from `apk` to `apt-get`
- Installed build dependencies using `apt-get`
- Removed unused `apk del` commands
- Updated package upgrade commands
- Installed `openssl` for production stage using `apt-get`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->