### PR TITLE
chore: add index on queuedAt and sentAt

### DIFF
--- a/src/prisma/migrations/20240731184631_add_queued_at_idx/migration.sql
+++ b/src/prisma/migrations/20240731184631_add_queued_at_idx/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "transactions_queuedAt_idx" ON "transactions"("queuedAt");
+
+-- CreateIndex
+CREATE INDEX "transactions_sentAt_idx" ON "transactions"("sentAt");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -160,6 +160,8 @@ model Transactions {
   sentAtBlockNumber         Int?      @map("sentAtBlockNumber")
   blockNumber               Int?      @map("blockNumber")
 
+  @@index([queuedAt])
+  @@index([sentAt])
   @@map("transactions")
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding indexes for the `queuedAt` and `sentAt` columns in the `transactions` table.

### Detailed summary
- Added index for `queuedAt` column in `transactions` table
- Added index for `sentAt` column in `transactions` table

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->