### PR TITLE
fix: use ZERO_ADDRESS constant for currencyAddress example

### DIFF
--- a/src/server/routes/backend-wallet/transfer.ts
+++ b/src/server/routes/backend-wallet/transfer.ts
@@ -39,7 +39,7 @@ const requestBodySchema = Type.Object({
   },
   currencyAddress: Type.Optional({
     ...AddressSchema,
-    examples: [constants.AddressZero],
+    examples: [ZERO_ADDRESS],
     description:
       "The token address to transfer. Omit to transfer the chain's native currency (e.g. ETH on Ethereum).",
   }),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the example value for `currencyAddress` in the `transfer.ts` file.

### Detailed summary
- Updated the example value for `currencyAddress` from `constants.AddressZero` to `ZERO_ADDRESS`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->