### PR TITLE
Updates: Build base OS changed to Ubuntu Latest 32

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-32
 
     steps:
       - name: Check Disk Space Before Build

--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   buildImageForNewTag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-32
     # Set environment variables
     env:
       LATEST_TAG: ${{ (github.event.release.target_commitish == 'main') && 'thirdweb/engine:latest' || '' }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the GitHub Actions workflow to run on `ubuntu-latest-32` instead of `ubuntu-latest`.

### Detailed summary
- Updated the `runs-on` field in the GitHub Actions workflow to use `ubuntu-latest-32` instead of `ubuntu-latest` for both jobs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->