### PR TITLE
Updates: Removed logs + queuedAt indexed

### DIFF
--- a/src/prisma/migrations/20240802175702_transaction_tbl_queued_at_idx/migration.sql
+++ b/src/prisma/migrations/20240802175702_transaction_tbl_queued_at_idx/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "transactions_queuedAt_idx" ON "transactions"("queuedAt");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -163,6 +163,7 @@ model Transactions {
   @@index([sentAt, minedAt, cancelledAt, errorMessage, queuedAt])
   @@index([sentAt, accountAddress, userOpHash, minedAt, errorMessage, retryCount])
   @@index([sentAt, transactionHash, accountAddress, minedAt, errorMessage, nonce])
+  @@index([queuedAt])
   @@map("transactions")
 }
 

--- a/src/worker/tasks/processTx.ts
+++ b/src/worker/tasks/processTx.ts
@@ -116,7 +116,7 @@ export const processTx = async () => {
           });
           logger({
             service: "worker",
-            level: "info",
+            level: "debug",
             message: `[processTx] Got DB nonce ${dbNonceData?.nonce} for ${walletAddress}.`,
           });
 
@@ -129,7 +129,7 @@ export const processTx = async () => {
             ]);
           logger({
             service: "worker",
-            level: "info",
+            level: "debug",
             message: `[processTx] Got onchain nonce ${mempoolNonceData} for ${walletAddress}.`,
           });
 
@@ -152,7 +152,7 @@ export const processTx = async () => {
 
           logger({
             service: "worker",
-            level: "info",
+            level: "debug",
             message: `[processTx] Sending ${txsToSend.length} transactions from wallet ${walletAddress}.`,
           });
 
@@ -314,7 +314,7 @@ export const processTx = async () => {
 
           logger({
             service: "worker",
-            level: "info",
+            level: "debug",
             message: `[processTx] Updated nonce to ${nextUnusedNonce} for ${walletAddress}.`,
           });
 
@@ -536,7 +536,7 @@ export const processTx = async () => {
 
         logger({
           service: "worker",
-          level: "info",
+          level: "debug",
           message: `[processTx] Awaiting transactions/userOps promises...`,
         });
         await Promise.all([...sentTxs, ...sentUserOps]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update logging levels in the `processTx` function from "info" to "debug".

### Detailed summary
- Added a new index `transactions_queuedAt_idx` on the `queuedAt` column in the `transactions` table in the database migration script.
- Added an index on `queuedAt` in the Prisma schema.
- Updated logging levels in the `processTx` function from "info" to "debug" for various messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->