### PR TITLE
fix: handle filters missing from CS job data

### DIFF
--- a/src/worker/tasks/processEventLogsWorker.ts
+++ b/src/worker/tasks/processEventLogsWorker.ts
@@ -30,8 +30,12 @@ import { logWorkerEvents } from "../queues/queues";
 import { enqueueWebhook } from "../queues/sendWebhookQueue";
 
 const handler: Processor<any, void, string> = async (job: Job<string>) => {
-  const { chainId, filters, fromBlock, toBlock } =
-    superjson.parse<EnqueueProcessEventLogsData>(job.data);
+  const {
+    chainId,
+    filters = [],
+    fromBlock,
+    toBlock,
+  } = superjson.parse<EnqueueProcessEventLogsData>(job.data);
 
   const logs = await getLogs({
     chainId,

--- a/src/worker/tasks/processTransactionReceiptsWorker.ts
+++ b/src/worker/tasks/processTransactionReceiptsWorker.ts
@@ -28,8 +28,12 @@ import { getContractId } from "../utils/contractId";
 import { getWebhooksByContractAddresses } from "./processEventLogsWorker";
 
 const handler: Processor<any, void, string> = async (job: Job<string>) => {
-  const { chainId, filters, fromBlock, toBlock } =
-    superjson.parse<EnqueueProcessTransactionReceiptsData>(job.data);
+  const {
+    chainId,
+    filters = [],
+    fromBlock,
+    toBlock,
+  } = superjson.parse<EnqueueProcessTransactionReceiptsData>(job.data);
 
   const receipts = await getFormattedTransactionReceipts({
     chainId,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates two worker tasks to include default values for `filters` in the destructuring assignment of job data.

### Detailed summary
- Added default value `[]` for `filters` in `processEventLogsWorker.ts` and `processTransactionReceiptsWorker.ts`
- Improved readability and consistency in handling job data parameters

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->