### PR TITLE
fix: add from address to claimTo to support merkle proofs

### DIFF
--- a/src/server/routes/contract/extensions/erc1155/write/claimTo.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/claimTo.ts
@@ -80,6 +80,7 @@ export async function erc1155claimTo(fastify: FastifyInstance) {
       });
       const transaction = claimTo({
         contract,
+        from: fromAddress as Address,
         to: receiver,
         quantity: BigInt(quantity),
         tokenId: BigInt(tokenId),

--- a/src/server/routes/contract/extensions/erc20/write/claimTo.ts
+++ b/src/server/routes/contract/extensions/erc20/write/claimTo.ts
@@ -77,6 +77,7 @@ export async function erc20claimTo(fastify: FastifyInstance) {
       });
       const transaction = claimTo({
         contract,
+        from: fromAddress as Address,
         to: recipient,
         quantity: amount,
       });

--- a/src/server/routes/contract/extensions/erc721/write/claimTo.ts
+++ b/src/server/routes/contract/extensions/erc721/write/claimTo.ts
@@ -76,6 +76,7 @@ export async function erc721claimTo(fastify: FastifyInstance) {
       });
       const transaction = claimTo({
         contract,
+        from: fromAddress as Address,
         to: receiver,
         quantity: BigInt(quantity),
       });

--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -162,6 +162,7 @@ const _sendTransaction = async (
   } catch (e: unknown) {
     // If the transaction will revert, error.message contains the human-readable error.
     const errorMessage = (e as Error)?.message ?? `${e}`;
+    job.log(`Failed to estimate gas: ${errorMessage}`);
     return {
       ...queuedTransaction,
       status: "errored",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `claimTo` function in ERC20, ERC721, and ERC1155 contract extensions to include the `from` address parameter. It also adds error logging in `sendTransactionWorker`.

### Detailed summary
- Added `from` address parameter to `claimTo` functions in ERC20, ERC721, and ERC1155
- Added error logging in `sendTransactionWorker` for failed gas estimation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->