### PR TITLE
add `x-account-factory-address` header to contract-write and send-transaction

### DIFF
--- a/src/db/transactions/queueTx.ts
+++ b/src/db/transactions/queueTx.ts
@@ -6,6 +6,7 @@ import { maybeBigInt, normalizeAddress } from "../../utils/primitiveTypes";
 import { insertTransaction } from "../../utils/transaction/insertTransaction";
 
 interface QueueTxParams {
+  // we should move away from Transaction type (v4 SDK)
   tx: Transaction<any> | DeployTransaction;
   chainId: number;
   extension: ContractExtension;
@@ -14,6 +15,7 @@ interface QueueTxParams {
   deployedContractType?: string;
   simulateTx?: boolean;
   idempotencyKey?: string;
+  accountFactoryAddress?: Address;
   txOverrides?: {
     gas?: string;
     maxFeePerGas?: string;
@@ -31,6 +33,7 @@ export const queueTx = async ({
   simulateTx,
   idempotencyKey,
   txOverrides,
+  accountFactoryAddress,
 }: QueueTxParams) => {
   // Transaction Details
   const functionName = tx.getMethod();
@@ -68,6 +71,7 @@ export const queueTx = async ({
         signerAddress,
         accountAddress: normalizeAddress(await tx.getSignerAddress()),
         target: normalizeAddress(tx.getTarget()),
+        accountFactoryAddress,
       },
       idempotencyKey,
       shouldSimulate: simulateTx,

--- a/src/server/middleware/error.ts
+++ b/src/server/middleware/error.ts
@@ -30,6 +30,14 @@ export const createCustomDateTimestampError = (key: string): CustomError => {
   );
 };
 
+export const createBadAddressError = (key: string): CustomError => {
+  return createCustomError(
+    `Invalid ${key} Value. Needs to be a valid EVM address`,
+    422,
+    "INVALID_ADDRESS",
+  );
+};
+
 const flipObject = (data: any) =>
   Object.fromEntries(Object.entries(data).map(([key, value]) => [value, key]));
 

--- a/src/server/routes/backend-wallet/sendTransaction.ts
+++ b/src/server/routes/backend-wallet/sendTransaction.ts
@@ -11,6 +11,7 @@ import {
 } from "../../schemas/sharedApiSchemas";
 import { txOverridesSchema } from "../../schemas/txOverrides";
 import {
+  maybeAddress,
   walletChainParamSchema,
   walletWithAAHeaderSchema,
 } from "../../schemas/wallet";
@@ -73,6 +74,7 @@ export async function sendTransaction(fastify: FastifyInstance) {
         "x-backend-wallet-address": fromAddress,
         "x-idempotency-key": idempotencyKey,
         "x-account-address": accountAddress,
+        "x-account-factory-address": accountFactoryAddress,
       } = request.headers as Static<typeof walletWithAAHeaderSchema>;
 
       const chainId = await getChainIdFromChain(chain);
@@ -90,7 +92,7 @@ export async function sendTransaction(fastify: FastifyInstance) {
             accountAddress: accountAddress as Address,
             signerAddress: fromAddress as Address,
             target: toAddress as Address | undefined,
-
+            accountFactoryAddress: maybeAddress(accountFactoryAddress),
             gas: maybeBigInt(txOverrides?.gas),
             maxFeePerGas: maybeBigInt(txOverrides?.maxFeePerGas),
             maxPriorityFeePerGas: maybeBigInt(

--- a/src/server/routes/backend-wallet/sendTransaction.ts
+++ b/src/server/routes/backend-wallet/sendTransaction.ts
@@ -92,7 +92,10 @@ export async function sendTransaction(fastify: FastifyInstance) {
             accountAddress: accountAddress as Address,
             signerAddress: fromAddress as Address,
             target: toAddress as Address | undefined,
-            accountFactoryAddress: maybeAddress(accountFactoryAddress),
+            accountFactoryAddress: maybeAddress(
+              accountFactoryAddress,
+              "x-account-factory-address",
+            ),
             gas: maybeBigInt(txOverrides?.gas),
             maxFeePerGas: maybeBigInt(txOverrides?.maxFeePerGas),
             maxPriorityFeePerGas: maybeBigInt(

--- a/src/server/routes/contract/write/write.ts
+++ b/src/server/routes/contract/write/write.ts
@@ -95,9 +95,10 @@ export async function writeToContract(fastify: FastifyInstance) {
         extension: "none",
         idempotencyKey,
         txOverrides,
-        accountFactoryAddress: accountFactoryAddress
-          ? maybeAddress(accountFactoryAddress)
-          : undefined,
+        accountFactoryAddress: maybeAddress(
+          accountFactoryAddress,
+          "x-account-factory-address",
+        ),
       });
 
       reply.status(StatusCodes.OK).send({

--- a/src/server/routes/contract/write/write.ts
+++ b/src/server/routes/contract/write/write.ts
@@ -11,7 +11,10 @@ import {
   transactionWritesResponseSchema,
 } from "../../../schemas/sharedApiSchemas";
 import { txOverridesWithValueSchema } from "../../../schemas/txOverrides";
-import { walletWithAAHeaderSchema } from "../../../schemas/wallet";
+import {
+  maybeAddress,
+  walletWithAAHeaderSchema,
+} from "../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../utils/chain";
 
 // INPUT
@@ -66,6 +69,7 @@ export async function writeToContract(fastify: FastifyInstance) {
         "x-backend-wallet-address": walletAddress,
         "x-account-address": accountAddress,
         "x-idempotency-key": idempotencyKey,
+        "x-account-factory-address": accountFactoryAddress,
       } = request.headers as Static<typeof walletWithAAHeaderSchema>;
 
       const chainId = await getChainIdFromChain(chain);
@@ -76,6 +80,7 @@ export async function writeToContract(fastify: FastifyInstance) {
         accountAddress,
         abi,
       });
+
       const tx = contract.prepare(functionName, args, {
         value: txOverrides?.value,
         gasLimit: txOverrides?.gas,
@@ -90,6 +95,9 @@ export async function writeToContract(fastify: FastifyInstance) {
         extension: "none",
         idempotencyKey,
         txOverrides,
+        accountFactoryAddress: accountFactoryAddress
+          ? maybeAddress(accountFactoryAddress)
+          : undefined,
       });
 
       reply.status(StatusCodes.OK).send({

--- a/src/server/schemas/wallet/index.ts
+++ b/src/server/schemas/wallet/index.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { getAddress } from "thirdweb";
 import { env } from "../../../utils/env";
 import { AddressSchema } from "../address";
 
@@ -20,7 +21,24 @@ export const walletWithAAHeaderSchema = Type.Object({
     ...AddressSchema,
     description: "Smart account address",
   }),
+  "x-account-factory-address": Type.Optional({
+    ...AddressSchema,
+    description: "Smart account factory address",
+  }),
 });
+
+/*
+ * Helper function to parse an address string.
+ * Returns undefined if the address is invalid.
+ */
+export function maybeAddress(address: string | undefined) {
+  if (!address) return undefined;
+  try {
+    return getAddress(address);
+  } catch {
+    return undefined;
+  }
+}
 
 export const walletChainParamSchema = Type.Object({
   chain: Type.String({

--- a/src/server/schemas/wallet/index.ts
+++ b/src/server/schemas/wallet/index.ts
@@ -24,7 +24,8 @@ export const walletWithAAHeaderSchema = Type.Object({
   }),
   "x-account-factory-address": Type.Optional({
     ...AddressSchema,
-    description: "Smart account factory address",
+    description:
+      "Smart account factory address. If omitted, engine will try to resolve it from the chain.",
   }),
 });
 

--- a/src/server/schemas/wallet/index.ts
+++ b/src/server/schemas/wallet/index.ts
@@ -1,6 +1,7 @@
 import { Type } from "@sinclair/typebox";
-import { getAddress } from "thirdweb";
+import { Address, getAddress } from "thirdweb";
 import { env } from "../../../utils/env";
+import { createBadAddressError } from "../../middleware/error";
 import { AddressSchema } from "../address";
 
 export const walletHeaderSchema = Type.Object({
@@ -27,16 +28,21 @@ export const walletWithAAHeaderSchema = Type.Object({
   }),
 });
 
-/*
+/**
  * Helper function to parse an address string.
- * Returns undefined if the address is invalid.
+ * Returns undefined if the address is undefined.
+ *
+ * Throws a custom 422 INVALID_ADDRESS error with variableName if the address is invalid (other than undefined).
  */
-export function maybeAddress(address: string | undefined) {
+export function maybeAddress(
+  address: string | undefined,
+  variableName: string,
+): Address | undefined {
   if (!address) return undefined;
   try {
     return getAddress(address);
   } catch {
-    return undefined;
+    throw createBadAddressError(variableName);
   }
 }
 

--- a/src/utils/transaction/types.ts
+++ b/src/utils/transaction/types.ts
@@ -33,6 +33,7 @@ export type InsertedTransaction = {
   // User Operation
   signerAddress?: Address;
   accountAddress?: Address;
+  accountFactoryAddress?: Address;
   target?: Address;
   sender?: Address;
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add support for an `accountFactoryAddress` parameter in transactions and user operations.

### Detailed summary
- Added `accountFactoryAddress` property to transaction and user operation types
- Implemented `createBadAddressError` function for invalid address errors
- Updated transaction queueing and contract writing to handle `accountFactoryAddress`
- Added `maybeAddress` helper function to parse and validate addresses

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->