### PR TITLE
fix workflow ref

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: "main"
+          ref: ${{ github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the workflow file `.github/workflows/npmPublish.yml` to dynamically set the Git reference in the checkout step.

### Detailed summary
- Dynamically set the Git reference in the checkout step using `${{ github.ref }}` instead of hardcoding it.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->