### PR TITLE
fix: dont track send_tx on retries

### DIFF
--- a/src/server/routes/transaction/syncRetry.ts
+++ b/src/server/routes/transaction/syncRetry.ts
@@ -5,9 +5,7 @@ import { StatusCodes } from "http-status-codes";
 import { prisma } from "../../../db/client";
 import { updateTx } from "../../../db/transactions/updateTx";
 import { getSdk } from "../../../utils/cache/getSdk";
-import { msSince } from "../../../utils/date";
 import { parseTxError } from "../../../utils/errors";
-import { UsageEventTxActionEnum, reportUsage } from "../../../utils/usage";
 import { createCustomError } from "../../middleware/error";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 import { TransactionStatus } from "../../schemas/transaction";
@@ -148,21 +146,6 @@ export async function syncRetryTransaction(fastify: FastifyInstance) {
           sentAtBlockNumber: blockNumber,
         },
       });
-      reportUsage([
-        {
-          action: UsageEventTxActionEnum.SendTx,
-          input: {
-            fromAddress: tx.fromAddress,
-            toAddress: tx.toAddress,
-            value: tx.value,
-            chainId: tx.chainId,
-            transactionHash,
-            functionName: tx.functionName || undefined,
-            extension: tx.extension || undefined,
-            msSinceQueue: msSince(new Date(tx.queuedAt)),
-          },
-        },
-      ]);
 
       reply.status(StatusCodes.OK).send({
         result: {

--- a/src/worker/tasks/retryTx.ts
+++ b/src/worker/tasks/retryTx.ts
@@ -125,23 +125,6 @@ export const retryTx = async () => {
           },
         });
 
-        reportUsage([
-          {
-            input: {
-              fromAddress: tx.fromAddress || undefined,
-              toAddress: tx.toAddress || undefined,
-              value: tx.value || undefined,
-              chainId: tx.chainId,
-              functionName: tx.functionName || undefined,
-              extension: tx.extension || undefined,
-              retryCount: tx.retryCount + 1,
-              transactionHash: transactionResponse.hash || undefined,
-              provider: provider.connection.url,
-            },
-            action: UsageEventTxActionEnum.SendTx,
-          },
-        ]);
-
         logger({
           service: "worker",
           level: "info",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to remove redundant `reportUsage` calls in `retryTx.ts` and `syncRetry.ts`.

### Detailed summary
- Removed `reportUsage` calls in `retryTx.ts` and `syncRetry.ts`
- Removed unused imports in `syncRetry.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->