### PR TITLE
Revert "chore: add index on queuedAt and sentAt"

### DIFF
--- a/src/prisma/migrations/20240731184631_add_queued_at_idx/migration.sql
+++ b/src/prisma/migrations/20240731184631_add_queued_at_idx/migration.sql
@@ -1,5 +1,0 @@
--- CreateIndex
-CREATE INDEX "transactions_queuedAt_idx" ON "transactions"("queuedAt");
-
--- CreateIndex
-CREATE INDEX "transactions_sentAt_idx" ON "transactions"("sentAt");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -160,8 +160,6 @@ model Transactions {
   sentAtBlockNumber         Int?      @map("sentAtBlockNumber")
   blockNumber               Int?      @map("blockNumber")
 
-  @@index([queuedAt])
-  @@index([sentAt])
   @@map("transactions")
 }
 


### PR DESCRIPTION
Reverts thirdweb-dev/engine#589

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes a migration SQL file and a field from the Prisma schema related to `queuedAt` and `sentAt` indexes.

### Detailed summary
- Deleted `20240731184631_add_queued_at_idx` migration SQL file
- Removed `queuedAt` field index from Prisma schema
- Removed `sentAt` field index from Prisma schema

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->