### PR TITLE
fix: cancel nonces in ascending order

### DIFF
--- a/src/server/routes/backend-wallet/withdraw.ts
+++ b/src/server/routes/backend-wallet/withdraw.ts
@@ -3,7 +3,6 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import {
   Address,
-  defineChain,
   estimateGasCost,
   prepareTransaction,
   sendTransaction,
@@ -68,7 +67,7 @@ export async function withdraw(fastify: FastifyInstance) {
       } = request.headers as Static<typeof walletHeaderSchema>;
 
       const chainId = await getChainIdFromChain(chainQuery);
-      const chain = defineChain(chainId);
+      const chain = await getChain(chainId);
       const from = walletAddress as Address;
 
       const account = await getAccount({ chainId, from });

--- a/src/server/routes/contract/extensions/erc721/write/signatureMint.ts
+++ b/src/server/routes/contract/extensions/erc721/write/signatureMint.ts
@@ -3,16 +3,12 @@ import { SignedPayload721WithQuantitySignature } from "@thirdweb-dev/sdk";
 import { BigNumber } from "ethers";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import {
-  Address,
-  Hex,
-  defineChain,
-  getContract as getContractV5,
-} from "thirdweb";
+import { Address, Hex, getContract as getContractV5 } from "thirdweb";
 import { mintWithSignature } from "thirdweb/extensions/erc721";
 import { resolvePromisedValue } from "thirdweb/utils";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { getChain } from "../../../../../../utils/chain";
 import { maybeBigInt } from "../../../../../../utils/primitiveTypes";
 import { thirdwebClient } from "../../../../../../utils/sdk";
 import { insertTransaction } from "../../../../../../utils/transaction/insertTransaction";
@@ -103,7 +99,7 @@ export async function erc721SignatureMint(fastify: FastifyInstance) {
         const payloadV5 = payload as Static<typeof signature721OutputSchemaV5>;
         const contract = getContractV5({
           client: thirdwebClient,
-          chain: defineChain(chainId),
+          chain: await getChain(chainId),
           address: contractAddress,
         });
         const transaction = mintWithSignature({

--- a/src/worker/tasks/cancelRecycledNoncesWorker.ts
+++ b/src/worker/tasks/cancelRecycledNoncesWorker.ts
@@ -88,5 +88,5 @@ const getAndDeleteUnusedNonces = async (key: string) => {
   if (error) {
     throw new Error(`Error getting members of ${key}: ${error}`);
   }
-  return (nonces as string[]).map((v) => parseInt(v));
+  return (nonces as string[]).map((v) => parseInt(v)).sort();
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates functions to use `getChain` instead of `defineChain` for chain retrieval.

### Detailed summary
- Replaces `defineChain` with `getChain` in `withdraw.ts` and `signatureMint.ts`
- Adds `.sort()` to mapped array in `cancelRecycledNoncesWorker.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->