### PR TITLE
feat: add new debug endpoints to debug nonces

### DIFF
--- a/src/db/transactions/db.ts
+++ b/src/db/transactions/db.ts
@@ -158,6 +158,7 @@ export class TransactionDB {
 
   /**
    * Lists all transaction details by status.
+   * Returns results paginated in descending order.
    * @param status "queued" | "mined" | "cancelled" | "errored"
    * @param page
    * @param limit

--- a/src/db/wallets/nonceMap.ts
+++ b/src/db/wallets/nonceMap.ts
@@ -1,0 +1,68 @@
+import { Address } from "thirdweb";
+import { env } from "../../utils/env";
+import { normalizeAddress } from "../../utils/primitiveTypes";
+import { redis } from "../../utils/redis/redis";
+
+/**
+ * The "nonce map" sorted set stores the queue ID that acquired each nonce.
+ * It is pruned to the latest 10k per wallet.
+ *
+ * Example:
+ *   {
+ *     "10": "e0fa731e-a947-4587-a48a-c56c02f8e7a8"
+ *     "11": "d111435a-1c0c-4308-ba40-59bad0868ee6"
+ *   }
+ */
+const nonceMapKey = (chainId: number, walletAddress: Address) =>
+  `nonce-map:${chainId}:${normalizeAddress(walletAddress)}`;
+
+export const updateNonceMap = async (args: {
+  chainId: number;
+  walletAddress: Address;
+  nonce: number;
+  queueId: string;
+}) => {
+  const { chainId, walletAddress, nonce, queueId } = args;
+  const key = nonceMapKey(chainId, walletAddress);
+  await redis.zadd(key, nonce, queueId);
+};
+
+/**
+ * Returns (nonce, queueId) pairs sorted by ascending nonce for the
+ * given wallet between the specified range.
+ */
+export const getNonceMap = async (args: {
+  chainId: number;
+  walletAddress: Address;
+  fromNonce: number;
+  toNonce: number;
+}): Promise<{ nonce: number; queueId: string }[]> => {
+  const { chainId, walletAddress, fromNonce, toNonce } = args;
+  const key = nonceMapKey(chainId, walletAddress);
+
+  // Returns [ queueId1, nonce1, queueId2, nonce2, ... ]
+  const elementsWithScores = await redis.zrangebyscore(
+    key,
+    fromNonce,
+    toNonce,
+    "WITHSCORES",
+  );
+
+  const result: { nonce: number; queueId: string }[] = [];
+  for (let i = 0; i < elementsWithScores.length; i += 2) {
+    result.push({
+      queueId: elementsWithScores[1],
+      nonce: parseInt(elementsWithScores[2]),
+    });
+  }
+  return result;
+};
+
+export const pruneNonceMaps = async () => {
+  const pipeline = redis.pipeline();
+  const keys = await redis.keys("nonce-map:*");
+  for (const key of keys) {
+    pipeline.zremrangebyrank(key, 0, -env.NONCE_MAP_COUNT);
+  }
+  await pipeline.exec();
+};

--- a/src/db/wallets/walletNonce.ts
+++ b/src/db/wallets/walletNonce.ts
@@ -102,7 +102,7 @@ export const acquireNonce = async (args: {
     if (nonce === 1) {
       // If INCR returned 1, the nonce was not set.
       // This may be a newly imported wallet.
-      nonce = await _syncNonce(chainId, walletAddress);
+      nonce = await syncLatestNonceFromOnchain(chainId, walletAddress);
     }
   }
 
@@ -158,7 +158,8 @@ const _acquireRecycledNonce = async (
   return parseInt(result[0]);
 };
 
-const _syncNonce = async (
+// @TODO: Redis lock this to make this method safe to call concurrently.
+export const syncLatestNonceFromOnchain = async (
   chainId: number,
   walletAddress: Address,
 ): Promise<number> => {

--- a/src/server/routes/backend-wallet/getTransactionsByNonce.ts
+++ b/src/server/routes/backend-wallet/getTransactionsByNonce.ts
@@ -1,0 +1,100 @@
+import { Static, Type } from "@sinclair/typebox";
+import { FastifyInstance } from "fastify";
+import { StatusCodes } from "http-status-codes";
+import { TransactionDB } from "../../../db/transactions/db";
+import { getNonceMap } from "../../../db/wallets/nonceMap";
+import { normalizeAddress } from "../../../utils/primitiveTypes";
+import { AnyTransaction } from "../../../utils/transaction/types";
+import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
+import {
+  TransactionSchema,
+  toTransactionSchema,
+} from "../../schemas/transaction";
+import { walletWithAddressParamSchema } from "../../schemas/wallet";
+import { getChainIdFromChain } from "../../utils/chain";
+
+const requestQuerySchema = Type.Object({
+  ...walletWithAddressParamSchema.properties,
+  fromNonce: Type.Integer({
+    description: "The earliest nonce, inclusive.",
+    examples: [100],
+    minimum: 0,
+  }),
+  toNonce: Type.Integer({
+    description: "The latest nonce, inclusive.",
+    examples: [100],
+    minimum: 0,
+  }),
+});
+
+const responseBodySchema = Type.Object({
+  result: Type.Array(
+    Type.Object({
+      nonce: Type.Number(),
+      // Returns the transaction details by default.
+      // Falls back to the queueId if the transaction details have been pruned.
+      transaction: Type.Union([TransactionSchema, Type.String()]),
+    }),
+  ),
+});
+
+export async function getTransactionsByNonce(fastify: FastifyInstance) {
+  fastify.route<{
+    Params: Static<typeof requestQuerySchema>;
+    Reply: Static<typeof responseBodySchema>;
+  }>({
+    method: "GET",
+    url: "/backend-wallet/:chain/:walletAddress/get-transactions-by-nonce",
+    schema: {
+      summary: "Get recent transactions by nonce",
+      description:
+        "Get recent transactions for this backend wallet, sorted by descending nonce.",
+      tags: ["Backend Wallet"],
+      operationId: "getTransactionsByNonceForBackendWallet",
+      params: requestQuerySchema,
+      response: {
+        ...standardResponseSchema,
+        [StatusCodes.OK]: responseBodySchema,
+      },
+    },
+    handler: async (req, res) => {
+      const {
+        chain,
+        walletAddress: _walletAddress,
+        fromNonce,
+        toNonce,
+      } = req.params;
+      const chainId = await getChainIdFromChain(chain);
+      const walletAddress = normalizeAddress(_walletAddress);
+
+      // Get queueIds.
+      const nonceMap = await getNonceMap({
+        chainId,
+        walletAddress,
+        fromNonce,
+        toNonce,
+      });
+
+      // Build map of { queueId => transaction }.
+      const queueIds = nonceMap.map(({ queueId }) => queueId);
+      const transactions = await TransactionDB.bulkGet(queueIds);
+      const transactionsMap = new Map<string, AnyTransaction>();
+      for (const transaction of transactions) {
+        transactionsMap.set(transaction.queueId, transaction);
+      }
+
+      // Hydrate the transaction, if found.
+      const result = nonceMap.map(({ nonce, queueId }) => {
+        const transaction = transactionsMap.get(queueId);
+        return {
+          nonce,
+          transaction: transaction ? toTransactionSchema(transaction) : queueId,
+        };
+      });
+
+      res.status(StatusCodes.OK).send({
+        result,
+      });
+    },
+  });
+}

--- a/src/server/routes/backend-wallet/transfer.ts
+++ b/src/server/routes/backend-wallet/transfer.ts
@@ -40,9 +40,9 @@ const requestBodySchema = Type.Object({
   },
   currencyAddress: {
     ...AddressSchema,
+    examples: [constants.AddressZero],
     description:
       "The token address to transfer. Omit to transfer the chain's native currency (e.g. ETH on Ethereum).",
-    default: constants.AddressZero,
   },
   amount: Type.String({
     description:

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -14,7 +14,8 @@ import { createBackendWallet } from "./backend-wallet/create";
 import { getAll } from "./backend-wallet/getAll";
 import { getBalance } from "./backend-wallet/getBalance";
 import { getBackendWalletNonce } from "./backend-wallet/getNonce";
-import { getTransactionsByBackendWallet } from "./backend-wallet/getTransactions";
+import { getTransactionsForBackendWallet } from "./backend-wallet/getTransactions";
+import { getTransactionsForBackendWalletByNonce } from "./backend-wallet/getTransactionsByNonce";
 import { importBackendWallet } from "./backend-wallet/import";
 import { removeBackendWallet } from "./backend-wallet/remove";
 import { resetBackendWalletNonces } from "./backend-wallet/resetNonces";
@@ -96,6 +97,7 @@ import { getUserOpReceipt } from "./transaction/blockchain/getUserOpReceipt";
 import { sendSignedTransaction } from "./transaction/blockchain/sendSignedTx";
 import { sendSignedUserOp } from "./transaction/blockchain/sendSignedUserOp";
 import { cancelTransaction } from "./transaction/cancel";
+import { getAllTransactions } from "./transaction/getAll";
 import { getAllDeployedContracts } from "./transaction/getAllDeployedContracts";
 import { retryTransaction } from "./transaction/retry";
 import { retryFailedTransaction } from "./transaction/retry-failed";
@@ -121,7 +123,8 @@ export const withRoutes = async (fastify: FastifyInstance) => {
   await fastify.register(signTransaction);
   await fastify.register(signMessage);
   await fastify.register(signTypedData);
-  await fastify.register(getTransactionsByBackendWallet);
+  await fastify.register(getTransactionsForBackendWallet);
+  await fastify.register(getTransactionsForBackendWalletByNonce);
   await fastify.register(resetBackendWalletNonces);
   await fastify.register(getBackendWalletNonce);
   await fastify.register(simulateTransaction);
@@ -211,8 +214,8 @@ export const withRoutes = async (fastify: FastifyInstance) => {
   await fastify.register(prebuiltsRoutes);
 
   // Transactions
+  await fastify.register(getAllTransactions);
   await fastify.register(checkTxStatus);
-  await fastify.register(getTransactionsByBackendWallet);
   await fastify.register(getAllDeployedContracts);
   await fastify.register(retryTransaction);
   await fastify.register(syncRetryTransaction);

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -14,7 +14,7 @@ import { createBackendWallet } from "./backend-wallet/create";
 import { getAll } from "./backend-wallet/getAll";
 import { getBalance } from "./backend-wallet/getBalance";
 import { getBackendWalletNonce } from "./backend-wallet/getNonce";
-import { getAllTransactions } from "./backend-wallet/getTransactions";
+import { getTransactionsByBackendWallet } from "./backend-wallet/getTransactions";
 import { importBackendWallet } from "./backend-wallet/import";
 import { removeBackendWallet } from "./backend-wallet/remove";
 import { resetBackendWalletNonces } from "./backend-wallet/resetNonces";
@@ -96,7 +96,6 @@ import { getUserOpReceipt } from "./transaction/blockchain/getUserOpReceipt";
 import { sendSignedTransaction } from "./transaction/blockchain/sendSignedTx";
 import { sendSignedUserOp } from "./transaction/blockchain/sendSignedUserOp";
 import { cancelTransaction } from "./transaction/cancel";
-import { getAllTx } from "./transaction/getAll";
 import { getAllDeployedContracts } from "./transaction/getAllDeployedContracts";
 import { retryTransaction } from "./transaction/retry";
 import { retryFailedTransaction } from "./transaction/retry-failed";
@@ -122,7 +121,7 @@ export const withRoutes = async (fastify: FastifyInstance) => {
   await fastify.register(signTransaction);
   await fastify.register(signMessage);
   await fastify.register(signTypedData);
-  await fastify.register(getAllTransactions);
+  await fastify.register(getTransactionsByBackendWallet);
   await fastify.register(resetBackendWalletNonces);
   await fastify.register(getBackendWalletNonce);
   await fastify.register(simulateTransaction);
@@ -213,7 +212,7 @@ export const withRoutes = async (fastify: FastifyInstance) => {
 
   // Transactions
   await fastify.register(checkTxStatus);
-  await fastify.register(getAllTx);
+  await fastify.register(getTransactionsByBackendWallet);
   await fastify.register(getAllDeployedContracts);
   await fastify.register(retryTransaction);
   await fastify.register(syncRetryTransaction);

--- a/src/server/routes/transaction/getAll.ts
+++ b/src/server/routes/transaction/getAll.ts
@@ -13,6 +13,7 @@ const requestQuerySchema = Type.Object({
   ...PaginationSchema.properties,
   status: Type.Union(
     [
+      // Note: 'queued' returns all transcations, not just transactions currently queued.
       Type.Literal("queued"),
       Type.Literal("mined"),
       Type.Literal("cancelled"),
@@ -21,7 +22,6 @@ const requestQuerySchema = Type.Object({
     {
       description:
         "The status to query: 'queued', 'mined', 'errored', or 'cancelled'. Default: 'queued'",
-      // DEBUG: test this is optional
       default: "queued",
     },
   ),

--- a/src/server/routes/transaction/getAll.ts
+++ b/src/server/routes/transaction/getAll.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { TransactionDB } from "../../../db/transactions/db";
+import { PaginationSchema } from "../../schemas/pagination";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 import {
   TransactionSchema,
@@ -9,18 +10,21 @@ import {
 } from "../../schemas/transaction";
 
 const requestQuerySchema = Type.Object({
-  page: Type.Integer({
-    description: "Specify the page number for pagination.",
-    examples: [1],
-    default: 1,
-    minimum: 1,
-  }),
-  limit: Type.Integer({
-    description: "Specify the number of transactions to return per page.",
-    examples: [10],
-    default: 10,
-    minimum: 1,
-  }),
+  ...PaginationSchema.properties,
+  status: Type.Union(
+    [
+      Type.Literal("queued"),
+      Type.Literal("mined"),
+      Type.Literal("cancelled"),
+      Type.Literal("errored"),
+    ],
+    {
+      description:
+        "The status to query: 'queued', 'mined', 'errored', or 'cancelled'. Default: 'queued'",
+      // DEBUG: test this is optional
+      default: "queued",
+    },
+  ),
 });
 
 export const responseBodySchema = Type.Object({
@@ -82,7 +86,7 @@ responseBodySchema.example = {
   },
 };
 
-export async function getAllTx(fastify: FastifyInstance) {
+export async function getAllTransactions(fastify: FastifyInstance) {
   fastify.route<{
     Querystring: Static<typeof requestQuerySchema>;
     Reply: Static<typeof responseBodySchema>;
@@ -101,11 +105,11 @@ export async function getAllTx(fastify: FastifyInstance) {
       },
     },
     handler: async (request, reply) => {
-      const { page, limit } = request.query;
+      const { status, page, limit } = request.query;
 
       const { transactions, totalCount } =
         await TransactionDB.getTransactionListByStatus({
-          status: "queued",
+          status,
           page,
           limit,
         });

--- a/src/server/schemas/pagination.ts
+++ b/src/server/schemas/pagination.ts
@@ -1,0 +1,15 @@
+import { Type } from "@sinclair/typebox";
+
+export const PaginationSchema = Type.Object({
+  page: Type.Integer({
+    description: "Specify the page number.",
+    examples: [1],
+    default: 1,
+    minimum: 1,
+  }),
+  limit: Type.Integer({
+    description: "Specify the number of results to return per page.",
+    examples: [100],
+    default: 100,
+  }),
+});

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -61,12 +61,6 @@ export const env = createEnv({
     ENABLE_HTTPS: boolSchema("false"),
     HTTPS_PASSPHRASE: z.string().default("thirdweb-engine"),
     TRUST_PROXY: z.boolean().default(false),
-    // Sets the max amount of memory Redis can use.
-    // "0" means use all available memory.
-    REDIS_MAXMEMORY: z.string().default("0"),
-    // Sets the number of recent transactions to store. Older transactions are pruned periodically.
-    // In testing, 100k transactions consumes ~300mb memory.
-    TRANSACTION_HISTORY_COUNT: z.coerce.number().default(100_000),
     CLIENT_ANALYTICS_URL: z
       .union([UrlSchema, z.literal("")])
       .default("https://c.thirdweb.com/event"),
@@ -85,6 +79,23 @@ export const env = createEnv({
       .default("default"),
     GLOBAL_RATE_LIMIT_PER_MIN: z.coerce.number().default(400 * 60),
     DD_TRACER_ACTIVATED: z.coerce.boolean().default(false),
+
+    /**
+     * Limits
+     */
+    // Sets the max amount of memory Redis can use.
+    // "0" means use all available memory.
+    REDIS_MAXMEMORY: z.string().default("0"),
+    // Sets the number of recent transactions to store. Older transactions are pruned periodically.
+    // In testing, 100k transactions consumes ~300mb memory.
+    TRANSACTION_HISTORY_COUNT: z.coerce.number().default(100_000),
+    // Sets the number of recent completed jobs in each queue.
+    QUEUE_COMPLETE_HISTORY_COUNT: z.coerce.number().default(10_000),
+    // Sets the number of recent failed jobs in each queue.
+    // These limits are higher to debug failed jobs.
+    QUEUE_FAIL_HISTORY_COUNT: z.coerce.number().default(25_000),
+    // Sets the number of recent nonces to map to queue IDs.
+    NONCE_MAP_COUNT: z.coerce.number().default(10_000),
   },
   clientPrefix: "NEVER_USED",
   client: {},
@@ -102,8 +113,6 @@ export const env = createEnv({
     ENABLE_HTTPS: process.env.ENABLE_HTTPS,
     HTTPS_PASSPHRASE: process.env.HTTPS_PASSPHRASE,
     TRUST_PROXY: process.env.TRUST_PROXY,
-    REDIS_MAXMEMORY: process.env.REDIS_MAXMEMORY,
-    TRANSACTION_HISTORY_COUNT: process.env.TRANSACTION_HISTORY_COUNT,
     CLIENT_ANALYTICS_URL: process.env.CLIENT_ANALYTICS_URL,
     SDK_BATCH_TIME_LIMIT: process.env.SDK_BATCH_TIME_LIMIT,
     SDK_BATCH_SIZE_LIMIT: process.env.SDK_BATCH_SIZE_LIMIT,
@@ -116,8 +125,13 @@ export const env = createEnv({
     CONFIRM_TRANSACTION_QUEUE_CONCURRENCY:
       process.env.CONFIRM_TRANSACTION_QUEUE_CONCURRENCY,
     ENGINE_MODE: process.env.ENGINE_MODE,
+    REDIS_MAXMEMORY: process.env.REDIS_MAXMEMORY,
+    TRANSACTION_HISTORY_COUNT: process.env.TRANSACTION_HISTORY_COUNT,
     GLOBAL_RATE_LIMIT_PER_MIN: process.env.GLOBAL_RATE_LIMIT_PER_MIN,
     DD_TRACER_ACTIVATED: process.env.DD_TRACER_ACTIVATED,
+    QUEUE_COMPLETE_HISTORY_COUNT: process.env.QUEUE_COMPLETE_HISTORY_COUNT,
+    QUEUE_FAIL_HISTORY_COUNT: process.env.QUEUE_FAIL_HISTORY_COUNT,
+    NONCE_MAP_COUNT: process.env.NONCE_MAP_COUNT,
   },
   onValidationError: (error: ZodError) => {
     console.error(

--- a/src/worker/queues/queues.ts
+++ b/src/worker/queues/queues.ts
@@ -5,16 +5,13 @@ import { logger } from "../../utils/logger";
 export const defaultJobOptions: JobsOptions = {
   // Does not retry by default. Queues must explicitly define their own retry count and backoff behavior.
   attempts: 0,
-  // Purges successful jobs.
   removeOnComplete: {
     age: 7 * 24 * 60 * 60,
-    count: 10_000,
+    count: env.QUEUE_COMPLETE_HISTORY_COUNT,
   },
-  // Purge failed jobs.
-  // These limits are higher to debug or retry failed jobs.
   removeOnFail: {
     age: 7 * 24 * 60 * 60,
-    count: 25_000,
+    count: env.QUEUE_FAIL_HISTORY_COUNT,
   },
 };
 

--- a/src/worker/tasks/pruneTransactionsWorker.ts
+++ b/src/worker/tasks/pruneTransactionsWorker.ts
@@ -7,12 +7,14 @@ import { PruneTransactionsQueue } from "../queues/pruneTransactionsQueue";
 import { logWorkerExceptions } from "../queues/queues";
 
 const handler: Processor<any, void, string> = async (job: Job<string>) => {
-  const numPruned = await TransactionDB.pruneTransactionDetailsAndLists(
-    env.TRANSACTION_HISTORY_COUNT,
-  );
-  job.log(`Pruned ${numPruned} transaction details.`);
+  const numTransactionsDeleted =
+    await TransactionDB.pruneTransactionDetailsAndLists(
+      env.TRANSACTION_HISTORY_COUNT,
+    );
+  job.log(`Pruned ${numTransactionsDeleted} transaction details.`);
 
-  await pruneNonceMaps();
+  const numNonceMapsDeleted = await pruneNonceMaps();
+  job.log(`Pruned ${numNonceMapsDeleted} nonce maps.`);
 };
 
 // Must be explicitly called for the worker to run on this host.

--- a/src/worker/tasks/pruneTransactionsWorker.ts
+++ b/src/worker/tasks/pruneTransactionsWorker.ts
@@ -1,5 +1,6 @@
 import { Job, Processor, Worker } from "bullmq";
 import { TransactionDB } from "../../db/transactions/db";
+import { pruneNonceMaps } from "../../db/wallets/nonceMap";
 import { env } from "../../utils/env";
 import { redis } from "../../utils/redis/redis";
 import { PruneTransactionsQueue } from "../queues/pruneTransactionsQueue";
@@ -10,6 +11,8 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
     env.TRANSACTION_HISTORY_COUNT,
   );
   job.log(`Pruned ${numPruned} transaction details.`);
+
+  await pruneNonceMaps();
 };
 
 // Must be explicitly called for the worker to run on this host.

--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -181,7 +181,11 @@ const _sendTransaction = async (
   }
 
   // Acquire an unused nonce for this transaction.
-  const { nonce, isRecycledNonce } = await acquireNonce(chainId, from);
+  const { nonce, isRecycledNonce } = await acquireNonce({
+    queueId,
+    chainId,
+    from,
+  });
   job.log(
     `Acquired nonce ${nonce} for transaction ${queuedTransaction.queueId}. isRecycledNonce=${isRecycledNonce}`,
   );

--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -149,7 +149,7 @@ const _sendTransaction = async (
 ): Promise<SentTransaction | ErroredTransaction> => {
   assert(!queuedTransaction.isUserOp);
 
-  const { chainId, from } = queuedTransaction;
+  const { queueId, chainId, from } = queuedTransaction;
   const chain = await getChain(chainId);
 
   // Populate the transaction to resolve gas values.
@@ -184,14 +184,14 @@ const _sendTransaction = async (
   const { nonce, isRecycledNonce } = await acquireNonce({
     queueId,
     chainId,
-    from,
+    walletAddress: from,
   });
   job.log(
-    `Acquired nonce ${nonce} for transaction ${queuedTransaction.queueId}. isRecycledNonce=${isRecycledNonce}`,
+    `Acquired nonce ${nonce} for transaction ${queueId}. isRecycledNonce=${isRecycledNonce}`,
   );
   logger({
     level: "info",
-    message: `Acquired nonce ${nonce} for transaction ${queuedTransaction.queueId}. isRecycledNonce=${isRecycledNonce}`,
+    message: `Acquired nonce ${nonce} for transaction ${queueId}. isRecycledNonce=${isRecycledNonce}`,
     service: "worker",
   });
 

--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -10,7 +10,7 @@ import {
   acquireNonce,
   addSentNonce,
   recycleNonce,
-  resyncNonce,
+  syncLatestNonceFromOnchainIfHigher,
 } from "../../db/wallets/walletNonce";
 import { getAccount } from "../../utils/account";
 import { getBlockNumberish } from "../../utils/block";
@@ -212,7 +212,7 @@ const _sendTransaction = async (
     // If the nonce is already seen onchain (nonce too low) or in mempool (replacement underpriced),
     // correct the DB nonce.
     if (isNonceAlreadyUsedError(error) || isReplacementGasFeeTooLow(error)) {
-      const result = await resyncNonce(chainId, from);
+      const result = await syncLatestNonceFromOnchainIfHigher(chainId, from);
       job.log(`Resynced nonce to ${result}.`);
     } else {
       // Otherwise this nonce is not used yet. Recycle it to be used by a future transaction.


### PR DESCRIPTION
No breaking changes.

Changes:
- Update transaction getters to optionally allow filtering by status
- Track a map of `nonce => queueId` for each wallet
- Add an endpoint to query transactions by nonce range
- `reset-nonce` endpoint now syncs nonces after deleting them


---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing transaction handling and pagination, updating nonce map functionality, and refining wallet operations.

### Detailed summary
- Improved transaction handling with pagination and status filtering
- Updated nonce map functionality for better tracking and pruning
- Refined wallet operations for backend wallets

> The following files were skipped due to too many changes: `src/db/wallets/nonceMap.ts`, `src/utils/env.ts`, `src/server/routes/backend-wallet/getTransactions.ts`, `src/server/routes/backend-wallet/getTransactionsByNonce.ts`, `src/db/wallets/walletNonce.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->