### PR TITLE
Added prometheus metrics for response, queued, sent, mined, nonces

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "node-cron": "^3.0.2",
     "pg": "^8.11.3",
     "prisma": "^5.14.0",
+    "prom-client": "^15.1.3",
     "superjson": "^2.2.1",
     "thirdweb": "^5.45.1",
     "uuid": "^9.0.1",

--- a/src/db/transactions/queueTx.ts
+++ b/src/db/transactions/queueTx.ts
@@ -3,7 +3,6 @@ import { ERC4337EthersSigner } from "@thirdweb-dev/wallets/dist/declarations/src
 import { Address, ZERO_ADDRESS } from "thirdweb";
 import type { ContractExtension } from "../../schema/extension";
 import { maybeBigInt, normalizeAddress } from "../../utils/primitiveTypes";
-import { recordMetrics } from "../../utils/prometheus";
 import { insertTransaction } from "../../utils/transaction/insertTransaction";
 
 interface QueueTxParams {
@@ -92,14 +91,6 @@ export const queueTx = async ({
       },
       idempotencyKey,
       shouldSimulate: simulateTx,
-    });
-
-    recordMetrics({
-      event: "transaction_queued",
-      params: {
-        chainId,
-        extension,
-      },
     });
 
     return queueId;

--- a/src/db/transactions/queueTx.ts
+++ b/src/db/transactions/queueTx.ts
@@ -3,6 +3,7 @@ import { ERC4337EthersSigner } from "@thirdweb-dev/wallets/dist/declarations/src
 import { Address, ZERO_ADDRESS } from "thirdweb";
 import type { ContractExtension } from "../../schema/extension";
 import { maybeBigInt, normalizeAddress } from "../../utils/primitiveTypes";
+import { recordMetrics } from "../../utils/prometheus";
 import { insertTransaction } from "../../utils/transaction/insertTransaction";
 
 interface QueueTxParams {
@@ -91,6 +92,14 @@ export const queueTx = async ({
       },
       idempotencyKey,
       shouldSimulate: simulateTx,
+    });
+
+    recordMetrics({
+      event: "transaction_queued",
+      params: {
+        chainId,
+        extension,
+      },
     });
 
     return queueId;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -16,6 +16,7 @@ import { withErrorHandler } from "./middleware/error";
 import { withExpress } from "./middleware/express";
 import { withRequestLogs } from "./middleware/logs";
 import { withOpenApi } from "./middleware/open-api";
+import { withPrometheus } from "./middleware/prometheus";
 import { withRateLimit } from "./middleware/rateLimit";
 import { withWebSocket } from "./middleware/websocket";
 import { withRoutes } from "./routes";
