### PR TITLE
feat: Add retryFailedTransaction route to transaction API

### DIFF
--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -99,6 +99,7 @@ import { cancelTransaction } from "./transaction/cancel";
 import { getAllTx } from "./transaction/getAll";
 import { getAllDeployedContracts } from "./transaction/getAllDeployedContracts";
 import { retryTransaction } from "./transaction/retry";
+import { retryFailedTransaction } from "./transaction/retry-failed";
 import { checkTxStatus } from "./transaction/status";
 import { syncRetryTransaction } from "./transaction/syncRetry";
 import { createWebhook } from "./webhooks/create";
@@ -216,6 +217,7 @@ export const withRoutes = async (fastify: FastifyInstance) => {
   await fastify.register(getAllDeployedContracts);
   await fastify.register(retryTransaction);
   await fastify.register(syncRetryTransaction);
+  await fastify.register(retryFailedTransaction);
   await fastify.register(cancelTransaction);
   await fastify.register(sendSignedTransaction);
   await fastify.register(sendSignedUserOp);

--- a/src/server/routes/transaction/retry-failed.ts
+++ b/src/server/routes/transaction/retry-failed.ts
@@ -38,7 +38,7 @@ export async function retryFailedTransaction(fastify: FastifyInstance) {
     Reply: Static<typeof responseBodySchema>;
   }>({
     method: "POST",
-    url: "/transaction/retry",
+    url: "/transaction/retry-failed",
     schema: {
       summary: "Retry failed transaction",
       description: "Retry a failed transaction",

--- a/src/server/routes/transaction/retry-failed.ts
+++ b/src/server/routes/transaction/retry-failed.ts
@@ -1,0 +1,134 @@
+import { Static, Type } from "@sinclair/typebox";
+import { FastifyInstance } from "fastify";
+import { StatusCodes } from "http-status-codes";
+import { eth_getTransactionReceipt, getRpcClient } from "thirdweb";
+import { TransactionDB } from "../../../db/transactions/db";
+import { getChain } from "../../../utils/chain";
+import { thirdwebClient } from "../../../utils/sdk";
+import { QueuedTransaction } from "../../../utils/transaction/types";
+import { SendTransactionQueue } from "../../../worker/queues/sendTransactionQueue";
+import { createCustomError } from "../../middleware/error";
+import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
+
+const requestBodySchema = Type.Object({
+  queueId: Type.String({
+    description: "Transaction queue ID",
+    examples: ["9eb88b00-f04f-409b-9df7-7dcc9003bc35"],
+  }),
+});
+
+export const responseBodySchema = Type.Object({
+  result: Type.Object({
+    message: Type.String(),
+    status: Type.String(),
+  }),
+});
+
+responseBodySchema.example = {
+  result: {
+    message:
+      "Transaction queued for retry with queueId: a20ed4ce-301d-4251-a7af-86bd88f6c015",
+    status: "success",
+  },
+};
+
+export async function retryFailedTransaction(fastify: FastifyInstance) {
+  fastify.route<{
+    Body: Static<typeof requestBodySchema>;
+    Reply: Static<typeof responseBodySchema>;
+  }>({
+    method: "POST",
+    url: "/transaction/retry",
+    schema: {
+      summary: "Retry failed transaction",
+      description: "Retry a failed transaction",
+      tags: ["Transaction"],
+      operationId: "retry",
+      body: requestBodySchema,
+      response: {
+        ...standardResponseSchema,
+        [StatusCodes.OK]: responseBodySchema,
+      },
+      deprecated: true,
+      hide: true,
+    },
+    handler: async (request, reply) => {
+      const { queueId } = request.body;
+
+      const transaction = await TransactionDB.get(queueId);
+      if (!transaction) {
+        throw createCustomError(
+          "Transaction not found.",
+          StatusCodes.BAD_REQUEST,
+          "TRANSACTION_NOT_FOUND",
+        );
+      }
+      if (transaction.status !== "sent") {
+        throw createCustomError(
+          `Transaction cannot be retried because status: ${transaction.status}`,
+          StatusCodes.BAD_REQUEST,
+          "TRANSACTION_CANNOT_BE_RETRIED",
+        );
+      }
+
+      // temp do not handle userop
+      if (transaction.isUserOp) {
+        throw createCustomError(
+          `Transaction cannot be retried because it is a userop`,
+          StatusCodes.BAD_REQUEST,
+          "TRANSACTION_CANNOT_BE_RETRIED",
+        );
+      }
+
+      const rpcRequest = getRpcClient({
+        client: thirdwebClient,
+        chain: await getChain(transaction.chainId),
+      });
+
+      const receiptPromises = transaction.sentTransactionHashes.map((hash) => {
+        // if receipt is not found, it will throw an error
+        // so we catch it and return null
+        try {
+          return eth_getTransactionReceipt(rpcRequest, {
+            hash,
+          });
+        } catch {
+          return null;
+        }
+      });
+
+      const receipts = await Promise.all(receiptPromises);
+
+      // If any of the transactions are mined, we should not retry.
+      const minedReceipt = receipts.find((receipt) => !!receipt);
+
+      if (minedReceipt) {
+        throw createCustomError(
+          `Transaction cannot be retried because it has already been mined with hash: ${minedReceipt.transactionHash}`,
+          StatusCodes.BAD_REQUEST,
+          "TRANSACTION_CANNOT_BE_RETRIED",
+        );
+      }
+
+      const toQueueTransaction: QueuedTransaction = {
+        ...transaction,
+        status: "queued",
+      };
+
+      // how do we keep a record of the fact that this is manually retried?
+      await TransactionDB.set(toQueueTransaction);
+
+      await SendTransactionQueue.add({
+        queueId: toQueueTransaction.queueId,
+        resendCount: toQueueTransaction.resendCount + 1,
+      });
+
+      reply.status(StatusCodes.OK).send({
+        result: {
+          message: `Transaction queued for retry with queueId: ${queueId}`,
+          status: "success",
+        },
+      });
+    },
+  });
+}

--- a/src/utils/transaction/types.ts
+++ b/src/utils/transaction/types.ts
@@ -46,6 +46,8 @@ export type QueuedTransaction = InsertedTransaction & {
   queuedAt: Date;
   value: bigint;
   data?: Hex;
+
+  manuallyResentAt?: Date;
 };
 
 // SentTransaction has been submitted to RPC successfully.
@@ -83,7 +85,11 @@ export type MinedTransaction = (
 
 // ErroredTransaction received an error before or while sending to RPC.
 // A transaction that reverted onchain is not considered "errored".
-export type ErroredTransaction = Omit<QueuedTransaction, "status"> & {
+export type ErroredTransaction = (
+  | Omit<QueuedTransaction, "status">
+  | Omit<_SentTransactionEOA, "status">
+  | Omit<_SentTransactionUserOp, "status">
+) & {
   status: "errored";
 
   errorMessage: string;

--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -61,8 +61,17 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
   // An errored queued transaction (resendCount = 0) is safe to retry: the transaction wasn't sent to RPC.
   if (transaction.status === "errored" && resendCount === 0) {
     transaction = {
-      ...transaction,
+      ...{
+        ...transaction,
+        nonce: undefined,
+        errorMessage: undefined,
+        gas: undefined,
+        gasPrice: undefined,
+        maxFeePerGas: undefined,
+        maxPriorityFeePerGas: undefined,
+      },
       status: "queued",
+      manuallyResentAt: new Date(),
     } satisfies QueuedTransaction;
   }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance transaction retry functionality by adding a new route to retry failed transactions.

### Detailed summary
- Added a new route `retryFailedTransaction` to retry failed transactions
- Updated `ErroredTransaction` type to include new transaction types
- Modified `sendTransactionWorker` to update transaction status and add `manuallyResentAt` date
- Added necessary imports and schemas for the new route

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->