### PR TITLE
fix: don't apply rate limit to health check endpoints

### DIFF
--- a/src/server/middleware/rateLimit.ts
+++ b/src/server/middleware/rateLimit.ts
@@ -6,6 +6,14 @@ import { createCustomError } from "./error";
 
 export const withRateLimit = async (server: FastifyInstance) => {
   server.addHook("onRequest", async (request, reply) => {
+    if (
+      request.url === "/" ||
+      request.url === "/system/health" ||
+      request.url === "/json"
+    ) {
+      return;
+    }
+
     const epochTimeInMinutes = Math.floor(new Date().getTime() / (1000 * 60));
     const key = `rate-limit:global:${epochTimeInMinutes}`;
     const count = await redis.incr(key);

--- a/src/server/middleware/rateLimit.ts
+++ b/src/server/middleware/rateLimit.ts
@@ -6,11 +6,7 @@ import { createCustomError } from "./error";
 
 export const withRateLimit = async (server: FastifyInstance) => {
   server.addHook("onRequest", async (request, reply) => {
-    if (
-      request.url === "/" ||
-      request.url === "/system/health" ||
-      request.url === "/json"
-    ) {
+    if (request.url === "/" || request.url === "/json") {
       return;
     }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a rate limiting middleware to a Fastify server, skipping rate limiting for "/" and "/json" routes.

### Detailed summary
- Added a rate limiting middleware to the Fastify server
- Skips rate limiting for "/" and "/json" routes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->