### PR TITLE
chore: add p50/p90 queue metrics to health check

### DIFF
--- a/src/server/routes/system/queue.ts
+++ b/src/server/routes/system/queue.ts
@@ -52,13 +52,14 @@ export async function queueStatus(fastify: FastifyInstance) {
       // Get # queued and sent transactions.
       const { queued, pending } = await getQueueStatus({ walletAddress });
 
-      // Get sent/queued latency of last 1k txs.
+      // Get last 1k sent transactions.
       const recentTransactions = await prisma.transactions.findMany({
-        orderBy: {
-          queuedAt: "desc",
-        },
+        orderBy: { queuedAt: "desc" },
+        where: { sentAt: { not: null } },
         take: 1_000,
       });
+
+      // Get "queue -> send" and "queue -> mine" times.
       const msToSendArr: number[] = [];
       const msToMineArr: number[] = [];
       for (const transaction of recentTransactions) {

--- a/src/server/routes/system/queue.ts
+++ b/src/server/routes/system/queue.ts
@@ -1,7 +1,9 @@
 import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
+import { prisma } from "../../../db/client";
 import { getQueueStatus } from "../../../db/transactions/getQueueStatus";
+import { getPercentile } from "../../../utils/math";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 
 const QuerySchema = Type.Object({
@@ -12,6 +14,16 @@ const responseBodySchema = Type.Object({
   result: Type.Object({
     queued: Type.Number(),
     pending: Type.Number(),
+    latency: Type.Object({
+      msToSend: Type.Object({
+        p50: Type.Number(),
+        p90: Type.Number(),
+      }),
+      msToMine: Type.Object({
+        p50: Type.Number(),
+        p90: Type.Number(),
+      }),
+    }),
   }),
 });
 
@@ -37,11 +49,45 @@ export async function queueStatus(fastify: FastifyInstance) {
     handler: async (req, res) => {
       const { walletAddress } = req.query;
 
+      // Get # queued and sent transactions.
       const { queued, pending } = await getQueueStatus({ walletAddress });
+
+      // Get sent/queued latency of last 1k txs.
+      const recentTransactions = await prisma.transactions.findMany({
+        orderBy: {
+          queuedAt: "desc",
+        },
+        take: 1_000,
+      });
+      const msToSendArr: number[] = [];
+      const msToMineArr: number[] = [];
+      for (const transaction of recentTransactions) {
+        const queuedAt = transaction.queuedAt.getTime();
+        const sentAt = transaction.sentAt?.getTime();
+        const minedAt = transaction.minedAt?.getTime();
+
+        if (sentAt) {
+          msToSendArr.push(sentAt - queuedAt);
+        }
+        if (minedAt) {
+          msToMineArr.push(minedAt - queuedAt);
+        }
+      }
+
       res.status(StatusCodes.OK).send({
         result: {
           queued,
           pending,
+          latency: {
+            msToSend: {
+              p50: getPercentile(msToSendArr, 50),
+              p90: getPercentile(msToSendArr, 90),
+            },
+            msToMine: {
+              p50: getPercentile(msToMineArr, 50),
+              p90: getPercentile(msToMineArr, 90),
+            },
+          },
         },
       });
     },

--- a/src/tests/math.test.ts
+++ b/src/tests/math.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getPercentile } from "../utils/math";
+
+describe("getPercentile", () => {
+  it("should correctly calculate the p50 (median) of a sorted array", () => {
+    const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(getPercentile(numbers, 50)).toBe(5);
+  });
+
+  it("should correctly calculate the p90 of a sorted array", () => {
+    const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(getPercentile(numbers, 90)).toBe(9);
+  });
+
+  it("should handle arrays with even number of elements", () => {
+    const numbers = [10, 20, 30, 40, 50, 60, 70, 80];
+    expect(getPercentile(numbers, 50)).toBe(40);
+  });
+
+  it("should handle single element array", () => {
+    const numbers = [1];
+    expect(getPercentile(numbers, 50)).toBe(1);
+  });
+
+  it("should handle empty array", () => {
+    const numbers: number[] = [];
+    expect(getPercentile(numbers, 50)).toBe(0);
+  });
+});

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,9 @@
+export const getPercentile = (arr: number[], percentile: number): number => {
+  if (arr.length === 0) {
+    return 0;
+  }
+
+  arr.sort((a, b) => a - b);
+  const index = Math.floor((percentile / 100) * (arr.length - 1));
+  return arr[index];
+};


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add percentile calculations for latency metrics in the queue status endpoint.

### Detailed summary
- Added `getPercentile` function to calculate percentiles in `math.ts`.
- Updated tests for `getPercentile` in `math.test.ts`.
- Added latency percentile calculations in `queue.ts`.
- Imported `getPercentile` in `queue.ts` for latency calculations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->