### PR TITLE
chore: to is target when userOp through queueTx

### DIFF
--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -403,7 +403,10 @@ export const getPopulatedOrErroredTransaction = async (
       ? queuedTransaction.accountAddress
       : queuedTransaction.from;
 
+    const to = queuedTransaction.to ?? queuedTransaction.target;
+
     if (!from) throw new Error("Invalid transaction parameters: from");
+    if (!to) throw new Error("Invalid transaction parameters: to");
 
     const populatedTransaction = await toSerializableTransaction({
       from: getChecksumAddress(from),
@@ -411,6 +414,7 @@ export const getPopulatedOrErroredTransaction = async (
         client: thirdwebClient,
         chain: await getChain(queuedTransaction.chainId),
         ...queuedTransaction,
+        to: getChecksumAddress(to),
         // if transaction is EOA, we stub the nonce to reduce RPC calls
         nonce: queuedTransaction.isUserOp ? undefined : 1,
       },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving transaction parameter handling in `sendTransactionWorker.ts`.

### Detailed summary
- Added a fallback for `to` parameter using `target`
- Ensured `to` and `from` parameters are present, throwing errors if not
- Updated `to` parameter to use `getChecksumAddress` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->