### PR TITLE
Cache smart wallet account factory address

### DIFF
--- a/src/server/routes/contract/extensions/accountFactory/write/createAccount.ts
+++ b/src/server/routes/contract/extensions/accountFactory/write/createAccount.ts
@@ -12,7 +12,7 @@ import {
 import { txOverridesWithValueSchema } from "../../../../../schemas/txOverrides";
 import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
-import { redis } from "../../../../../utils/redis";
+import { redis } from "../../../../../../utils/redis/redis";
 
 const requestBodySchema = Type.Object({
   adminAddress: Type.String({

--- a/src/server/routes/contract/extensions/accountFactory/write/createAccount.ts
+++ b/src/server/routes/contract/extensions/accountFactory/write/createAccount.ts
@@ -12,7 +12,7 @@ import {
 import { txOverridesWithValueSchema } from "../../../../../schemas/txOverrides";
 import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
-import { redis } from "../../../../../../utils/redis/redis";
+import { redis } from "utils/redis/redis";
 
 const requestBodySchema = Type.Object({
   adminAddress: Type.String({

--- a/src/server/routes/contract/extensions/accountFactory/write/createAccount.ts
+++ b/src/server/routes/contract/extensions/accountFactory/write/createAccount.ts
@@ -95,9 +95,7 @@ export const createAccount = async (fastify: FastifyInstance) => {
 
       // Note: This is a temporary solution to cache the deployed address's factory for 7 days.
       // This is needed due to a potential race condition of submitting a transaction immediately after creating an account that is not yet mined onchain
-      if (redis) {
-        await redis.set(`account-factory:${deployedAddress.toLowerCase()}`, contractAddress, 'EX', 7 * 24 * 60 * 60);
-      }
+      await redis.set(`account-factory:${deployedAddress.toLowerCase()}`, contractAddress, 'EX', 7 * 24 * 60 * 60);
 
       reply.status(StatusCodes.OK).send({
         result: {

--- a/src/server/routes/contract/extensions/accountFactory/write/createAccount.ts
+++ b/src/server/routes/contract/extensions/accountFactory/write/createAccount.ts
@@ -12,6 +12,7 @@ import {
 import { txOverridesWithValueSchema } from "../../../../../schemas/txOverrides";
 import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
+import { redis } from "../../../../../utils/redis";
 
 const requestBodySchema = Type.Object({
   adminAddress: Type.String({
@@ -91,6 +92,12 @@ export const createAccount = async (fastify: FastifyInstance) => {
         idempotencyKey,
         txOverrides,
       });
+
+      // Note: This is a temporary solution to cache the deployed address's factory for 7 days.
+      // This is needed due to a potential race condition of submitting a transaction immediately after creating an account that is not yet mined onchain
+      if (redis) {
+        await redis.set(`account-factory:${deployedAddress.toLowerCase()}`, contractAddress, 'EX', 7 * 24 * 60 * 60);
+      }
 
       reply.status(StatusCodes.OK).send({
         result: {

--- a/src/server/utils/wallets/getSmartWallet.ts
+++ b/src/server/utils/wallets/getSmartWallet.ts
@@ -14,12 +14,12 @@ export const getSmartWallet = async ({
   backendWallet,
   accountAddress,
 }: GetSmartWalletParams) => {
-  let factoryAddress: string;
+  let factoryAddress: string = "";
 
   try {
     // Note: This is a temporary solution to use cached deployed address's factory address from create-account
     // This is needed due to a potential race condition of submitting a transaction immediately after creating an account that is not yet mined onchain
-    factoryAddress = await redis.get(`account-factory:${accountAddress.toLowerCase()}`);
+    factoryAddress = (await redis.get(`account-factory:${accountAddress.toLowerCase()}`)) || "";
   } catch {
   }
 

--- a/src/server/utils/wallets/getSmartWallet.ts
+++ b/src/server/utils/wallets/getSmartWallet.ts
@@ -1,7 +1,7 @@
 import { EVMWallet, SmartWallet } from "@thirdweb-dev/wallets";
 import { getContract } from "../../../utils/cache/getContract";
 import { env } from "../../../utils/env";
-import { redis } from "../../../utils/redis/redis";
+import { redis } from "utils/redis/redis";
 
 interface GetSmartWalletParams {
   chainId: number;

--- a/src/server/utils/wallets/getSmartWallet.ts
+++ b/src/server/utils/wallets/getSmartWallet.ts
@@ -1,7 +1,7 @@
 import { EVMWallet, SmartWallet } from "@thirdweb-dev/wallets";
 import { getContract } from "../../../utils/cache/getContract";
 import { env } from "../../../utils/env";
-import { redis } from "../../../utils/redis";
+import { redis } from "../../../utils/redis/redis";
 
 interface GetSmartWalletParams {
   chainId: number;

--- a/src/server/utils/wallets/getSmartWallet.ts
+++ b/src/server/utils/wallets/getSmartWallet.ts
@@ -19,27 +19,22 @@ export const getSmartWallet = async ({
   try {
     // Note: This is a temporary solution to use cached deployed address's factory address from create-account
     // This is needed due to a potential race condition of submitting a transaction immediately after creating an account that is not yet mined onchain
-    if (redis) {
-      factoryAddress = await redis.get(`account-factory:${accountAddress.toLowerCase()}`);
-    }
+    factoryAddress = await redis.get(`account-factory:${accountAddress.toLowerCase()}`);
   } catch {
   }
 
-  try {
-    if (!factoryAddress) {
+  if (!factoryAddress) {
+    try {
       const contract = await getContract({
         chainId,
         contractAddress: accountAddress,
       });
       factoryAddress = await contract.call("factory");
+    } catch {
+      throw new Error(
+        `Failed to find factory address for account '${accountAddress}' on chain '${chainId}'`,
+      );
     }
-  } catch {
-  }
-
-  if (!factoryAddress) {
-    throw new Error(
-      `Failed to find factory address for account '${accountAddress}' on chain '${chainId}'`,
-    );
   }
 
   const smartWallet = new SmartWallet({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,
     "allowJs": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": "src"
   },
   "ts-node": {
     "esm": true,


### PR DESCRIPTION
## Changes

- Cache smart wallet account factory address (create-account)

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to introduce caching mechanisms using Redis for factory addresses and deployed account codes to handle potential race conditions in account creation and transaction processing.

### Detailed summary
- Added Redis caching for factory addresses and deployed account codes
- Improved handling of potential race conditions in account creation and transaction processing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->