### PR TITLE
fix: allow int idempotency keys

### DIFF
--- a/src/worker/queues/mineTransactionQueue.ts
+++ b/src/worker/queues/mineTransactionQueue.ts
@@ -16,7 +16,7 @@ export class MineTransactionQueue {
 
   // There must be a worker to poll the result for every transaction hash,
   // even for the same queueId. This handles if any retried transactions succeed.
-  static jobId = (data: MineTransactionData) => data.queueId;
+  static jobId = (data: MineTransactionData) => `mine.${data.queueId}`;
 
   static add = async (data: MineTransactionData) => {
     const serialized = superjson.stringify(data);

--- a/src/worker/queues/sendTransactionQueue.ts
+++ b/src/worker/queues/sendTransactionQueue.ts
@@ -21,7 +21,7 @@ export class SendTransactionQueue {
 
   // Allow enqueing the same queueId for multiple retries.
   static jobId = (data: SendTransactionData) =>
-    `${data.queueId}:${data.resendCount}`;
+    `${data.queueId}.${data.resendCount}`;
 
   static add = async (data: SendTransactionData) => {
     const serialized = superjson.stringify(data);

--- a/src/worker/queues/sendWebhookQueue.ts
+++ b/src/worker/queues/sendWebhookQueue.ts
@@ -104,9 +104,9 @@ export class SendWebhookQueue {
     const { webhook, eventLog, transactionReceipt } = args;
 
     if (eventLog) {
-      return `${webhook.url}:${eventLog.transactionHash}:${eventLog.logIndex}`;
+      return `${webhook.url}.${eventLog.transactionHash}.${eventLog.logIndex}`;
     } else if (transactionReceipt) {
-      return `${webhook.url}:${transactionReceipt.transactionHash}`;
+      return `${webhook.url}.${transactionReceipt.transactionHash}`;
     }
     throw 'Must provide "eventLog" or "transactionReceipt".';
   };
@@ -139,5 +139,5 @@ export class SendWebhookQueue {
     webhook: Webhooks;
     eventType: WebhooksEventTypes;
     queueId: string;
-  }) => `${args.webhook.url}:${args.eventType}:${args.queueId}`;
+  }) => `${args.webhook.url}.${args.eventType}.${args.queueId}`;
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the queue jobId generation logic in multiple worker queues for better identification and handling of retry transactions.

### Detailed summary
- Updated `jobId` generation in `sendTransactionQueue.ts` and `mineTransactionQueue.ts`
- Updated `jobId` generation in `sendWebhookQueue.ts` for better identification

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->