@@ -62,6 +63,7 @@ export const initServer = async () => {
 
   await withCors(server);
   await withRequestLogs(server);
+  await withPrometheus(server);
   await withErrorHandler(server);
   await withEnforceEngineMode(server);
   await withRateLimit(server);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import { URL } from "url";
 import { clearCacheCron } from "../utils/cron/clearCacheCron";
 import { env } from "../utils/env";
 import { logger } from "../utils/logger";
+import { metricsServer } from "../utils/prometheus";
 import { withServerUsageReporting } from "../utils/usage";
 import { updateTxListener } from "./listeners/updateTxListener";
 import { withAdminRoutes } from "./middleware/adminRoutes";
@@ -76,6 +77,15 @@ export const initServer = async () => {
   await withAdminRoutes(server);
 
   await server.ready();
+
+  // if metrics are enabled, expose the metrics endpoint
+  if (env.METRICS_ENABLED) {
+    await metricsServer.ready();
+    metricsServer.listen({
+      host: env.HOST,
+      port: env.METRICS_PORT,
+    });
+  }
 
   server.listen(
     {

--- a/src/server/middleware/prometheus.ts
+++ b/src/server/middleware/prometheus.ts
@@ -1,0 +1,23 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { recordMetrics } from "../../utils/prometheus";
+
+export const withPrometheus = async (server: FastifyInstance) => {
+  server.addHook(
+    "onResponse",
+    async (req: FastifyRequest, res: FastifyReply) => {
+      const { method, url, ip, routeOptions } = req;
+      const { statusCode } = res;
+      const duration = res.elapsedTime; // Use Fastify's built-in timing
+
+      // Record metrics
+      recordMetrics({
+        event: "response_sent",
+        params: {
+          endpoint: new URL(url).pathname,
+          statusCode,
+          duration: duration / 1000, // Convert to seconds for Prometheus
+        },
+      });
+    },
+  );
+};

--- a/src/server/middleware/prometheus.ts
+++ b/src/server/middleware/prometheus.ts
@@ -4,11 +4,9 @@ import { recordMetrics } from "../../utils/prometheus";
 
 export const withPrometheus = async (server: FastifyInstance) => {
   if (!env.METRICS_ENABLED) {
-    console.log("Metrics are disabled");
     return;
   }
 
-  console.log("Metrics are enabled");
   server.addHook(
     "onResponse",
     (req: FastifyRequest, res: FastifyReply, done) => {

--- a/src/server/middleware/prometheus.ts
+++ b/src/server/middleware/prometheus.ts
@@ -1,6 +1,5 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import { register } from "prom-client";
-import { recordMetrics } from "../../utils/prometheus";
+import { enginePromRegister, recordMetrics } from "../../utils/prometheus";
 
 export const withPrometheus = async (server: FastifyInstance) => {
   server.addHook(
@@ -25,7 +24,7 @@ export const withPrometheus = async (server: FastifyInstance) => {
 
   // Expose metrics endpoint
   server.get("/metrics", async (request, reply) => {
-    reply.header("Content-Type", register.contentType);
-    return register.metrics();
+    reply.header("Content-Type", enginePromRegister.contentType);
+    return enginePromRegister.metrics();
   });
 };

--- a/src/server/middleware/prometheus.ts
+++ b/src/server/middleware/prometheus.ts
@@ -1,10 +1,6 @@
-import fastify, {
-  FastifyInstance,
-  FastifyReply,
-  FastifyRequest,
-} from "fastify";
+import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { env } from "../../utils/env";
-import { enginePromRegister, recordMetrics } from "../../utils/prometheus";
+import { recordMetrics } from "../../utils/prometheus";
 
 export const withPrometheus = async (server: FastifyInstance) => {
   if (!env.METRICS_ENABLED) {
@@ -35,20 +31,4 @@ export const withPrometheus = async (server: FastifyInstance) => {
       done();
     },
   );
-  // Expose metrics endpoint
-
-  const metricsServer = fastify({
-    disableRequestLogging: true,
-  });
-
-  metricsServer.get("/metrics", async (request, reply) => {
-    reply.header("Content-Type", enginePromRegister.contentType);
-    return enginePromRegister.metrics();
-  });
-
-  await metricsServer.ready();
-  metricsServer.listen({
-    host: env.METRICS_HOST ?? env.HOST,
-    port: env.METRICS_PORT,
-  });
 };

--- a/src/server/middleware/prometheus.ts
+++ b/src/server/middleware/prometheus.ts
@@ -1,11 +1,12 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { register } from "prom-client";
 import { recordMetrics } from "../../utils/prometheus";
 
 export const withPrometheus = async (server: FastifyInstance) => {
   server.addHook(
     "onResponse",
     async (req: FastifyRequest, res: FastifyReply) => {
-      const { method, url, ip, routeOptions } = req;
+      const { method, url } = req;
       const { statusCode } = res;
       const duration = res.elapsedTime; // Use Fastify's built-in timing
 
@@ -14,10 +15,17 @@ export const withPrometheus = async (server: FastifyInstance) => {
         event: "response_sent",
         params: {
           endpoint: new URL(url).pathname,
-          statusCode,
-          duration: duration / 1000, // Convert to seconds for Prometheus
+          statusCode: statusCode.toString(),
+          duration: duration,
+          method: method,
         },
       });
     },
   );
+
+  // Expose metrics endpoint
+  server.get("/metrics", async (request, reply) => {
+    reply.header("Content-Type", register.contentType);
+    return register.metrics();
+  });
 };

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -81,7 +81,6 @@ export const env = createEnv({
     DD_TRACER_ACTIVATED: z.coerce.boolean().default(false),
 
     // Prometheus
-    METRICS_HOST: z.string().optional(),
     METRICS_PORT: z.coerce.number().default(4001),
     METRICS_ENABLED: boolSchema("false"),
 
@@ -137,7 +136,6 @@ export const env = createEnv({
     QUEUE_COMPLETE_HISTORY_COUNT: process.env.QUEUE_COMPLETE_HISTORY_COUNT,
     QUEUE_FAIL_HISTORY_COUNT: process.env.QUEUE_FAIL_HISTORY_COUNT,
     NONCE_MAP_COUNT: process.env.NONCE_MAP_COUNT,
-    METRICS_HOST: process.env.METRICS_HOST,
     METRICS_PORT: process.env.METRICS_PORT,
     METRICS_ENABLED: process.env.METRICS_ENABLED,
   },

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -79,6 +79,7 @@ export const env = createEnv({
       .default("default"),
     GLOBAL_RATE_LIMIT_PER_MIN: z.coerce.number().default(400 * 60),
     DD_TRACER_ACTIVATED: z.coerce.boolean().default(false),
+    PROMETHEUS_PUSHGATEWAY_URL: z.string().url().optional(),
 
     /**
      * Limits
@@ -132,6 +133,7 @@ export const env = createEnv({
     QUEUE_COMPLETE_HISTORY_COUNT: process.env.QUEUE_COMPLETE_HISTORY_COUNT,
     QUEUE_FAIL_HISTORY_COUNT: process.env.QUEUE_FAIL_HISTORY_COUNT,
     NONCE_MAP_COUNT: process.env.NONCE_MAP_COUNT,
+    PROMETHEUS_PUSHGATEWAY_URL: process.env.PROMETHEUS_PUSHGATEWAY_URL,
   },
   onValidationError: (error: ZodError) => {
     console.error(

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -79,7 +79,6 @@ export const env = createEnv({
       .default("default"),
     GLOBAL_RATE_LIMIT_PER_MIN: z.coerce.number().default(400 * 60),
     DD_TRACER_ACTIVATED: z.coerce.boolean().default(false),
-    PROMETHEUS_PUSHGATEWAY_URL: z.string().url().optional(),
 
     /**
      * Limits
@@ -133,7 +132,6 @@ export const env = createEnv({
     QUEUE_COMPLETE_HISTORY_COUNT: process.env.QUEUE_COMPLETE_HISTORY_COUNT,
     QUEUE_FAIL_HISTORY_COUNT: process.env.QUEUE_FAIL_HISTORY_COUNT,
     NONCE_MAP_COUNT: process.env.NONCE_MAP_COUNT,
-    PROMETHEUS_PUSHGATEWAY_URL: process.env.PROMETHEUS_PUSHGATEWAY_URL,
   },
   onValidationError: (error: ZodError) => {
     console.error(

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -80,6 +80,11 @@ export const env = createEnv({
     GLOBAL_RATE_LIMIT_PER_MIN: z.coerce.number().default(400 * 60),
     DD_TRACER_ACTIVATED: z.coerce.boolean().default(false),
 
+    // Prometheus
+    METRICS_HOST: z.string().optional(),
+    METRICS_PORT: z.coerce.number().default(4001),
+    METRICS_ENABLED: boolSchema("false"),
+
     /**
      * Limits
      */
@@ -132,6 +137,9 @@ export const env = createEnv({
     QUEUE_COMPLETE_HISTORY_COUNT: process.env.QUEUE_COMPLETE_HISTORY_COUNT,
     QUEUE_FAIL_HISTORY_COUNT: process.env.QUEUE_FAIL_HISTORY_COUNT,
     NONCE_MAP_COUNT: process.env.NONCE_MAP_COUNT,
+    METRICS_HOST: process.env.METRICS_HOST,
+    METRICS_PORT: process.env.METRICS_PORT,
+    METRICS_ENABLED: process.env.METRICS_ENABLED,
   },
   onValidationError: (error: ZodError) => {
     console.error(

--- a/src/utils/prometheus.ts
+++ b/src/utils/prometheus.ts
@@ -3,7 +3,7 @@ import { getUsedBackendWallets, inspectNonce } from "../db/wallets/walletNonce";
 import { getLastUsedOnchainNonce } from "../server/routes/admin/nonces";
 
 const nonceMetrics = new Gauge({
-  name: "engine_largest_sent_nonce",
+  name: "engine_nonces",
   help: "Current nonce values and health for backend wallets",
   labelNames: ["wallet", "chain", "type"],
   async collect() {

--- a/src/utils/prometheus.ts
+++ b/src/utils/prometheus.ts
@@ -5,7 +5,7 @@ import { getLastUsedOnchainNonce } from "../server/routes/admin/nonces";
 const nonceMetrics = new Gauge({
   name: "engine_nonces",
   help: "Current nonce values and health for backend wallets",
-  labelNames: ["wallet", "chain", "type"],
+  labelNames: ["wallet_address", "chain_id", "nonce_type"],
   async collect() {
     const allWallets = await getUsedBackendWallets();
 
@@ -17,17 +17,17 @@ const nonceMetrics = new Gauge({
 
       this.set(
         {
-          wallet: walletAddress,
-          chain: chainId.toString(),
-          type: "onchain",
+          wallet_address: walletAddress,
+          chain_id: chainId.toString(),
+          nonce_type: "onchain",
         },
         onchainNonce,
       );
       this.set(
         {
-          wallet: walletAddress,
-          chain: chainId.toString(),
-          type: "engine",
+          wallet_address: walletAddress,
+          chain_id: chainId.toString(),
+          nonce_type: "engine",
         },
         engineNonce,
       );

--- a/src/utils/prometheus.ts
+++ b/src/utils/prometheus.ts
@@ -80,7 +80,7 @@ const requestsTotal = new Counter({
 const requestDuration = new Histogram({
   name: "engine_response_time_ms",
   help: "Response time in milliseconds",
-  labelNames: ["endpoint", "status_code"],
+  labelNames: ["endpoint", "status_code", "method"],
   buckets: [100, 300, 500, 700, 1000, 3000, 5000, 7000, 10_000],
   registers: [enginePromRegister],
 });
@@ -120,6 +120,7 @@ const queueToSentDuration = new Histogram({
   help: "Duration from queue to sent in seconds",
   labelNames: ["chain_id", "wallet_address"],
   buckets: [1, 5, 15, 30, 60, 120, 300, 600],
+  registers: [enginePromRegister],
 });
 
 const sentToMinedDuration = new Histogram({
@@ -127,6 +128,7 @@ const sentToMinedDuration = new Histogram({
   help: "Duration from sent to mined in seconds",
   labelNames: ["chain_id", "wallet_address"],
   buckets: [10, 30, 60, 120, 300, 600, 1200, 1800],
+  registers: [enginePromRegister],
 });
 
 const endToEndDuration = new Histogram({
@@ -134,6 +136,7 @@ const endToEndDuration = new Histogram({
   help: "Duration from request to mined in seconds",
   labelNames: ["chain_id", "wallet_address"],
   buckets: [10, 30, 60, 120, 300, 600, 1200, 1800, 3600],
+  registers: [enginePromRegister],
 });
 
 // Function to record metrics
@@ -145,7 +148,6 @@ export function recordMetrics(eventData: MetricParams): void {
       labels = {
         endpoint: params.endpoint,
         status_code: params.statusCode,
-        method: params.method,
       };
       requestsTotal.inc(labels);
       requestDuration.observe(labels, params.duration);

--- a/src/utils/prometheus.ts
+++ b/src/utils/prometheus.ts
@@ -1,3 +1,4 @@
+import fastify from "fastify";
 import { Counter, Gauge, Histogram, Registry } from "prom-client";
 import { getUsedBackendWallets, inspectNonce } from "../db/wallets/walletNonce";
 import { getLastUsedOnchainNonce } from "../server/routes/admin/nonces";
@@ -183,3 +184,13 @@ export function recordMetrics(eventData: MetricParams): void {
       break;
   }
 }
+// Expose metrics endpoint
+
+export const metricsServer = fastify({
+  disableRequestLogging: true,
+});
+
+metricsServer.get("/metrics", async (_request, reply) => {
+  reply.header("Content-Type", enginePromRegister.contentType);
+  return enginePromRegister.metrics();
+});

--- a/src/utils/prometheus.ts
+++ b/src/utils/prometheus.ts
@@ -1,30 +1,65 @@
-import { Counter, Gauge, Histogram, Pushgateway, Registry } from "prom-client";
-import { env } from "./env";
-import { logger } from "./logger";
+import { Counter, Gauge, Histogram, Registry } from "prom-client";
+import { getUsedBackendWallets, inspectNonce } from "../db/wallets/walletNonce";
+import { getLastUsedOnchainNonce } from "../server/routes/admin/nonces";
 
-const register = new Registry();
-const pushgateway = env.PROMETHEUS_PUSHGATEWAY_URL
-  ? new Pushgateway(env.PROMETHEUS_PUSHGATEWAY_URL, {}, register)
-  : null;
+const nonceMetrics = new Gauge({
+  name: "engine_largest_sent_nonce",
+  help: "Current nonce values and health for backend wallets",
+  labelNames: ["wallet", "chain", "type"],
+  async collect() {
+    const allWallets = await getUsedBackendWallets();
+
+    for (const { chainId, walletAddress } of allWallets) {
+      const [onchainNonce, engineNonce] = await Promise.all([
+        getLastUsedOnchainNonce(chainId, walletAddress),
+        inspectNonce(chainId, walletAddress),
+      ]);
+
+      this.set(
+        {
+          wallet: walletAddress,
+          chain: chainId.toString(),
+          type: "onchain",
+        },
+        onchainNonce,
+      );
+      this.set(
+        {
+          wallet: walletAddress,
+          chain: chainId.toString(),
+          type: "engine",
+        },
+        engineNonce,
+      );
+    }
+  },
+});
+
+export const register = new Registry();
+
+register.registerMetric(nonceMetrics);
 
 // Define strict types for each event
 type ResponseSentParams = {
   endpoint: string;
-  statusCode: number;
+  statusCode: string;
+  method: string;
   duration: number;
 };
 
 type TransactionQueuedParams = {
-  extension: string;
-  chainId: number;
+  chainId: string;
+  walletAddress: string;
 };
 
 type TransactionSentParams = TransactionQueuedParams & {
   success: boolean;
+  duration: number;
 };
 
 type TransactionMinedParams = TransactionQueuedParams & {
-  mineTime: number;
+  endToEndDuration: number;
+  duration: number;
 };
 
 // Union type for all possible event parameters
@@ -34,77 +69,115 @@ type MetricParams =
   | { event: "transaction_sent"; params: TransactionSentParams }
   | { event: "transaction_mined"; params: TransactionMinedParams };
 
-// Define metrics
-const requestCounter = new Counter({
+// Request metrics
+const requestsTotal = new Counter({
   name: "engine_requests_total",
   help: "Total number of completed requests",
-  labelNames: ["endpoint", "extension", "chainId", "provider", "status_code"],
+  labelNames: ["endpoint", "status_code", "method"],
   registers: [register],
 });
 
-const responseTimeHistogram = new Histogram({
-  name: "engine_response_time_seconds",
-  help: "Response time in seconds",
-  labelNames: ["endpoint", "extension", "chainId", "provider", "status_code"],
-  buckets: [0.1, 0.3, 0.5, 0.7, 1, 3, 5, 7, 10],
+const requestDuration = new Histogram({
+  name: "engine_response_time_ms",
+  help: "Response time in milliseconds",
+  labelNames: ["endpoint", "status_code"],
+  buckets: [100, 300, 500, 700, 1000, 3000, 5000, 7000, 10_000],
   registers: [register],
 });
 
+// Transaction metrics
 const transactionsQueued = new Gauge({
   name: "engine_transactions_queued",
   help: "Number of transactions currently in queue",
-  labelNames: ["endpoint", "extension", "chainId", "provider"],
+  labelNames: ["chain_id", "wallet_address"],
   registers: [register],
 });
 
-const transactionTimeHistogram = new Histogram({
-  name: "engine_transaction_time_seconds",
-  help: "Time for transaction to be mined",
-  labelNames: ["endpoint", "extension", "chainId", "provider"],
-  buckets: [10, 30, 60, 120, 300, 600, 1200, 1800],
+const transactionsQueuedTotal = new Counter({
+  name: "engine_transactions_queued_total",
+  help: "Total number of transactions queued",
+  labelNames: ["chain_id", "wallet_address"],
   registers: [register],
+});
+
+const transactionsSentTotal = new Counter({
+  name: "engine_transactions_sent_total",
+  help: "Total number of transactions sent",
+  labelNames: ["chain_id", "wallet_address", "is_success"],
+  registers: [register],
+});
+
+const transactionsMinedTotal = new Counter({
+  name: "engine_transactions_mined_total",
+  help: "Total number of transactions mined",
+  labelNames: ["chain_id", "wallet_address"],
+  registers: [register],
+});
+
+// Transaction duration histograms
+const queueToSentDuration = new Histogram({
+  name: "engine_transaction_queue_to_sent_seconds",
+  help: "Duration from queue to sent in seconds",
+  labelNames: ["chain_id", "wallet_address"],
+  buckets: [1, 5, 15, 30, 60, 120, 300, 600],
+});
+
+const sentToMinedDuration = new Histogram({
+  name: "engine_transaction_sent_to_mined_seconds",
+  help: "Duration from sent to mined in seconds",
+  labelNames: ["chain_id", "wallet_address"],
+  buckets: [10, 30, 60, 120, 300, 600, 1200, 1800],
+});
+
+const endToEndDuration = new Histogram({
+  name: "engine_transaction_end_to_end_seconds",
+  help: "Duration from request to mined in seconds",
+  labelNames: ["chain_id", "wallet_address"],
+  buckets: [10, 30, 60, 120, 300, 600, 1200, 1800, 3600],
 });
 
 // Function to record metrics
 export function recordMetrics(eventData: MetricParams): void {
-  if (!pushgateway) {
-    return;
-  }
   const { event, params } = eventData;
-
-  const labels = {
-    ...eventData.params,
-    chainId:
-      "chainId" in eventData.params
-        ? eventData.params.chainId.toString()
-        : undefined,
-  };
-
+  let labels: any;
   switch (event) {
     case "response_sent":
-      requestCounter.inc({
-        ...labels,
-        status_code: params.statusCode.toString(),
-      });
-      responseTimeHistogram.observe(labels, params.duration);
+      labels = {
+        endpoint: params.endpoint,
+        status_code: params.statusCode,
+        method: params.method,
+      };
+      requestsTotal.inc(labels);
+      requestDuration.observe(labels, params.duration);
       break;
+
     case "transaction_queued":
+      labels = {
+        chain_id: params.chainId,
+        wallet_address: params.walletAddress,
+      };
       transactionsQueued.inc(labels);
+      transactionsQueuedTotal.inc(labels);
       break;
+
     case "transaction_sent":
+      labels = {
+        chain_id: params.chainId,
+        wallet_address: params.walletAddress,
+      };
       transactionsQueued.dec(labels);
+      transactionsSentTotal.inc({ ...labels, is_success: params.success });
+      queueToSentDuration.observe(labels, params.duration);
       break;
+
     case "transaction_mined":
-      transactionTimeHistogram.observe(labels, params.mineTime);
+      labels = {
+        chain_id: params.chainId,
+        wallet_address: params.walletAddress,
+      };
+      transactionsMinedTotal.inc(labels);
+      sentToMinedDuration.observe(labels, params.duration);
+      endToEndDuration.observe(labels, params.endToEndDuration);
       break;
   }
-
-  pushgateway.push({ jobName: "engine" }).catch((err) => {
-    logger({
-      service: "server",
-      level: "error",
-      message: "Failed to push metrics to Prometheus",
-      data: { error: err },
-    });
-  });
 }

--- a/src/utils/prometheus.ts
+++ b/src/utils/prometheus.ts
@@ -1,0 +1,110 @@
+import { Counter, Gauge, Histogram, Pushgateway, Registry } from "prom-client";
+import { env } from "./env";
+import { logger } from "./logger";
+
+const register = new Registry();
+const pushgateway = env.PROMETHEUS_PUSHGATEWAY_URL
+  ? new Pushgateway(env.PROMETHEUS_PUSHGATEWAY_URL, {}, register)
+  : null;
+
+// Define strict types for each event
+type ResponseSentParams = {
+  endpoint: string;
+  statusCode: number;
+  duration: number;
+};
+
+type TransactionQueuedParams = {
+  extension: string;
+  chainId: number;
+};
+
+type TransactionSentParams = TransactionQueuedParams & {
+  success: boolean;
+};
+
+type TransactionMinedParams = TransactionQueuedParams & {
+  mineTime: number;
+};
+
+// Union type for all possible event parameters
+type MetricParams =
+  | { event: "response_sent"; params: ResponseSentParams }
+  | { event: "transaction_queued"; params: TransactionQueuedParams }
+  | { event: "transaction_sent"; params: TransactionSentParams }
+  | { event: "transaction_mined"; params: TransactionMinedParams };
+
+// Define metrics
+const requestCounter = new Counter({
+  name: "engine_requests_total",
+  help: "Total number of completed requests",
+  labelNames: ["endpoint", "extension", "chainId", "provider", "status_code"],
+  registers: [register],
+});
+
+const responseTimeHistogram = new Histogram({
+  name: "engine_response_time_seconds",
+  help: "Response time in seconds",
+  labelNames: ["endpoint", "extension", "chainId", "provider", "status_code"],
+  buckets: [0.1, 0.3, 0.5, 0.7, 1, 3, 5, 7, 10],
+  registers: [register],
+});
+
+const transactionsQueued = new Gauge({
+  name: "engine_transactions_queued",
+  help: "Number of transactions currently in queue",
+  labelNames: ["endpoint", "extension", "chainId", "provider"],
+  registers: [register],
+});
+
+const transactionTimeHistogram = new Histogram({
+  name: "engine_transaction_time_seconds",
+  help: "Time for transaction to be mined",
+  labelNames: ["endpoint", "extension", "chainId", "provider"],
+  buckets: [10, 30, 60, 120, 300, 600, 1200, 1800],
+  registers: [register],
+});
+
+// Function to record metrics
+export function recordMetrics(eventData: MetricParams): void {
+  if (!pushgateway) {
+    return;
+  }
+  const { event, params } = eventData;
+
+  const labels = {
+    ...eventData.params,
+    chainId:
+      "chainId" in eventData.params
+        ? eventData.params.chainId.toString()
+        : undefined,
+  };
+
+  switch (event) {
+    case "response_sent":
+      requestCounter.inc({
+        ...labels,
+        status_code: params.statusCode.toString(),
+      });
+      responseTimeHistogram.observe(labels, params.duration);
+      break;
+    case "transaction_queued":
+      transactionsQueued.inc(labels);
+      break;
+    case "transaction_sent":
+      transactionsQueued.dec(labels);
+      break;
+    case "transaction_mined":
+      transactionTimeHistogram.observe(labels, params.mineTime);
+      break;
+  }
+
+  pushgateway.push({ jobName: "engine" }).catch((err) => {
+    logger({
+      service: "server",
+      level: "error",
+      message: "Failed to push metrics to Prometheus",
+      data: { error: err },
+    });
+  });
+}

--- a/src/utils/prometheus.ts
+++ b/src/utils/prometheus.ts
@@ -35,9 +35,9 @@ const nonceMetrics = new Gauge({
   },
 });
 
-export const register = new Registry();
+export const enginePromRegister = new Registry();
 
-register.registerMetric(nonceMetrics);
+enginePromRegister.registerMetric(nonceMetrics);
 
 // Define strict types for each event
 type ResponseSentParams = {
@@ -74,7 +74,7 @@ const requestsTotal = new Counter({
   name: "engine_requests_total",
   help: "Total number of completed requests",
   labelNames: ["endpoint", "status_code", "method"],
-  registers: [register],
+  registers: [enginePromRegister],
 });
 
 const requestDuration = new Histogram({
@@ -82,7 +82,7 @@ const requestDuration = new Histogram({
   help: "Response time in milliseconds",
   labelNames: ["endpoint", "status_code"],
   buckets: [100, 300, 500, 700, 1000, 3000, 5000, 7000, 10_000],
-  registers: [register],
+  registers: [enginePromRegister],
 });
 
 // Transaction metrics
@@ -90,28 +90,28 @@ const transactionsQueued = new Gauge({
   name: "engine_transactions_queued",
   help: "Number of transactions currently in queue",
   labelNames: ["chain_id", "wallet_address"],
-  registers: [register],
+  registers: [enginePromRegister],
 });
 
 const transactionsQueuedTotal = new Counter({
   name: "engine_transactions_queued_total",
   help: "Total number of transactions queued",
   labelNames: ["chain_id", "wallet_address"],
-  registers: [register],
+  registers: [enginePromRegister],
 });
 
 const transactionsSentTotal = new Counter({
   name: "engine_transactions_sent_total",
   help: "Total number of transactions sent",
   labelNames: ["chain_id", "wallet_address", "is_success"],
-  registers: [register],
+  registers: [enginePromRegister],
 });
 
 const transactionsMinedTotal = new Counter({
   name: "engine_transactions_mined_total",
   help: "Total number of transactions mined",
   labelNames: ["chain_id", "wallet_address"],
-  registers: [register],
+  registers: [enginePromRegister],
 });
 
 // Transaction duration histograms

--- a/src/utils/prometheus.ts
+++ b/src/utils/prometheus.ts
@@ -82,7 +82,7 @@ const requestDuration = new Histogram({
   name: "engine_response_time_ms",
   help: "Response time in milliseconds",
   labelNames: ["endpoint", "status_code", "method"],
-  buckets: [100, 300, 500, 700, 1000, 3000, 5000, 7000, 10_000],
+  buckets: [1, 10, 50, 100, 300, 500, 700, 1000, 3000, 5000, 7000, 10_000],
   registers: [enginePromRegister],
 });
 

--- a/src/utils/transaction/insertTransaction.ts
+++ b/src/utils/transaction/insertTransaction.ts
@@ -3,6 +3,7 @@ import { TransactionDB } from "../../db/transactions/db";
 import { createCustomError } from "../../server/middleware/error";
 import { SendTransactionQueue } from "../../worker/queues/sendTransactionQueue";
 import { getChecksumAddress } from "../primitiveTypes";
+import { recordMetrics } from "../prometheus";
 import { reportUsage } from "../usage";
 import { doSimulateTransaction } from "./simulateQueuedTransaction";
 import { InsertedTransaction, QueuedTransaction } from "./types";
@@ -69,6 +70,14 @@ export const insertTransaction = async (
     resendCount: 0,
   });
   reportUsage([{ action: "queue_tx", input: queuedTransaction }]);
+
+  recordMetrics({
+    event: "transaction_queued",
+    params: {
+      chainId: insertedTransaction.chainId,
+      extension: insertedTransaction.extension ?? "none",
+    },
+  });
 
   return queueId;
 };

--- a/src/utils/transaction/insertTransaction.ts
+++ b/src/utils/transaction/insertTransaction.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "crypto";
-import { getAddress } from "thirdweb";
 import { TransactionDB } from "../../db/transactions/db";
 import { createCustomError } from "../../server/middleware/error";
 import { SendTransactionQueue } from "../../worker/queues/sendTransactionQueue";
@@ -75,8 +74,8 @@ export const insertTransaction = async (
   recordMetrics({
     event: "transaction_queued",
     params: {
-      chainId: insertedTransaction.chainId.toString(),
-      walletAddress: getAddress(insertedTransaction.from),
+      chainId: queuedTransaction.chainId.toString(),
+      walletAddress: queuedTransaction.from,
     },
   });
 

--- a/src/utils/transaction/insertTransaction.ts
+++ b/src/utils/transaction/insertTransaction.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { getAddress } from "thirdweb";
 import { TransactionDB } from "../../db/transactions/db";
 import { createCustomError } from "../../server/middleware/error";
 import { SendTransactionQueue } from "../../worker/queues/sendTransactionQueue";
@@ -74,8 +75,8 @@ export const insertTransaction = async (
   recordMetrics({
     event: "transaction_queued",
     params: {
-      chainId: insertedTransaction.chainId,
-      extension: insertedTransaction.extension ?? "none",
+      chainId: insertedTransaction.chainId.toString(),
+      walletAddress: getAddress(insertedTransaction.from),
     },
   });
 

--- a/src/worker/tasks/mineTransactionWorker.ts
+++ b/src/worker/tasks/mineTransactionWorker.ts
@@ -5,6 +5,7 @@ import {
   Address,
   eth_getTransactionByHash,
   eth_getTransactionReceipt,
+  getAddress,
   getRpcClient,
 } from "thirdweb";
 import { stringify } from "thirdweb/utils";
@@ -69,9 +70,10 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
     recordMetrics({
       event: "transaction_mined",
       params: {
-        chainId: resultTransaction.chainId,
-        extension: resultTransaction.extension ?? "",
-        mineTime: msSince(resultTransaction.queuedAt),
+        chainId: resultTransaction.chainId.toString(),
+        endToEndDuration: msSince(resultTransaction.queuedAt) / 1000,
+        duration: msSince(resultTransaction.sentAt) / 1000,
+        walletAddress: getAddress(resultTransaction.from),
       },
     });
     logger({

--- a/src/worker/tasks/mineTransactionWorker.ts
+++ b/src/worker/tasks/mineTransactionWorker.ts
@@ -17,6 +17,7 @@ import { getChain } from "../../utils/chain";
 import { msSince } from "../../utils/date";
 import { env } from "../../utils/env";
 import { logger } from "../../utils/logger";
+import { recordMetrics } from "../../utils/prometheus";
 import { redis } from "../../utils/redis/redis";
 import { thirdwebClient } from "../../utils/sdk";
 import {
@@ -65,6 +66,14 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
     await TransactionDB.set(resultTransaction);
     await enqueueTransactionWebhook(resultTransaction);
     await _reportUsageSuccess(resultTransaction);
+    recordMetrics({
+      event: "transaction_mined",
+      params: {
+        chainId: resultTransaction.chainId,
+        extension: resultTransaction.extension ?? "",
+        mineTime: msSince(resultTransaction.queuedAt),
+      },
+    });
     logger({
       level: "info",
       queueId: resultTransaction.queueId,

--- a/src/worker/tasks/mineTransactionWorker.ts
+++ b/src/worker/tasks/mineTransactionWorker.ts
@@ -71,8 +71,9 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
       event: "transaction_mined",
       params: {
         chainId: resultTransaction.chainId.toString(),
-        endToEndDuration: msSince(resultTransaction.queuedAt) / 1000,
-        duration: msSince(resultTransaction.sentAt) / 1000,
+        queuedToMinedDurationSeconds:
+          msSince(resultTransaction.queuedAt) / 1000,
+        durationSeconds: msSince(resultTransaction.sentAt) / 1000,
         walletAddress: getAddress(resultTransaction.from),
       },
     });

--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { Job, Processor, Worker } from "bullmq";
 import superjson from "superjson";
-import { Hex, toSerializableTransaction } from "thirdweb";
+import { Hex, getAddress, toSerializableTransaction } from "thirdweb";
 import { stringify } from "thirdweb/utils";
 import { bundleUserOp } from "thirdweb/wallets/smart";
 import { getContractAddress } from "viem";
@@ -111,9 +111,10 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
         recordMetrics({
           event: "transaction_sent",
           params: {
-            chainId: transaction.chainId,
-            extension: transaction.extension ?? "none",
+            chainId: transaction.chainId.toString(),
             success: true,
+            walletAddress: getAddress(transaction.from),
+            duration: msSince(transaction.queuedAt) / 1000,
           },
         });
       }
@@ -122,9 +123,10 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
       recordMetrics({
         event: "transaction_sent",
         params: {
-          chainId: transaction.chainId,
-          extension: transaction.extension ?? "none",
-          success: false,
+          chainId: transaction.chainId.toString(),
+          success: true,
+          walletAddress: getAddress(transaction.from),
+          duration: msSince(transaction.queuedAt) / 1000,
         },
       });
     }

--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -124,7 +124,7 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
         event: "transaction_sent",
         params: {
           chainId: transaction.chainId.toString(),
-          success: true,
+          success: false,
           walletAddress: getAddress(transaction.from),
           duration: msSince(transaction.queuedAt) / 1000,
         },

--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -114,7 +114,7 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
             chainId: transaction.chainId.toString(),
             success: true,
             walletAddress: getAddress(transaction.from),
-            duration: msSince(transaction.queuedAt) / 1000,
+            durationSeconds: msSince(transaction.queuedAt) / 1000,
           },
         });
       }
@@ -126,7 +126,7 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
           chainId: transaction.chainId.toString(),
           success: false,
           walletAddress: getAddress(transaction.from),
-          duration: msSince(transaction.queuedAt) / 1000,
+          durationSeconds: msSince(transaction.queuedAt) / 1000,
         },
       });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2430,6 +2430,11 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.8.0.tgz#5aa7abb48f23f693068ed2999ae627d2f7d902ec"
   integrity sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==
 
+"@opentelemetry/api@^1.4.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
+  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
+
 "@opentelemetry/core@^1.14.0":
   version "1.25.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.25.1.tgz#ff667d939d128adfc7c793edae2f6bca177f829d"
@@ -5186,6 +5191,11 @@ binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
 blakejs@^1.1.0:
   version "1.2.1"
@@ -9614,6 +9624,14 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
+prom-client@^15.1.3:
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-15.1.3.tgz#69fa8de93a88bc9783173db5f758dc1c69fa8fc2"
+  integrity sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==
+  dependencies:
+    "@opentelemetry/api" "^1.4.0"
+    tdigest "^0.1.1"
+
 proto3-json-serializer@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-1.1.1.tgz#1b5703152b6ce811c5cdcc6468032caf53521331"
@@ -10390,7 +10408,16 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10427,7 +10454,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10520,6 +10554,13 @@ tarn@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tarn/-/tarn-3.0.2.tgz#73b6140fbb881b71559c4f8bfde3d9a4b3d27693"
   integrity sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 teeny-request@^9.0.0:
   version "9.0.0"
@@ -11451,7 +11492,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11464,6 +11505,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds Prometheus metrics support to the application. It introduces metrics recording for queued, mined, and sent transactions, along with a middleware for recording response metrics.

### Detailed summary
- Added `prom-client` for Prometheus metrics
- Added metrics recording for queued, mined, and sent transactions
- Implemented middleware for recording response metrics

> The following files were skipped due to too many changes: `yarn.lock`, `src/utils/prometheus.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->