### PR TITLE
chore: Call defineChain to ensure chain registration in CUSTOM_CHAIN_MAP

### DIFF
--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -11,7 +11,9 @@ export const getChain = async (chainId: number): Promise<Chain> => {
 
   for (const override of config.chainOverridesParsed) {
     if (chainId === override.id) {
-      return override;
+      // we need to call defineChain to ensure that the chain is registered in CUSTOM_CHAIN_MAP
+      // even if we have a Chain type, we need to call defineChain to ensure that the chain is registered
+      return defineChain(override);
     }
   }
 


### PR DESCRIPTION
This commit modifies the `getChain` function in the `chain.ts` file to call the `defineChain` function when a matching chain override is found. This ensures that the chain is registered in the `CUSTOM_CHAIN_MAP` even if a `Chain` type is already available.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `chain.ts` to ensure that the chain is registered in `CUSTOM_CHAIN_MAP` by calling `defineChain` for the specified `chainId`.

### Detailed summary
- Calls `defineChain(override)` to register the chain in `CUSTOM_CHAIN_MAP` for the specified `chainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->