### PR TITLE
fix: AA header is optional

### DIFF
--- a/src/server/schemas/wallet/index.ts
+++ b/src/server/schemas/wallet/index.ts
@@ -16,10 +16,10 @@ export const walletHeaderSchema = Type.Object({
 
 export const walletWithAAHeaderSchema = Type.Object({
   ...walletHeaderSchema.properties,
-  "x-account-address": {
+  "x-account-address": Type.Optional({
     ...AddressSchema,
     description: "Smart account address",
-  },
+  }),
 });
 
 export const walletChainParamSchema = Type.Object({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `walletWithAAHeaderSchema` in the `index.ts` file to make the `x-account-address` field optional.

### Detailed summary
- Updated `walletWithAAHeaderSchema` to make `x-account-address` field optional.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->