### PR TITLE
bugfix: parse boolean args in readContract

### DIFF
--- a/src/server/routes/contract/read/read.ts
+++ b/src/server/routes/contract/read/read.ts
@@ -28,10 +28,17 @@ export async function readContract(fastify: FastifyInstance) {
         contractAddress,
       });
 
-      let returnData = await contract.call(
-        functionName,
-        args ? args.split(",") : [],
-      );
+      const parsedArgs = args?.split(",").map((arg) => {
+        if (arg === "true") {
+          return true;
+        } else if (arg === "false") {
+          return false;
+        } else {
+          return arg;
+        }
+      });
+
+      let returnData = await contract.call(functionName, parsedArgs);
       returnData = bigNumberReplacer(returnData);
 
       reply.status(StatusCodes.OK).send({

--- a/src/server/routes/contract/read/read.ts
+++ b/src/server/routes/contract/read/read.ts
@@ -38,7 +38,7 @@ export async function readContract(fastify: FastifyInstance) {
         }
       });
 
-      let returnData = await contract.call(functionName, parsedArgs);
+      let returnData = await contract.call(functionName, parsedArgs ?? []);
       returnData = bigNumberReplacer(returnData);
 
       reply.status(StatusCodes.OK).send({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the parsing of arguments in a contract call by converting "true" and "false" strings to boolean values.

### Detailed summary
- Updated argument parsing in contract call to convert "true" and "false" strings to boolean values
- Used `map` to transform arguments array
- Replaced old argument parsing logic with a new conditional approach

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->