### PR TITLE
chore: Add accountFactoryAddress parameter to doSimulateTransaction

### DIFF
--- a/src/utils/transaction/simulateQueuedTransaction.ts
+++ b/src/utils/transaction/simulateQueuedTransaction.ts
@@ -29,6 +29,7 @@ export const doSimulateTransaction = async (
     maxFeePerGas,
     maxPriorityFeePerGas,
     accountAddress,
+    accountFactoryAddress,
     target,
     from,
   } = transaction;
@@ -61,6 +62,7 @@ export const doSimulateTransaction = async (
       from,
       chain,
       accountAddress,
+      accountFactoryAddress,
     });
   } else {
     account = await getAccount({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add the `accountFactoryAddress` parameter to the `doSimulateTransaction` function.

### Detailed summary
- Added `accountFactoryAddress` parameter to `doSimulateTransaction` function
- Updated function calls to include `accountFactoryAddress` argument

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->