### PR TITLE
Updates: Claim-to using v5 SDK

### DIFF
--- a/src/server/routes/contract/extensions/erc1155/write/claimTo.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/claimTo.ts
@@ -86,7 +86,7 @@ export async function erc1155claimTo(fastify: FastifyInstance) {
       });
 
       let queueId: string;
-      let insertedTransaction = {
+      const insertedTransaction = {
         chainId,
         from: fromAddress as Address,
         to: contractAddress as Address | undefined,

--- a/src/server/routes/contract/extensions/erc1155/write/claimTo.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/claimTo.ts
@@ -1,8 +1,12 @@
 import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { queueTx } from "../../../../../../db/transactions/queueTx";
-import { getContract } from "../../../../../../utils/cache/getContract";
+import { Address, Hex } from "thirdweb";
+import { claimTo } from "thirdweb/extensions/erc1155";
+import { resolvePromisedValue } from "thirdweb/utils";
+import { getContractV5 } from "../../../../../../utils/cache/getContractv5";
+import { maybeBigInt } from "../../../../../../utils/primitiveTypes";
+import { insertTransaction } from "../../../../../../utils/transaction/insertTransaction";
 import {
   erc1155ContractParamSchema,
   requestQuerystringSchema,
@@ -64,32 +68,57 @@ export async function erc1155claimTo(fastify: FastifyInstance) {
       const { simulateTx } = request.query;
       const { receiver, tokenId, quantity, txOverrides } = request.body;
       const {
-        "x-backend-wallet-address": walletAddress,
+        "x-backend-wallet-address": fromAddress,
         "x-account-address": accountAddress,
         "x-idempotency-key": idempotencyKey,
       } = request.headers as Static<typeof walletWithAAHeaderSchema>;
 
       const chainId = await getChainIdFromChain(chain);
-      const contract = await getContract({
+      const contract = await getContractV5({
         chainId,
         contractAddress,
-        walletAddress,
-        accountAddress,
       });
-      const tx = await contract.erc1155.claimTo.prepare(
-        receiver,
-        tokenId,
-        quantity,
-      );
+      const transaction = claimTo({
+        contract,
+        to: receiver,
+        quantity: BigInt(quantity),
+        tokenId: BigInt(tokenId),
+      });
 
-      const queueId = await queueTx({
-        tx,
+      let queueId: string;
+      let insertedTransaction = {
         chainId,
-        simulateTx,
-        extension: "erc1155",
-        idempotencyKey,
-        txOverrides,
-      });
+        from: fromAddress as Address,
+        to: contractAddress as Address | undefined,
+        data: (await resolvePromisedValue(transaction.data)) as Hex,
+        value: maybeBigInt(txOverrides?.value),
+        gas: maybeBigInt(txOverrides?.gas),
+        maxFeePerGas: maybeBigInt(txOverrides?.maxFeePerGas),
+        maxPriorityFeePerGas: maybeBigInt(txOverrides?.maxPriorityFeePerGas),
+      };
+
+      if (accountAddress) {
+        queueId = await insertTransaction({
+          insertedTransaction: {
+            ...insertedTransaction,
+            isUserOp: true,
+            accountAddress: accountAddress as Address,
+            signerAddress: fromAddress as Address,
+            target: contractAddress as Address | undefined,
+          },
+          shouldSimulate: simulateTx,
+          idempotencyKey,
+        });
+      } else {
+        queueId = await insertTransaction({
+          insertedTransaction: {
+            ...insertedTransaction,
+            isUserOp: false,
+          },
+          shouldSimulate: simulateTx,
+          idempotencyKey,
+        });
+      }
 
       reply.status(StatusCodes.OK).send({
         result: {

--- a/src/server/routes/contract/extensions/erc20/write/claimTo.ts
+++ b/src/server/routes/contract/extensions/erc20/write/claimTo.ts
@@ -82,7 +82,7 @@ export async function erc20claimTo(fastify: FastifyInstance) {
       });
 
       let queueId: string;
-      let insertedTransaction = {
+      const insertedTransaction = {
         chainId,
         from: fromAddress as Address,
         to: contractAddress as Address | undefined,

--- a/src/server/routes/contract/extensions/erc20/write/claimTo.ts
+++ b/src/server/routes/contract/extensions/erc20/write/claimTo.ts
@@ -1,8 +1,12 @@
 import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { queueTx } from "../../../../../../db/transactions/queueTx";
-import { getContract } from "../../../../../../utils/cache/getContract";
+import { Address } from "thirdweb";
+import { claimTo } from "thirdweb/extensions/erc20";
+import { resolvePromisedValue } from "thirdweb/utils";
+import { getContractV5 } from "../../../../../../utils/cache/getContractv5";
+import { maybeBigInt } from "../../../../../../utils/primitiveTypes";
+import { insertTransaction } from "../../../../../../utils/transaction/insertTransaction";
 import {
   erc20ContractParamSchema,
   requestQuerystringSchema,
@@ -61,28 +65,56 @@ export async function erc20claimTo(fastify: FastifyInstance) {
       const { simulateTx } = request.query;
       const { recipient, amount, txOverrides } = request.body;
       const {
-        "x-backend-wallet-address": walletAddress,
+        "x-backend-wallet-address": fromAddress,
         "x-account-address": accountAddress,
         "x-idempotency-key": idempotencyKey,
       } = request.headers as Static<typeof walletWithAAHeaderSchema>;
 
       const chainId = await getChainIdFromChain(chain);
-      const contract = await getContract({
+      const contract = await getContractV5({
         chainId,
         contractAddress,
-        walletAddress,
-        accountAddress,
       });
-      const tx = await contract.erc20.claimTo.prepare(recipient, amount);
+      const transaction = claimTo({
+        contract,
+        to: recipient,
+        quantity: amount,
+      });
 
-      const queueId = await queueTx({
-        tx,
+      let queueId: string;
+      let insertedTransaction = {
         chainId,
-        simulateTx,
-        extension: "erc20",
-        idempotencyKey,
-        txOverrides,
-      });
+        from: fromAddress as Address,
+        to: contractAddress as Address | undefined,
+        data: (await resolvePromisedValue(transaction.data)) as Hex,
+        value: maybeBigInt(txOverrides?.value),
+        gas: maybeBigInt(txOverrides?.gas),
+        maxFeePerGas: maybeBigInt(txOverrides?.maxFeePerGas),
+        maxPriorityFeePerGas: maybeBigInt(txOverrides?.maxPriorityFeePerGas),
+      };
+
+      if (accountAddress) {
+        queueId = await insertTransaction({
+          insertedTransaction: {
+            ...insertedTransaction,
+            isUserOp: true,
+            accountAddress: accountAddress as Address,
+            signerAddress: fromAddress as Address,
+            target: contractAddress as Address | undefined,
+          },
+          shouldSimulate: simulateTx,
+          idempotencyKey,
+        });
+      } else {
+        queueId = await insertTransaction({
+          insertedTransaction: {
+            ...insertedTransaction,
+            isUserOp: false,
+          },
+          shouldSimulate: simulateTx,
+          idempotencyKey,
+        });
+      }
 
       reply.status(StatusCodes.OK).send({
         result: {

--- a/src/server/routes/contract/extensions/erc721/write/claimTo.ts
+++ b/src/server/routes/contract/extensions/erc721/write/claimTo.ts
@@ -81,7 +81,7 @@ export async function erc721claimTo(fastify: FastifyInstance) {
       });
 
       let queueId: string;
-      let insertedTransaction = {
+      const insertedTransaction = {
         chainId,
         from: fromAddress as Address,
         to: contractAddress as Address | undefined,

--- a/src/utils/cache/clearCache.ts
+++ b/src/utils/cache/clearCache.ts
@@ -1,6 +1,7 @@
 import { env } from "../env";
 import { accessTokenCache } from "./accessToken";
 import { invalidateConfig } from "./getConfig";
+import { contractCache } from "./getContractv5";
 import { sdkCache } from "./getSdk";
 import { walletsCache } from "./getWallet";
 import { webhookCache } from "./getWebhook";
@@ -15,4 +16,5 @@ export const clearCache = async (
   walletsCache.clear();
   accessTokenCache.clear();
   keypairCache.clear();
+  contractCache.clear();
 };

--- a/src/utils/cache/clearCache.ts
+++ b/src/utils/cache/clearCache.ts
@@ -1,7 +1,6 @@
 import { env } from "../env";
 import { accessTokenCache } from "./accessToken";
 import { invalidateConfig } from "./getConfig";
-import { contractCache } from "./getContractv5";
 import { sdkCache } from "./getSdk";
 import { walletsCache } from "./getWallet";
 import { webhookCache } from "./getWebhook";
@@ -16,5 +15,4 @@ export const clearCache = async (
   walletsCache.clear();
   accessTokenCache.clear();
   keypairCache.clear();
-  contractCache.clear();
 };

--- a/src/utils/cache/getContractv5.ts
+++ b/src/utils/cache/getContractv5.ts
@@ -1,0 +1,34 @@
+import { ContractOptions, defineChain, getContract } from "thirdweb";
+import { thirdwebClient } from "../../utils/sdk";
+
+interface GetContractParams {
+  chainId: number;
+  contractAddress: string;
+}
+
+// export const definedChainCache = new Map<number, Chain>(); // This is a cache
+export const contractCache = new Map<string, ContractOptions<[]>>(); // This is a cache
+
+// Using new v5 SDK
+export const getContractV5 = ({
+  chainId,
+  contractAddress,
+}: GetContractParams) => {
+  const definedChain = defineChain(chainId);
+  const cacheKey = `${definedChain.id}-${contractAddress}`;
+  const cachedContractData = contractCache.get(cacheKey);
+
+  if (cachedContractData) {
+    return cachedContractData;
+  }
+
+  // get a contract
+  return getContract({
+    // the client you have created via `createThirdwebClient()`
+    client: thirdwebClient,
+    // the contract's address
+    address: contractAddress,
+    // the chain the contract is deployed on
+    chain: definedChain,
+  });
+};

--- a/src/utils/cache/getContractv5.ts
+++ b/src/utils/cache/getContractv5.ts
@@ -1,4 +1,4 @@
-import { ContractOptions, defineChain, getContract } from "thirdweb";
+import { defineChain, getContract } from "thirdweb";
 import { thirdwebClient } from "../../utils/sdk";
 
 interface GetContractParams {
@@ -6,21 +6,12 @@ interface GetContractParams {
   contractAddress: string;
 }
 
-// export const definedChainCache = new Map<number, Chain>(); // This is a cache
-export const contractCache = new Map<string, ContractOptions<[]>>(); // This is a cache
-
 // Using new v5 SDK
 export const getContractV5 = ({
   chainId,
   contractAddress,
 }: GetContractParams) => {
   const definedChain = defineChain(chainId);
-  const cacheKey = `${definedChain.id}-${contractAddress}`;
-  const cachedContractData = contractCache.get(cacheKey);
-
-  if (cachedContractData) {
-    return cachedContractData;
-  }
 
   // get a contract
   return getContract({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the contract interaction functions to use the new v5 SDK and improve transaction handling in ERC20, ERC721, and ERC1155 extensions.

### Detailed summary
- Updated contract interaction functions to use `getContractV5` with new v5 SDK
- Improved transaction handling with `insertTransaction` and `claimTo` functions
- Added `Address` and `Hex` imports from `thirdweb` for type safety

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->