### PR TITLE
support `errorMessage` field for mined but reverted userops

### DIFF
--- a/src/utils/transaction/types.ts
+++ b/src/utils/transaction/types.ts
@@ -81,6 +81,9 @@ export type MinedTransaction = (
   gasUsed: bigint;
   effectiveGasPrice?: bigint;
   cumulativeGasUsed?: bigint;
+
+  // mined transactions can have an error message if they revert
+  errorMessage?: string;
 };
 
 // ErroredTransaction received an error before or while sending to RPC.


### PR DESCRIPTION
This commit adds support for handling error messages in mined transactions. The `MinedTransaction` type in `types.ts` now includes an optional `errorMessage` field. In the `mineTransactionWorker.ts` file, the code has been updated to retrieve and store the error message if the `userOpReceipt` is not successful. This allows for better error handling and reporting for mined transactions.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality to capture error messages for mined transactions and updates `mineUserOp` function to handle user operation receipts.

### Detailed summary
- Added `errorMessage` field to transaction types
- Updated `mineTransactionWorker.ts` to handle error messages for user operation receipts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->