### PR TITLE
fix: Enforce Address schema wherever an address is expected

### DIFF
--- a/src/server/routes/admin/nonces.ts
+++ b/src/server/routes/admin/nonces.ts
@@ -16,16 +16,17 @@ import {
 import { getChain } from "../../../utils/chain";
 import { redis } from "../../../utils/redis/redis";
 import { thirdwebClient } from "../../../utils/sdk";
+import { AddressSchema } from "../../schemas/address";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 import { walletWithAddressParamSchema } from "../../schemas/wallet";
 
 export const responseBodySchema = Type.Object({
   result: Type.Array(
     Type.Object({
-      walletAddress: Type.String({
-        description: "Backend Wallet Address",
-        examples: ["0xcedf3b4d8f7f1f7e0f7f0f7f0f7f0f7f0f7f0f7f"],
-      }),
+      walletAddress: {
+        ...AddressSchema,
+        description: "Backend wallet address",
+      },
       chainId: Type.Number({
         description: "Chain ID",
         examples: [80002],

--- a/src/server/routes/auth/access-tokens/getAll.ts
+++ b/src/server/routes/auth/access-tokens/getAll.ts
@@ -2,12 +2,13 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getAccessTokens } from "../../../../db/tokens/getAccessTokens";
+import { AddressSchema } from "../../../schemas/address";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 
 export const AccessTokenSchema = Type.Object({
   id: Type.String(),
   tokenMask: Type.String(),
-  walletAddress: Type.String(),
+  walletAddress: AddressSchema,
   createdAt: Type.String(),
   expiresAt: Type.String(),
   label: Type.Union([Type.String(), Type.Null()]),

--- a/src/server/routes/auth/permissions/getAll.ts
+++ b/src/server/routes/auth/permissions/getAll.ts
@@ -2,12 +2,13 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { prisma } from "../../../../db/client";
+import { AddressSchema } from "../../../schemas/address";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 
 const responseBodySchema = Type.Object({
   result: Type.Array(
     Type.Object({
-      walletAddress: Type.String(),
+      walletAddress: AddressSchema,
       permissions: Type.String(),
       label: Type.Union([Type.String(), Type.Null()]),
     }),

--- a/src/server/routes/auth/permissions/grant.ts
+++ b/src/server/routes/auth/permissions/grant.ts
@@ -2,11 +2,12 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { updatePermissions } from "../../../../db/permissions/updatePermissions";
+import { AddressSchema } from "../../../schemas/address";
 import { permissionsSchema } from "../../../schemas/auth";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 
 const requestBodySchema = Type.Object({
-  walletAddress: Type.String(),
+  walletAddress: AddressSchema,
   permissions: permissionsSchema,
   label: Type.Optional(Type.String()),
 });

--- a/src/server/routes/auth/permissions/revoke.ts
+++ b/src/server/routes/auth/permissions/revoke.ts
@@ -2,10 +2,11 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { deletePermissions } from "../../../../db/permissions/deletePermissions";
+import { AddressSchema } from "../../../schemas/address";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 
 const requestBodySchema = Type.Object({
-  walletAddress: Type.String(),
+  walletAddress: AddressSchema,
 });
 
 const responseBodySchema = Type.Object({

--- a/src/server/routes/backend-wallet/create.ts
+++ b/src/server/routes/backend-wallet/create.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { WalletType } from "../../../schema/wallet";
 import { getConfig } from "../../../utils/cache/getConfig";
+import { AddressSchema } from "../../schemas/address";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 import { createAwsKmsWallet } from "../../utils/wallets/createAwsKmsWallet";
 import { createGcpKmsWallet } from "../../utils/wallets/createGcpKmsWallet";
@@ -14,7 +15,7 @@ const requestBodySchema = Type.Object({
 
 const responseSchema = Type.Object({
   result: Type.Object({
-    walletAddress: Type.String(),
+    walletAddress: AddressSchema,
     status: Type.String(),
   }),
 });

--- a/src/server/routes/backend-wallet/getBalance.ts
+++ b/src/server/routes/backend-wallet/getBalance.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getSdk } from "../../../utils/cache/getSdk";
+import { AddressSchema } from "../../schemas/address";
 import {
   currencyValueSchema,
   standardResponseSchema,
@@ -11,7 +12,7 @@ import { getChainIdFromChain } from "../../utils/chain";
 
 const responseSchema = Type.Object({
   result: Type.Object({
-    walletAddress: Type.String(),
+    walletAddress: AddressSchema,
     ...currencyValueSchema.properties,
   }),
 });

--- a/src/server/routes/backend-wallet/import.ts
+++ b/src/server/routes/backend-wallet/import.ts
@@ -4,6 +4,7 @@ import { StatusCodes } from "http-status-codes";
 import { WalletType } from "../../../schema/wallet";
 import { getConfig } from "../../../utils/cache/getConfig";
 import { createCustomError } from "../../middleware/error";
+import { AddressSchema } from "../../schemas/address";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 import { importAwsKmsWallet } from "../../utils/wallets/importAwsKmsWallet";
 import { importGcpKmsWallet } from "../../utils/wallets/importGcpKmsWallet";
@@ -80,7 +81,7 @@ RequestBodySchema.examples = [
 
 const ResponseSchema = Type.Object({
   result: Type.Object({
-    walletAddress: Type.String(),
+    walletAddress: AddressSchema,
     status: Type.String(),
   }),
 });

--- a/src/server/routes/backend-wallet/remove.ts
+++ b/src/server/routes/backend-wallet/remove.ts
@@ -3,10 +3,11 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { Address } from "thirdweb";
 import { deleteWalletDetails } from "../../../db/wallets/deleteWalletDetails";
+import { AddressSchema } from "../../schemas/address";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 
 const requestParamSchema = Type.Object({
-  walletAddress: Type.String(),
+  walletAddress: AddressSchema,
 });
 
 const responseSchema = Type.Object({

--- a/src/server/routes/backend-wallet/sendTransaction.ts
+++ b/src/server/routes/backend-wallet/sendTransaction.ts
@@ -4,6 +4,7 @@ import { StatusCodes } from "http-status-codes";
 import { Address, Hex } from "thirdweb";
 import { maybeBigInt } from "../../../utils/primitiveTypes";
 import { insertTransaction } from "../../../utils/transaction/insertTransaction";
+import { AddressSchema } from "../../schemas/address";
 import {
   requestQuerystringSchema,
   standardResponseSchema,
@@ -18,11 +19,7 @@ import {
 import { getChainIdFromChain } from "../../utils/chain";
 
 const requestBodySchema = Type.Object({
-  toAddress: Type.Optional(
-    Type.String({
-      examples: ["0x..."],
-    }),
-  ),
+  toAddress: Type.Optional(AddressSchema),
   data: Type.String({
     examples: ["0x..."],
   }),

--- a/src/server/routes/backend-wallet/sendTransactionBatch.ts
+++ b/src/server/routes/backend-wallet/sendTransactionBatch.ts
@@ -4,6 +4,7 @@ import { StatusCodes } from "http-status-codes";
 import { Address, Hex } from "thirdweb";
 import { maybeBigInt } from "../../../utils/primitiveTypes";
 import { insertTransaction } from "../../../utils/transaction/insertTransaction";
+import { AddressSchema } from "../../schemas/address";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 import { txOverridesWithValueSchema } from "../../schemas/txOverrides";
 import {
@@ -14,11 +15,7 @@ import { getChainIdFromChain } from "../../utils/chain";
 
 const requestBodySchema = Type.Array(
   Type.Object({
-    toAddress: Type.Optional(
-      Type.String({
-        examples: ["0x..."],
-      }),
-    ),
+    toAddress: Type.Optional(AddressSchema),
     data: Type.String({
       examples: ["0x..."],
     }),

--- a/src/server/routes/backend-wallet/update.ts
+++ b/src/server/routes/backend-wallet/update.ts
@@ -2,16 +2,17 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { updateWalletDetails } from "../../../db/wallets/updateWalletDetails";
+import { AddressSchema } from "../../schemas/address";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 
 const requestBodySchema = Type.Object({
-  walletAddress: Type.String(),
+  walletAddress: AddressSchema,
   label: Type.Optional(Type.String()),
 });
 
 const responseSchema = Type.Object({
   result: Type.Object({
-    walletAddress: Type.String(),
+    walletAddress: AddressSchema,
     status: Type.String(),
   }),
 });

--- a/src/server/routes/backend-wallet/withdraw.ts
+++ b/src/server/routes/backend-wallet/withdraw.ts
@@ -11,6 +11,7 @@ import { getWalletBalance } from "thirdweb/wallets";
 import { getAccount } from "../../../utils/account";
 import { getChain } from "../../../utils/chain";
 import { thirdwebClient } from "../../../utils/sdk";
+import { AddressSchema } from "../../schemas/address";
 import {
   requestQuerystringSchema,
   standardResponseSchema,
@@ -24,9 +25,10 @@ import { getChainIdFromChain } from "../../utils/chain";
 const ParamsSchema = Type.Omit(walletWithAddressParamSchema, ["walletAddress"]);
 
 const requestBodySchema = Type.Object({
-  toAddress: Type.String({
+  toAddress: {
+    ...AddressSchema,
     description: "Address to withdraw all funds to",
-  }),
+  },
 });
 
 const responseBodySchema = Type.Object({

--- a/src/server/routes/contract/events/getContractEventLogs.ts
+++ b/src/server/routes/contract/events/getContractEventLogs.ts
@@ -4,6 +4,7 @@ import { StatusCodes } from "http-status-codes";
 import { getContractEventLogsByBlockAndTopics } from "../../../../db/contractEventLogs/getContractEventLogs";
 import { isContractSubscribed } from "../../../../db/contractSubscriptions/getContractSubscriptions";
 import { createCustomError } from "../../../middleware/error";
+import { AddressSchema } from "../../../schemas/address";
 import {
   contractParamSchema,
   standardResponseSchema,
@@ -21,7 +22,7 @@ const responseSchema = Type.Object({
     logs: Type.Array(
       Type.Object({
         chainId: Type.Number(),
-        contractAddress: Type.String(),
+        contractAddress: AddressSchema,
         blockNumber: Type.Number(),
         transactionHash: Type.String(),
         topics: Type.Array(Type.String()),

--- a/src/server/routes/contract/events/getEventLogsByTimestamp.ts
+++ b/src/server/routes/contract/events/getEventLogsByTimestamp.ts
@@ -7,120 +7,120 @@ import { eventLogSchema } from "../../../schemas/eventLog";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 
 const requestQuerySchema = Type.Object({
-  contractAddresses: Type.Optional(Type.Array(AddressSchema)),
-  topics: Type.Optional(Type.Array(Type.String())),
-  fromBlockTimestamp: Type.Number(),
-  toBlockTimestamp: Type.Optional(Type.Number()),
+	contractAddresses: Type.Optional(Type.Array(AddressSchema)),
+	topics: Type.Optional(Type.Array(Type.String())),
+	fromBlockTimestamp: Type.Number(),
+	toBlockTimestamp: Type.Optional(Type.Number()),
 });
 
 const responseSchema = Type.Object({
-  result: Type.Object({
-    logs: Type.Array(eventLogSchema),
-    status: Type.String(),
-  }),
+	result: Type.Object({
+		logs: Type.Array(eventLogSchema),
+		status: Type.String(),
+	}),
 });
 
 responseSchema.example = {
-  result: {
-    logs: [
-      {
-        chainId: 1,
-        contractAddress: "0x....",
-        blockNumber: 1,
-        transactionHash: "0x...",
-        topics: ["0x..."],
-        data: "0x...",
-        eventName: "TransferFrom",
-        decodedLog: {
-          from: {
-            type: "address",
-            value: "0x...",
-          },
-          to: {
-            type: "address",
-            value: "0x...",
-          },
-          value: {
-            type: "uint256",
-            value: "1000",
-          },
-        },
-        timestamp: 100,
-        transactionIndex: 1,
-        logIndex: 1,
-      },
-    ],
-    status: "success",
-  },
+	result: {
+		logs: [
+			{
+				chainId: 1,
+				contractAddress: "0x....",
+				blockNumber: 1,
+				transactionHash: "0x...",
+				topics: ["0x..."],
+				data: "0x...",
+				eventName: "TransferFrom",
+				decodedLog: {
+					from: {
+						type: "address",
+						value: "0x...",
+					},
+					to: {
+						type: "address",
+						value: "0x...",
+					},
+					value: {
+						type: "uint256",
+						value: "1000",
+					},
+				},
+				timestamp: 100,
+				transactionIndex: 1,
+				logIndex: 1,
+			},
+		],
+		status: "success",
+	},
 };
 
 export async function getEventLogs(fastify: FastifyInstance) {
-  fastify.route<{
-    Reply: Static<typeof responseSchema>;
-    Querystring: Static<typeof requestQuerySchema>;
-  }>({
-    method: "GET",
-    url: "/contract/events/get-logs",
-    schema: {
-      summary: "Get subscribed contract event logs",
-      description: "Get event logs for a subscribed contract",
-      tags: ["Contract-Events"],
-      operationId: "getEventLogs",
-      querystring: requestQuerySchema,
-      response: {
-        ...standardResponseSchema,
-        [StatusCodes.OK]: responseSchema,
-      },
-      hide: true,
-    },
-    handler: async (request, reply) => {
-      const {
-        contractAddresses,
-        topics,
-        fromBlockTimestamp,
-        toBlockTimestamp,
-      } = request.query;
+	fastify.route<{
+		Reply: Static<typeof responseSchema>;
+		Querystring: Static<typeof requestQuerySchema>;
+	}>({
+		method: "GET",
+		url: "/contract/events/get-logs",
+		schema: {
+			summary: "Get subscribed contract event logs",
+			description: "Get event logs for a subscribed contract",
+			tags: ["Contract-Events"],
+			operationId: "getEventLogs",
+			querystring: requestQuerySchema,
+			response: {
+				...standardResponseSchema,
+				[StatusCodes.OK]: responseSchema,
+			},
+			hide: true,
+		},
+		handler: async (request, reply) => {
+			const {
+				contractAddresses,
+				topics,
+				fromBlockTimestamp,
+				toBlockTimestamp,
+			} = request.query;
 
-      const standardizedContractAddresses = contractAddresses?.map((val) =>
-        val.toLowerCase(),
-      );
+			const standardizedContractAddresses = contractAddresses?.map((val) =>
+				val.toLowerCase(),
+			);
 
-      const resultLogs = await getEventLogsByBlockTimestamp({
-        fromBlockTimestamp: fromBlockTimestamp,
-        toBlockTimestamp: toBlockTimestamp,
-        contractAddresses: standardizedContractAddresses,
-        topics: topics,
-      });
+			const resultLogs = await getEventLogsByBlockTimestamp({
+				fromBlockTimestamp: fromBlockTimestamp,
+				toBlockTimestamp: toBlockTimestamp,
+				contractAddresses: standardizedContractAddresses,
+				topics: topics,
+			});
 
-      const logs = resultLogs.map((log) => {
-        const topics: string[] = [];
-        [log.topic0, log.topic1, log.topic2, log.topic3].forEach((val) => {
-          if (val) {
-            topics.push(val);
-          }
-        });
+			const logs = resultLogs.map((log) => {
+				const topics: string[] = [];
+				[log.topic0, log.topic1, log.topic2, log.topic3].forEach((val) => {
+					if (val) {
+						topics.push(val);
+					}
+				});
 
-        return {
-          chainId: log.chainId,
-          contractAddress: log.contractAddress,
-          blockNumber: log.blockNumber,
-          transactionHash: log.transactionHash,
-          topics,
-          data: log.data,
-          eventName: log.eventName ?? undefined,
-          decodedLog: log.decodedLog,
-          timestamp: log.timestamp.getTime(),
-          transactionIndex: log.transactionIndex,
-          logIndex: log.logIndex,
-        };
-      });
+				return {
+					chainId: log.chainId,
+					contractAddress: log.contractAddress,
+					blockNumber: log.blockNumber,
+					transactionHash: log.transactionHash,
+					topics,
+					data: log.data,
+					eventName: log.eventName ?? undefined,
+					decodedLog: log.decodedLog,
+					timestamp: log.timestamp.getTime(),
+					transactionIndex: log.transactionIndex,
+					logIndex: log.logIndex,
+				};
+			});
 
-      reply.status(StatusCodes.OK).send({
-        result: {
-          logs,
-          status: "success",
-        },
-      });
-    },
-  });
+			reply.status(StatusCodes.OK).send({
+				result: {
+					logs,
+					status: "success",
+				},
+			});
+		},
+	});
 }

--- a/src/server/routes/contract/events/getEventLogsByTimestamp.ts
+++ b/src/server/routes/contract/events/getEventLogsByTimestamp.ts
@@ -7,120 +7,120 @@ import { eventLogSchema } from "../../../schemas/eventLog";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 
 const requestQuerySchema = Type.Object({
-	contractAddresses: Type.Optional(Type.Array(AddressSchema)),
-	topics: Type.Optional(Type.Array(Type.String())),
-	fromBlockTimestamp: Type.Number(),
-	toBlockTimestamp: Type.Optional(Type.Number()),
+  contractAddresses: Type.Optional(Type.Array(AddressSchema)),
+  topics: Type.Optional(Type.Array(Type.String())),
+  fromBlockTimestamp: Type.Number(),
+  toBlockTimestamp: Type.Optional(Type.Number()),
 });
 
 const responseSchema = Type.Object({
-	result: Type.Object({
-		logs: Type.Array(eventLogSchema),
-		status: Type.String(),
-	}),
+  result: Type.Object({
+    logs: Type.Array(eventLogSchema),
+    status: Type.String(),
+  }),
 });
 
 responseSchema.example = {
-	result: {
-		logs: [
-			{
-				chainId: 1,
-				contractAddress: "0x....",
-				blockNumber: 1,
-				transactionHash: "0x...",
-				topics: ["0x..."],
-				data: "0x...",
-				eventName: "TransferFrom",
-				decodedLog: {
-					from: {
-						type: "address",
-						value: "0x...",
-					},
-					to: {
-						type: "address",
-						value: "0x...",
-					},
-					value: {
-						type: "uint256",
-						value: "1000",
-					},
-				},
-				timestamp: 100,
-				transactionIndex: 1,
-				logIndex: 1,
-			},
-		],
-		status: "success",
-	},
+  result: {
+    logs: [
+      {
+        chainId: 1,
+        contractAddress: "0x....",
+        blockNumber: 1,
+        transactionHash: "0x...",
+        topics: ["0x..."],
+        data: "0x...",
+        eventName: "TransferFrom",
+        decodedLog: {
+          from: {
+            type: "address",
+            value: "0x...",
+          },
+          to: {
+            type: "address",
+            value: "0x...",
+          },
+          value: {
+            type: "uint256",
+            value: "1000",
+          },
+        },
+        timestamp: 100,
+        transactionIndex: 1,
+        logIndex: 1,
+      },
+    ],
+    status: "success",
+  },
 };
 
 export async function getEventLogs(fastify: FastifyInstance) {
-	fastify.route<{
-		Reply: Static<typeof responseSchema>;
-		Querystring: Static<typeof requestQuerySchema>;
-	}>({
-		method: "GET",
-		url: "/contract/events/get-logs",
-		schema: {
-			summary: "Get subscribed contract event logs",
-			description: "Get event logs for a subscribed contract",
-			tags: ["Contract-Events"],
-			operationId: "getEventLogs",
-			querystring: requestQuerySchema,
-			response: {
-				...standardResponseSchema,
-				[StatusCodes.OK]: responseSchema,
-			},
-			hide: true,
-		},
-		handler: async (request, reply) => {
-			const {
-				contractAddresses,
-				topics,
-				fromBlockTimestamp,
-				toBlockTimestamp,
-			} = request.query;
+  fastify.route<{
+    Reply: Static<typeof responseSchema>;
+    Querystring: Static<typeof requestQuerySchema>;
+  }>({
+    method: "GET",
+    url: "/contract/events/get-logs",
+    schema: {
+      summary: "Get subscribed contract event logs",
+      description: "Get event logs for a subscribed contract",
+      tags: ["Contract-Events"],
+      operationId: "getEventLogs",
+      querystring: requestQuerySchema,
+      response: {
+        ...standardResponseSchema,
+        [StatusCodes.OK]: responseSchema,
+      },
+      hide: true,
+    },
+    handler: async (request, reply) => {
+      const {
+        contractAddresses,
+        topics,
+        fromBlockTimestamp,
+        toBlockTimestamp,
+      } = request.query;
 
-			const standardizedContractAddresses = contractAddresses?.map((val) =>
-				val.toLowerCase(),
-			);
+      const standardizedContractAddresses = contractAddresses?.map((val) =>
+        val.toLowerCase(),
+      );
 
-			const resultLogs = await getEventLogsByBlockTimestamp({
-				fromBlockTimestamp: fromBlockTimestamp,
-				toBlockTimestamp: toBlockTimestamp,
-				contractAddresses: standardizedContractAddresses,
-				topics: topics,
-			});
+      const resultLogs = await getEventLogsByBlockTimestamp({
+        fromBlockTimestamp: fromBlockTimestamp,
+        toBlockTimestamp: toBlockTimestamp,
+        contractAddresses: standardizedContractAddresses,
+        topics: topics,
+      });
 
-			const logs = resultLogs.map((log) => {
-				const topics: string[] = [];
-				[log.topic0, log.topic1, log.topic2, log.topic3].forEach((val) => {
-					if (val) {
-						topics.push(val);
-					}
-				});
+      const logs = resultLogs.map((log) => {
+        const topics: string[] = [];
+        [log.topic0, log.topic1, log.topic2, log.topic3].forEach((val) => {
+          if (val) {
+            topics.push(val);
+          }
+        });
 
-				return {
-					chainId: log.chainId,
-					contractAddress: log.contractAddress,
-					blockNumber: log.blockNumber,
-					transactionHash: log.transactionHash,
-					topics,
-					data: log.data,
-					eventName: log.eventName ?? undefined,
-					decodedLog: log.decodedLog,
-					timestamp: log.timestamp.getTime(),
-					transactionIndex: log.transactionIndex,
-					logIndex: log.logIndex,
-				};
-			});
+        return {
+          chainId: log.chainId,
+          contractAddress: log.contractAddress,
+          blockNumber: log.blockNumber,
+          transactionHash: log.transactionHash,
+          topics,
+          data: log.data,
+          eventName: log.eventName ?? undefined,
+          decodedLog: log.decodedLog,
+          timestamp: log.timestamp.getTime(),
+          transactionIndex: log.transactionIndex,
+          logIndex: log.logIndex,
+        };
+      });
 
-			reply.status(StatusCodes.OK).send({
-				result: {
-					logs,
-					status: "success",
-				},
-			});
-		},
-	});
+      reply.status(StatusCodes.OK).send({
+        result: {
+          logs,
+          status: "success",
+        },
+      });
+    },
+  });
 }

--- a/src/server/routes/contract/events/getEventLogsByTimestamp.ts
+++ b/src/server/routes/contract/events/getEventLogsByTimestamp.ts
@@ -1,12 +1,13 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getEventLogsByBlockTimestamp } from "../../../../db/contractEventLogs/getContractEventLogs";
+import { AddressSchema } from "../../../schemas/address";
 import { eventLogSchema } from "../../../schemas/eventLog";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 
 const requestQuerySchema = Type.Object({
-  contractAddresses: Type.Optional(Type.Array(Type.String())),
+  contractAddresses: Type.Optional(Type.Array(AddressSchema)),
   topics: Type.Optional(Type.Array(Type.String())),
   fromBlockTimestamp: Type.Number(),
   toBlockTimestamp: Type.Optional(Type.Number()),

--- a/src/server/routes/contract/events/paginateEventLogs.ts
+++ b/src/server/routes/contract/events/paginateEventLogs.ts
@@ -1,8 +1,9 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getConfiguration } from "../../../../db/configuration/getConfiguration";
 import { getEventLogsByCursor } from "../../../../db/contractEventLogs/getContractEventLogs";
+import { AddressSchema } from "../../../schemas/address";
 import { eventLogSchema, toEventLogSchema } from "../../../schemas/eventLog";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 
@@ -10,7 +11,7 @@ const requestQuerySchema = Type.Object({
   cursor: Type.Optional(Type.String()),
   pageSize: Type.Optional(Type.Number()),
   topics: Type.Optional(Type.Array(Type.String())),
-  contractAddresses: Type.Optional(Type.Array(Type.String())),
+  contractAddresses: Type.Optional(Type.Array(AddressSchema)),
 });
 
 const responseSchema = Type.Object({

--- a/src/server/routes/contract/extensions/account/write/grantAdmin.ts
+++ b/src/server/routes/contract/extensions/account/write/grantAdmin.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   contractParamSchema,
   requestQuerystringSchema,
@@ -14,9 +15,10 @@ import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
 
 const requestBodySchema = Type.Object({
-  signerAddress: Type.String({
+  signerAddress: {
+    ...AddressSchema,
     description: "Address to grant admin permissions to",
-  }),
+  },
   ...txOverridesWithValueSchema.properties,
 });
 

--- a/src/server/routes/contract/extensions/account/write/revokeAdmin.ts
+++ b/src/server/routes/contract/extensions/account/write/revokeAdmin.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   contractParamSchema,
   requestQuerystringSchema,
@@ -14,9 +15,10 @@ import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
 
 const requestBodySchema = Type.Object({
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "Address to revoke admin permissions from",
-  }),
+  },
   ...txOverridesWithValueSchema.properties,
 });
 

--- a/src/server/routes/contract/extensions/account/write/revokeSession.ts
+++ b/src/server/routes/contract/extensions/account/write/revokeSession.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   contractParamSchema,
   requestQuerystringSchema,
@@ -14,9 +15,10 @@ import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
 
 const requestBodySchema = Type.Object({
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "Address to revoke session from",
-  }),
+  },
   ...txOverridesWithValueSchema.properties,
 });
 

--- a/src/server/routes/contract/extensions/account/write/updateSession.ts
+++ b/src/server/routes/contract/extensions/account/write/updateSession.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   contractParamSchema,
   requestQuerystringSchema,
@@ -14,8 +15,8 @@ import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
 
 const requestBodySchema = Type.Object({
-  signerAddress: Type.String(),
-  approvedCallTargets: Type.Array(Type.String()),
+  signerAddress: AddressSchema,
+  approvedCallTargets: Type.Array(AddressSchema),
   startDate: Type.Optional(Type.String()),
   expirationDate: Type.Optional(Type.String()),
   nativeTokenLimitPerTransaction: Type.Optional(Type.String()),

--- a/src/server/routes/contract/extensions/accountFactory/read/getAssociatedAccounts.ts
+++ b/src/server/routes/contract/extensions/accountFactory/read/getAssociatedAccounts.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   contractParamSchema,
   standardResponseSchema,
@@ -16,9 +17,10 @@ const responseBodySchema = Type.Object({
 });
 
 const QuerySchema = Type.Object({
-  signerAddress: Type.String({
+  signerAddress: {
+    ...AddressSchema,
     description: "The address of the signer to get associated accounts from",
-  }),
+  },
 });
 
 export const getAssociatedAccounts = async (fastify: FastifyInstance) => {

--- a/src/server/routes/contract/extensions/accountFactory/read/isAccountDeployed.ts
+++ b/src/server/routes/contract/extensions/accountFactory/read/isAccountDeployed.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   contractParamSchema,
   standardResponseSchema,
@@ -15,10 +16,11 @@ const responseBodySchema = Type.Object({
 });
 
 const QuerySchema = Type.Object({
-  adminAddress: Type.String({
+  adminAddress: {
+    ...AddressSchema,
     description:
       "The address of the admin to check if the account address is deployed",
-  }),
+  },
   extraData: Type.Optional(
     Type.String({
       description: "Extra data to use in predicting the account address",

--- a/src/server/routes/contract/extensions/accountFactory/read/predictAccountAddress.ts
+++ b/src/server/routes/contract/extensions/accountFactory/read/predictAccountAddress.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   contractParamSchema,
   standardResponseSchema,
@@ -15,9 +16,10 @@ const responseBodySchema = Type.Object({
 });
 
 const QuerySchema = Type.Object({
-  adminAddress: Type.String({
+  adminAddress: {
+    ...AddressSchema,
     description: "The address of the admin to predict the account address for",
-  }),
+  },
   extraData: Type.Optional(
     Type.String({
       description: "Extra data to add to use in predicting the account address",

--- a/src/server/routes/contract/extensions/erc1155/read/balanceOf.ts
+++ b/src/server/routes/contract/extensions/erc1155/read/balanceOf.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from "http-status-codes";
 
 import { Static, Type } from "@sinclair/typebox";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc1155ContractParamSchema,
   standardResponseSchema,
@@ -12,10 +13,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUTS
 const requestSchema = erc1155ContractParamSchema;
 const querystringSchema = Type.Object({
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "Address of the wallet to check NFT balance",
-    examples: ["0x1946267d81Fb8aDeeEa28e6B98bcD446c8248473"],
-  }),
+  },
   tokenId: Type.String({
     description: "The tokenId of the NFT to check balance of",
     examples: ["0"],

--- a/src/server/routes/contract/extensions/erc1155/read/getClaimerProofs.ts
+++ b/src/server/routes/contract/extensions/erc1155/read/getClaimerProofs.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import { claimerProofSchema } from "../../../../../schemas/claimConditions";
 import {
   contractParamSchema,
@@ -16,9 +17,10 @@ const requestQueryString = Type.Object({
     description:
       "The token ID of the NFT you want to get the claimer proofs for.",
   }),
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "The wallet address to get the merkle proofs for.",
-  }),
+  },
 });
 
 // OUTPUT

--- a/src/server/routes/contract/extensions/erc1155/read/getOwned.ts
+++ b/src/server/routes/contract/extensions/erc1155/read/getOwned.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import { nftSchema } from "../../../../../schemas/nft";
 import {
   erc1155ContractParamSchema,
@@ -12,10 +13,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUT
 const requestSchema = erc1155ContractParamSchema;
 const querystringSchema = Type.Object({
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "Address of the wallet to get NFTs for",
-    examples: ["0x1946267d81Fb8aDeeEa28e6B98bcD446c8248473"],
-  }),
+  },
 });
 
 // OUTPUT

--- a/src/server/routes/contract/extensions/erc1155/write/airdrop.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/airdrop.ts
@@ -1,8 +1,9 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc1155ContractParamSchema,
   requestQuerystringSchema,
@@ -21,7 +22,7 @@ const requestBodySchema = Type.Object({
   }),
   addresses: Type.Array(
     Type.Object({
-      address: Type.String(),
+      address: AddressSchema,
       quantity: Type.String({
         default: "1",
       }),

--- a/src/server/routes/contract/extensions/erc20/read/balanceOf.ts
+++ b/src/server/routes/contract/extensions/erc20/read/balanceOf.ts
@@ -1,8 +1,8 @@
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-
-import { Static, Type } from "@sinclair/typebox";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import { erc20MetadataSchema } from "../../../../../schemas/erc20";
 import {
   erc20ContractParamSchema,
@@ -13,10 +13,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUTS
 const requestSchema = erc20ContractParamSchema;
 const querystringSchema = Type.Object({
-  wallet_address: Type.String({
+  wallet_address: {
+    ...AddressSchema,
     description: "Address of the wallet to check token balance",
-    examples: ["0x1946267d81Fb8aDeeEa28e6B98bcD446c8248473"],
-  }),
+  },
 });
 
 // OUTPUT

--- a/src/server/routes/contract/extensions/erc20/read/getClaimerProofs.ts
+++ b/src/server/routes/contract/extensions/erc20/read/getClaimerProofs.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import { claimerProofSchema } from "../../../../../schemas/claimConditions";
 import {
   contractParamSchema,
@@ -12,9 +13,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUT
 const requestSchema = contractParamSchema;
 const requestQueryString = Type.Object({
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "The wallet address to get the merkle proofs for.",
-  }),
+  },
 });
 
 // OUTPUT

--- a/src/server/routes/contract/extensions/erc20/write/burnFrom.ts
+++ b/src/server/routes/contract/extensions/erc20/write/burnFrom.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc20ContractParamSchema,
   requestQuerystringSchema,
@@ -16,9 +17,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUTS
 const requestSchema = erc20ContractParamSchema;
 const requestBodySchema = Type.Object({
-  holderAddress: Type.String({
+  holderAddress: {
+    ...AddressSchema,
     description: "Address of the wallet sending the tokens",
-  }),
+  },
   amount: Type.String({
     description: "The amount of this token you want to burn",
   }),

--- a/src/server/routes/contract/extensions/erc20/write/mintBatchTo.ts
+++ b/src/server/routes/contract/extensions/erc20/write/mintBatchTo.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc20ContractParamSchema,
   requestQuerystringSchema,
@@ -18,9 +19,10 @@ const requestSchema = erc20ContractParamSchema;
 const requestBodySchema = Type.Object({
   data: Type.Array(
     Type.Object({
-      toAddress: Type.String({
+      toAddress: {
+        ...AddressSchema,
         description: "The address to mint tokens to",
-      }),
+      },
       amount: Type.String({
         description: "The number of tokens to mint to the specific address.",
       }),

--- a/src/server/routes/contract/extensions/erc20/write/mintTo.ts
+++ b/src/server/routes/contract/extensions/erc20/write/mintTo.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc20ContractParamSchema,
   requestQuerystringSchema,
@@ -16,9 +17,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUTS
 const requestSchema = erc20ContractParamSchema;
 const requestBodySchema = Type.Object({
-  toAddress: Type.String({
+  toAddress: {
+    ...AddressSchema,
     description: "Address of the wallet to mint tokens to",
-  }),
+  },
   amount: Type.String({
     description: "The amount of tokens you want to send",
   }),

--- a/src/server/routes/contract/extensions/erc20/write/setAllowance.ts
+++ b/src/server/routes/contract/extensions/erc20/write/setAllowance.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc20ContractParamSchema,
   requestQuerystringSchema,
@@ -16,9 +17,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUTS
 const requestSchema = erc20ContractParamSchema;
 const requestBodySchema = Type.Object({
-  spenderAddress: Type.String({
+  spenderAddress: {
+    ...AddressSchema,
     description: "Address of the wallet to allow transfers from",
-  }),
+  },
   amount: Type.String({
     description: "The number of tokens to give as allowance",
   }),

--- a/src/server/routes/contract/extensions/erc20/write/transfer.ts
+++ b/src/server/routes/contract/extensions/erc20/write/transfer.ts
@@ -4,6 +4,7 @@ import { StatusCodes } from "http-status-codes";
 
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc20ContractParamSchema,
   requestQuerystringSchema,
@@ -17,9 +18,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUTS
 const requestSchema = erc20ContractParamSchema;
 const requestBodySchema = Type.Object({
-  toAddress: Type.String({
+  toAddress: {
+    ...AddressSchema,
     description: "Address of the wallet you want to send the tokens to",
-  }),
+  },
   amount: Type.String({
     description: "The amount of tokens you want to send",
   }),

--- a/src/server/routes/contract/extensions/erc20/write/transferFrom.ts
+++ b/src/server/routes/contract/extensions/erc20/write/transferFrom.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc20ContractParamSchema,
   requestQuerystringSchema,
@@ -16,12 +17,14 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUTS
 const requestSchema = erc20ContractParamSchema;
 const requestBodySchema = Type.Object({
-  fromAddress: Type.String({
+  fromAddress: {
+    ...AddressSchema,
     description: "Address of the wallet sending the tokens",
-  }),
-  toAddress: Type.String({
+  },
+  toAddress: {
+    ...AddressSchema,
     description: "Address of the wallet you want to send the tokens to",
-  }),
+  },
   amount: Type.String({
     description: "The amount of tokens you want to send",
   }),

--- a/src/server/routes/contract/extensions/erc721/read/balanceOf.ts
+++ b/src/server/routes/contract/extensions/erc721/read/balanceOf.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from "http-status-codes";
 
 import { Static, Type } from "@sinclair/typebox";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc721ContractParamSchema,
   standardResponseSchema,
@@ -12,10 +13,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUTS
 const requestSchema = erc721ContractParamSchema;
 const querystringSchema = Type.Object({
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "Address of the wallet to check NFT balance",
-    examples: ["0x1946267d81Fb8aDeeEa28e6B98bcD446c8248473"],
-  }),
+  },
 });
 
 // OUTPUT

--- a/src/server/routes/contract/extensions/erc721/read/getClaimerProofs.ts
+++ b/src/server/routes/contract/extensions/erc721/read/getClaimerProofs.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import { claimerProofSchema } from "../../../../../schemas/claimConditions";
 import {
   contractParamSchema,
@@ -12,9 +13,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUT
 const requestSchema = contractParamSchema;
 const requestQueryString = Type.Object({
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "The wallet address to get the merkle proofs for.",
-  }),
+  },
 });
 
 // OUTPUT

--- a/src/server/routes/contract/extensions/erc721/read/getOwned.ts
+++ b/src/server/routes/contract/extensions/erc721/read/getOwned.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../schemas/address";
 import { nftSchema } from "../../../../../schemas/nft";
 import {
   contractParamSchema,
@@ -12,10 +13,10 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUT
 const requestSchema = contractParamSchema;
 const querystringSchema = Type.Object({
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "Address of the wallet to get NFTs for",
-    examples: ["0x1946267d81Fb8aDeeEa28e6B98bcD446c8248473"],
-  }),
+  },
 });
 
 // OUTPUT

--- a/src/server/routes/contract/extensions/marketplaceV3/directListings/read/isBuyerApprovedForListing.ts
+++ b/src/server/routes/contract/extensions/marketplaceV3/directListings/read/isBuyerApprovedForListing.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../../schemas/address";
 import {
   marketplaceV3ContractParamSchema,
   standardResponseSchema,
@@ -14,9 +15,10 @@ const requestQuerySchema = Type.Object({
   listingId: Type.String({
     description: "The id of the listing to retrieve.",
   }),
-  walletAddress: Type.String({
+  walletAddress: {
+    ...AddressSchema,
     description: "The wallet address of the buyer to check.",
-  }),
+  },
 });
 
 // OUTPUT

--- a/src/server/routes/contract/extensions/marketplaceV3/directListings/read/isCurrencyApprovedForListing.ts
+++ b/src/server/routes/contract/extensions/marketplaceV3/directListings/read/isCurrencyApprovedForListing.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../../schemas/address";
 import {
   marketplaceV3ContractParamSchema,
   standardResponseSchema,
@@ -14,9 +15,10 @@ const requestQuerySchema = Type.Object({
   listingId: Type.String({
     description: "The id of the listing to retrieve.",
   }),
-  currencyContractAddress: Type.String({
+  currencyContractAddress: {
+    ...AddressSchema,
     description: "The smart contract address of the ERC20 token to check.",
-  }),
+  },
 });
 
 // OUTPUT

--- a/src/server/routes/contract/extensions/marketplaceV3/directListings/write/revokeBuyerApprovalForReservedListing.ts
+++ b/src/server/routes/contract/extensions/marketplaceV3/directListings/write/revokeBuyerApprovalForReservedListing.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../../schemas/address";
 import {
   marketplaceV3ContractParamSchema,
   requestQuerystringSchema,
@@ -19,9 +20,10 @@ const requestBodySchema = Type.Object({
   listingId: Type.String({
     description: "The ID of the listing you want to approve a buyer for.",
   }),
-  buyerAddress: Type.String({
+  buyerAddress: {
+    ...AddressSchema,
     description: "The wallet address of the buyer to approve.",
-  }),
+  },
   ...txOverridesWithValueSchema.properties,
 });
 

--- a/src/server/routes/contract/extensions/marketplaceV3/directListings/write/revokeCurrencyApprovalForListing.ts
+++ b/src/server/routes/contract/extensions/marketplaceV3/directListings/write/revokeCurrencyApprovalForListing.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../../../schemas/address";
 import {
   marketplaceV3ContractParamSchema,
   requestQuerystringSchema,
@@ -19,9 +20,10 @@ const requestBodySchema = Type.Object({
   listingId: Type.String({
     description: "The ID of the listing you want to approve a buyer for.",
   }),
-  currencyContractAddress: Type.String({
+  currencyContractAddress: {
+    ...AddressSchema,
     description: "The wallet address of the buyer to approve.",
-  }),
+  },
   ...txOverridesWithValueSchema.properties,
 });
 

--- a/src/server/routes/contract/roles/write/grant.ts
+++ b/src/server/routes/contract/roles/write/grant.ts
@@ -1,13 +1,14 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../schemas/address";
 import {
-  contractParamSchema,
-  requestQuerystringSchema,
-  standardResponseSchema,
-  transactionWritesResponseSchema,
+	contractParamSchema,
+	requestQuerystringSchema,
+	standardResponseSchema,
+	transactionWritesResponseSchema,
 } from "../../../../schemas/sharedApiSchemas";
 import { txOverridesWithValueSchema } from "../../../../schemas/txOverrides";
 import { walletWithAAHeaderSchema } from "../../../../schemas/wallet";
@@ -16,74 +17,75 @@ import { getChainIdFromChain } from "../../../../utils/chain";
 // INPUTS
 const requestSchema = contractParamSchema;
 const requestBodySchema = Type.Object({
-  role: Type.String({
-    description: "The role to grant",
-  }),
-  address: Type.String({
-    description: "The address to grant the role to",
-  }),
-  ...txOverridesWithValueSchema.properties,
+	role: Type.String({
+		description: "The role to grant",
+	}),
+	address: {
+		...AddressSchema,
+		description: "The address to grant the role to",
+	},
+	...txOverridesWithValueSchema.properties,
 });
 
 // OUTPUT
 const responseSchema = transactionWritesResponseSchema;
 
 export async function grantRole(fastify: FastifyInstance) {
-  fastify.route<{
-    Params: Static<typeof requestSchema>;
-    Reply: Static<typeof responseSchema>;
-    Body: Static<typeof requestBodySchema>;
-    Querystring: Static<typeof requestQuerystringSchema>;
-  }>({
-    method: "POST",
-    url: "/contract/:chain/:contractAddress/roles/grant",
-    schema: {
-      summary: "Grant role",
-      description: "Grant a role to a specific wallet.",
-      tags: ["Contract-Roles"],
-      operationId: "grant",
-      headers: walletWithAAHeaderSchema,
-      params: requestSchema,
-      body: requestBodySchema,
-      querystring: requestQuerystringSchema,
-      response: {
-        ...standardResponseSchema,
-        [StatusCodes.OK]: responseSchema,
-      },
-    },
-    handler: async (request, reply) => {
-      const { chain, contractAddress } = request.params;
-      const { simulateTx } = request.query;
-      const { role, address, txOverrides } = request.body;
-      const {
-        "x-backend-wallet-address": walletAddress,
-        "x-account-address": accountAddress,
-        "x-idempotency-key": idempotencyKey,
-      } = request.headers as Static<typeof walletWithAAHeaderSchema>;
+	fastify.route<{
+		Params: Static<typeof requestSchema>;
+		Reply: Static<typeof responseSchema>;
+		Body: Static<typeof requestBodySchema>;
+		Querystring: Static<typeof requestQuerystringSchema>;
+	}>({
+		method: "POST",
+		url: "/contract/:chain/:contractAddress/roles/grant",
+		schema: {
+			summary: "Grant role",
+			description: "Grant a role to a specific wallet.",
+			tags: ["Contract-Roles"],
+			operationId: "grant",
+			headers: walletWithAAHeaderSchema,
+			params: requestSchema,
+			body: requestBodySchema,
+			querystring: requestQuerystringSchema,
+			response: {
+				...standardResponseSchema,
+				[StatusCodes.OK]: responseSchema,
+			},
+		},
+		handler: async (request, reply) => {
+			const { chain, contractAddress } = request.params;
+			const { simulateTx } = request.query;
+			const { role, address, txOverrides } = request.body;
+			const {
+				"x-backend-wallet-address": walletAddress,
+				"x-account-address": accountAddress,
+				"x-idempotency-key": idempotencyKey,
+			} = request.headers as Static<typeof walletWithAAHeaderSchema>;
 
-      const chainId = await getChainIdFromChain(chain);
-      const contract = await getContract({
-        chainId,
-        contractAddress,
-        walletAddress,
-        accountAddress,
-      });
-      const tx = await contract.roles.grant.prepare(role, address);
+			const chainId = await getChainIdFromChain(chain);
+			const contract = await getContract({
+				chainId,
+				contractAddress,
+				walletAddress,
+				accountAddress,
+			});
+			const tx = await contract.roles.grant.prepare(role, address);
 
-      const queueId = await queueTx({
-        tx,
-        chainId,
-        simulateTx,
-        extension: "roles",
-        idempotencyKey,
-        txOverrides,
-      });
+			const queueId = await queueTx({
+				tx,
+				chainId,
+				simulateTx,
+				extension: "roles",
+				idempotencyKey,
+				txOverrides,
+			});
 
-      reply.status(StatusCodes.OK).send({
-        result: {
-          queueId,
-        },
-      });
-    },
-  });
+			reply.status(StatusCodes.OK).send({
+				result: {
+					queueId,
+				},
+			});
+		},
+	});
 }

--- a/src/server/routes/contract/roles/write/grant.ts
+++ b/src/server/routes/contract/roles/write/grant.ts
@@ -5,10 +5,10 @@ import { queueTx } from "../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../utils/cache/getContract";
 import { AddressSchema } from "../../../../schemas/address";
 import {
-	contractParamSchema,
-	requestQuerystringSchema,
-	standardResponseSchema,
-	transactionWritesResponseSchema,
+  contractParamSchema,
+  requestQuerystringSchema,
+  standardResponseSchema,
+  transactionWritesResponseSchema,
 } from "../../../../schemas/sharedApiSchemas";
 import { txOverridesWithValueSchema } from "../../../../schemas/txOverrides";
 import { walletWithAAHeaderSchema } from "../../../../schemas/wallet";
@@ -17,75 +17,75 @@ import { getChainIdFromChain } from "../../../../utils/chain";
 // INPUTS
 const requestSchema = contractParamSchema;
 const requestBodySchema = Type.Object({
-	role: Type.String({
-		description: "The role to grant",
-	}),
-	address: {
-		...AddressSchema,
-		description: "The address to grant the role to",
-	},
-	...txOverridesWithValueSchema.properties,
+  role: Type.String({
+    description: "The role to grant",
+  }),
+  address: {
+    ...AddressSchema,
+    description: "The address to grant the role to",
+  },
+  ...txOverridesWithValueSchema.properties,
 });
 
 // OUTPUT
 const responseSchema = transactionWritesResponseSchema;
 
 export async function grantRole(fastify: FastifyInstance) {
-	fastify.route<{
-		Params: Static<typeof requestSchema>;
-		Reply: Static<typeof responseSchema>;
-		Body: Static<typeof requestBodySchema>;
-		Querystring: Static<typeof requestQuerystringSchema>;
-	}>({
-		method: "POST",
-		url: "/contract/:chain/:contractAddress/roles/grant",
-		schema: {
-			summary: "Grant role",
-			description: "Grant a role to a specific wallet.",
-			tags: ["Contract-Roles"],
-			operationId: "grant",
-			headers: walletWithAAHeaderSchema,
-			params: requestSchema,
-			body: requestBodySchema,
-			querystring: requestQuerystringSchema,
-			response: {
-				...standardResponseSchema,
-				[StatusCodes.OK]: responseSchema,
-			},
-		},
-		handler: async (request, reply) => {
-			const { chain, contractAddress } = request.params;
-			const { simulateTx } = request.query;
-			const { role, address, txOverrides } = request.body;
-			const {
-				"x-backend-wallet-address": walletAddress,
-				"x-account-address": accountAddress,
-				"x-idempotency-key": idempotencyKey,
-			} = request.headers as Static<typeof walletWithAAHeaderSchema>;
+  fastify.route<{
+    Params: Static<typeof requestSchema>;
+    Reply: Static<typeof responseSchema>;
+    Body: Static<typeof requestBodySchema>;
+    Querystring: Static<typeof requestQuerystringSchema>;
+  }>({
+    method: "POST",
+    url: "/contract/:chain/:contractAddress/roles/grant",
+    schema: {
+      summary: "Grant role",
+      description: "Grant a role to a specific wallet.",
+      tags: ["Contract-Roles"],
+      operationId: "grant",
+      headers: walletWithAAHeaderSchema,
+      params: requestSchema,
+      body: requestBodySchema,
+      querystring: requestQuerystringSchema,
+      response: {
+        ...standardResponseSchema,
+        [StatusCodes.OK]: responseSchema,
+      },
+    },
+    handler: async (request, reply) => {
+      const { chain, contractAddress } = request.params;
+      const { simulateTx } = request.query;
+      const { role, address, txOverrides } = request.body;
+      const {
+        "x-backend-wallet-address": walletAddress,
+        "x-account-address": accountAddress,
+        "x-idempotency-key": idempotencyKey,
+      } = request.headers as Static<typeof walletWithAAHeaderSchema>;
 
-			const chainId = await getChainIdFromChain(chain);
-			const contract = await getContract({
-				chainId,
-				contractAddress,
-				walletAddress,
-				accountAddress,
-			});
-			const tx = await contract.roles.grant.prepare(role, address);
+      const chainId = await getChainIdFromChain(chain);
+      const contract = await getContract({
+        chainId,
+        contractAddress,
+        walletAddress,
+        accountAddress,
+      });
+      const tx = await contract.roles.grant.prepare(role, address);
 
-			const queueId = await queueTx({
-				tx,
-				chainId,
-				simulateTx,
-				extension: "roles",
-				idempotencyKey,
-				txOverrides,
-			});
+      const queueId = await queueTx({
+        tx,
+        chainId,
+        simulateTx,
+        extension: "roles",
+        idempotencyKey,
+        txOverrides,
+      });
 
-			reply.status(StatusCodes.OK).send({
-				result: {
-					queueId,
-				},
-			});
-		},
-	});
+      reply.status(StatusCodes.OK).send({
+        result: {
+          queueId,
+        },
+      });
+    },
+  });
 }

--- a/src/server/routes/contract/roles/write/revoke.ts
+++ b/src/server/routes/contract/roles/write/revoke.ts
@@ -1,8 +1,9 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { queueTx } from "../../../../../db/transactions/queueTx";
 import { getContract } from "../../../../../utils/cache/getContract";
+import { AddressSchema } from "../../../../schemas/address";
 import {
   contractParamSchema,
   requestQuerystringSchema,
@@ -19,9 +20,10 @@ const requestBodySchema = Type.Object({
   role: Type.String({
     description: "The role to revoke",
   }),
-  address: Type.String({
+  address: {
+    ...AddressSchema,
     description: "The address to revoke the role from",
-  }),
+  },
   ...txOverridesWithValueSchema.properties,
 });
 

--- a/src/server/routes/contract/subscriptions/addContractSubscription.ts
+++ b/src/server/routes/contract/subscriptions/addContractSubscription.ts
@@ -12,6 +12,7 @@ import { getSdk } from "../../../../utils/cache/getSdk";
 import { getChain } from "../../../../utils/chain";
 import { thirdwebClient } from "../../../../utils/sdk";
 import { createCustomError } from "../../../middleware/error";
+import { AddressSchema } from "../../../schemas/address";
 import {
   contractSubscriptionSchema,
   toContractSubscriptionSchema,
@@ -24,9 +25,10 @@ const bodySchema = Type.Object({
   chain: Type.String({
     description: "The chain for the contract.",
   }),
-  contractAddress: Type.String({
+  contractAddress: {
+    ...AddressSchema,
     description: "The address for the contract.",
-  }),
+  },
   webhookUrl: Type.Optional(
     Type.String({
       description: "Webhook URL",

--- a/src/server/routes/contract/subscriptions/getContractIndexedBlockRange.ts
+++ b/src/server/routes/contract/subscriptions/getContractIndexedBlockRange.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContractEventLogsIndexedBlockRange } from "../../../../db/contractEventLogs/getContractEventLogs";
 import { createCustomError } from "../../../middleware/error";
+import { AddressSchema } from "../../../schemas/address";
 import {
   contractParamSchema,
   standardResponseSchema,
@@ -12,7 +13,7 @@ import { getChainIdFromChain } from "../../../utils/chain";
 const responseSchema = Type.Object({
   result: Type.Object({
     chain: Type.String(),
-    contractAddress: Type.String(),
+    contractAddress: AddressSchema,
     fromBlock: Type.Number(),
     toBlock: Type.Number(),
     status: Type.String(),

--- a/src/server/routes/contract/transactions/getTransactionReceiptsByTimestamp.ts
+++ b/src/server/routes/contract/transactions/getTransactionReceiptsByTimestamp.ts
@@ -1,12 +1,13 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getTransactionReceiptsByBlockTimestamp } from "../../../../db/contractTransactionReceipts/getContractTransactionReceipts";
+import { AddressSchema } from "../../../schemas/address";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 import { transactionReceiptSchema } from "../../../schemas/transactionReceipt";
 
 const requestQuerySchema = Type.Object({
-  contractAddresses: Type.Optional(Type.Array(Type.String())),
+  contractAddresses: Type.Optional(Type.Array(AddressSchema)),
   fromBlockTimestamp: Type.Number(),
   toBlockTimestamp: Type.Optional(Type.Number()),
 });

--- a/src/server/routes/contract/transactions/paginateTransactionReceipts.ts
+++ b/src/server/routes/contract/transactions/paginateTransactionReceipts.ts
@@ -1,8 +1,9 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getConfiguration } from "../../../../db/configuration/getConfiguration";
 import { getTransactionReceiptsByCursor } from "../../../../db/contractTransactionReceipts/getContractTransactionReceipts";
+import { AddressSchema } from "../../../schemas/address";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 import {
   toTransactionReceiptSchema,
@@ -14,7 +15,7 @@ import {
 const requestQuerySchema = Type.Object({
   cursor: Type.Optional(Type.String()),
   pageSize: Type.Optional(Type.Number()),
-  contractAddresses: Type.Optional(Type.Array(Type.String())),
+  contractAddresses: Type.Optional(Type.Array(AddressSchema)),
 });
 
 const responseSchema = Type.Object({

--- a/src/server/routes/deploy/prebuilt.ts
+++ b/src/server/routes/deploy/prebuilt.ts
@@ -4,6 +4,7 @@ import { StatusCodes } from "http-status-codes";
 import { Address } from "thirdweb";
 import { queueTx } from "../../../db/transactions/queueTx";
 import { getSdk } from "../../../utils/cache/getSdk";
+import { AddressSchema } from "../../schemas/address";
 import { contractDeployBasicSchema } from "../../schemas/contract";
 import {
   prebuiltDeployParamSchema,
@@ -42,7 +43,7 @@ requestBodySchema.examples = [
 // OUTPUT
 const responseSchema = Type.Object({
   queueId: Type.Optional(Type.String()),
-  deployedAddress: Type.Optional(Type.String()),
+  deployedAddress: Type.Optional(AddressSchema),
 });
 
 export async function deployPrebuilt(fastify: FastifyInstance) {

--- a/src/server/routes/relayer/create.ts
+++ b/src/server/routes/relayer/create.ts
@@ -9,10 +9,11 @@ import { getChainIdFromChain } from "../../utils/chain";
 const requestBodySchema = Type.Object({
   name: Type.Optional(Type.String()),
   chain: Type.String(),
-  backendWalletAddress: Type.String({
+  backendWalletAddress: {
+    ...AddressSchema,
     description:
       "The address of the backend wallet to use for relaying transactions.",
-  }),
+  },
   allowedContracts: Type.Optional(Type.Array(AddressSchema)),
   allowedForwarders: Type.Optional(Type.Array(AddressSchema)),
 });

--- a/src/server/routes/relayer/getAll.ts
+++ b/src/server/routes/relayer/getAll.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { prisma } from "../../../db/client";
+import { AddressSchema } from "../../schemas/address";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 
 const responseBodySchema = Type.Object({
@@ -10,7 +11,7 @@ const responseBodySchema = Type.Object({
       id: Type.String(),
       name: Type.Union([Type.String(), Type.Null()]),
       chainId: Type.String(),
-      backendWalletAddress: Type.String(),
+      backendWalletAddress: AddressSchema,
       allowedContracts: Type.Union([Type.Array(Type.String()), Type.Null()]),
       allowedForwarders: Type.Union([Type.Array(Type.String()), Type.Null()]),
     }),

--- a/src/server/routes/relayer/index.ts
+++ b/src/server/routes/relayer/index.ts
@@ -12,6 +12,7 @@ import {
 import { getRelayerById } from "../../../db/relayer/getRelayerById";
 import { queueTx } from "../../../db/transactions/queueTx";
 import { getSdk } from "../../../utils/cache/getSdk";
+import { AddressSchema } from "../../schemas/address";
 import {
   standardResponseSchema,
   transactionWritesResponseSchema,
@@ -34,7 +35,7 @@ const requestBodySchema = Type.Union([
       chainid: Type.Optional(Type.String()),
     }),
     signature: Type.String(),
-    forwarderAddress: Type.String(),
+    forwarderAddress: AddressSchema,
   }),
   Type.Object({
     type: Type.Literal("permit"),

--- a/src/server/routes/relayer/update.ts
+++ b/src/server/routes/relayer/update.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { prisma } from "../../../db/client";
+import { AddressSchema } from "../../schemas/address";
 import { standardResponseSchema } from "../../schemas/sharedApiSchemas";
 import { getChainIdFromChain } from "../../utils/chain";
 
@@ -9,7 +10,7 @@ const requestBodySchema = Type.Object({
   id: Type.String(),
   name: Type.Optional(Type.String()),
   chain: Type.Optional(Type.String()),
-  backendWalletAddress: Type.Optional(Type.String()),
+  backendWalletAddress: Type.Optional(AddressSchema),
   allowedContracts: Type.Optional(Type.Array(Type.String())),
   allowedForwarders: Type.Optional(Type.Array(Type.String())),
 });

--- a/src/server/routes/transaction/blockchain/getTxReceipt.ts
+++ b/src/server/routes/transaction/blockchain/getTxReceipt.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getSdk } from "../../../../utils/cache/getSdk";
+import { AddressSchema } from "../../../schemas/address";
 import { standardResponseSchema } from "../../../schemas/sharedApiSchemas";
 import { getChainIdFromChain } from "../../../utils/chain";
 
@@ -27,7 +28,7 @@ export const responseBodySchema = Type.Object({
       Type.Object({
         to: Type.String(),
         from: Type.String(),
-        contractAddress: Type.Union([Type.String(), Type.Null()]),
+        contractAddress: Type.Union([AddressSchema, Type.Null()]),
         transactionIndex: Type.Number(),
         root: Type.String(),
         gasUsed: Type.String(),

--- a/src/server/schemas/account/index.ts
+++ b/src/server/schemas/account/index.ts
@@ -1,7 +1,8 @@
 import { Type } from "@sinclair/typebox";
+import { AddressSchema } from "../address";
 
 export const sessionSchema = Type.Object({
-  signerAddress: Type.String(),
+  signerAddress: AddressSchema,
   startDate: Type.String(),
   expirationDate: Type.String(),
   nativeTokenLimitPerTransaction: Type.String(),

--- a/src/server/schemas/claimConditions/index.ts
+++ b/src/server/schemas/claimConditions/index.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { AddressSchema } from "../address";
 import { currencyValueSchema } from "../sharedApiSchemas";
 
 export const claimConditionInputSchema = Type.Object({
@@ -12,7 +13,7 @@ export const claimConditionInputSchema = Type.Object({
     ]),
   ),
   price: Type.Optional(Type.Union([Type.Number(), Type.String()])),
-  currencyAddress: Type.Optional(Type.String()),
+  currencyAddress: Type.Optional(AddressSchema),
   maxClaimablePerWallet: Type.Optional(
     Type.Union([Type.Number(), Type.String()]),
   ),
@@ -31,7 +32,7 @@ export const claimConditionInputSchema = Type.Object({
       Type.Array(
         Type.Object({
           price: Type.Optional(Type.Union([Type.String(), Type.Number()])),
-          currencyAddress: Type.Optional(Type.String()),
+          currencyAddress: Type.Optional(AddressSchema),
           address: Type.String(),
           maxClaimable: Type.Optional(
             Type.Union([Type.String(), Type.Number()]),
@@ -54,7 +55,7 @@ export const claimConditionOutputSchema = Type.Object({
     format: "date-time",
   }),
   price: Type.Optional(Type.Union([Type.Number(), Type.String()])),
-  currencyAddress: Type.Optional(Type.String()),
+  currencyAddress: Type.Optional(AddressSchema),
   maxClaimablePerWallet: Type.Optional(
     Type.Union([Type.Number(), Type.String()]),
   ),
@@ -75,7 +76,7 @@ export const claimConditionOutputSchema = Type.Object({
       Type.Array(
         Type.Object({
           price: Type.Optional(Type.Union([Type.String(), Type.Number()])),
-          currencyAddress: Type.Optional(Type.String()),
+          currencyAddress: Type.Optional(AddressSchema),
           address: Type.String(),
           maxClaimable: Type.Optional(
             Type.Union([Type.String(), Type.Number()]),
@@ -90,7 +91,7 @@ export const claimerProofSchema = Type.Union([
   Type.Null(),
   Type.Object({
     price: Type.Optional(Type.String()),
-    currencyAddress: Type.Optional(Type.String()),
+    currencyAddress: Type.Optional(AddressSchema),
     address: Type.String(),
     maxClaimable: Type.String(),
     proof: Type.Array(Type.String()),

--- a/src/server/schemas/claimConditions/index.ts
+++ b/src/server/schemas/claimConditions/index.ts
@@ -33,7 +33,7 @@ export const claimConditionInputSchema = Type.Object({
         Type.Object({
           price: Type.Optional(Type.Union([Type.String(), Type.Number()])),
           currencyAddress: Type.Optional(AddressSchema),
-          address: Type.String(),
+          address: AddressSchema,
           maxClaimable: Type.Optional(
             Type.Union([Type.String(), Type.Number()]),
           ),
@@ -77,7 +77,7 @@ export const claimConditionOutputSchema = Type.Object({
         Type.Object({
           price: Type.Optional(Type.Union([Type.String(), Type.Number()])),
           currencyAddress: Type.Optional(AddressSchema),
-          address: Type.String(),
+          address: AddressSchema,
           maxClaimable: Type.Optional(
             Type.Union([Type.String(), Type.Number()]),
           ),
@@ -92,7 +92,7 @@ export const claimerProofSchema = Type.Union([
   Type.Object({
     price: Type.Optional(Type.String()),
     currencyAddress: Type.Optional(AddressSchema),
-    address: Type.String(),
+    address: AddressSchema,
     maxClaimable: Type.String(),
     proof: Type.Array(Type.String()),
   }),

--- a/src/server/schemas/contractSubscription.ts
+++ b/src/server/schemas/contractSubscription.ts
@@ -1,11 +1,12 @@
 import { ContractSubscriptions, Webhooks } from "@prisma/client";
 import { Static, Type } from "@sinclair/typebox";
+import { AddressSchema } from "./address";
 import { WebhookSchema, toWebhookSchema } from "./webhook";
 
 export const contractSubscriptionSchema = Type.Object({
   id: Type.String(),
   chainId: Type.Number(),
-  contractAddress: Type.String(),
+  contractAddress: AddressSchema,
   webhook: Type.Optional(WebhookSchema),
   processEventLogs: Type.Boolean(),
   filterEvents: Type.Array(Type.String()),

--- a/src/server/schemas/erc20/index.ts
+++ b/src/server/schemas/erc20/index.ts
@@ -1,4 +1,5 @@
 import { Static, Type } from "@sinclair/typebox";
+import { AddressSchema } from "../address";
 
 export const erc20MetadataSchema = Type.Object({
   name: Type.String(),
@@ -84,10 +85,11 @@ export const signature20OutputSchema = Type.Object({
       The smart contract enforces on-chain that no uid gets used more than once, 
       which means you can deterministically generate the uid to prevent specific exploits.`,
   }),
-  currencyAddress: Type.String({
+  currencyAddress: {
+    ...AddressSchema,
     description:
       "The address of the currency to pay for minting the tokens (use the price field to specify the price). Defaults to NATIVE_TOKEN_ADDRESS",
-  }),
+  },
   price: Type.String({
     description:
       "If you want the user to pay for minting the tokens, you can specify the price per token. Defaults to 0.",

--- a/src/server/schemas/eventLog.ts
+++ b/src/server/schemas/eventLog.ts
@@ -1,9 +1,10 @@
 import { ContractEventLogs } from "@prisma/client";
 import { Static, Type } from "@sinclair/typebox";
+import { AddressSchema } from "./address";
 
 export const eventLogSchema = Type.Object({
   chainId: Type.Number(),
-  contractAddress: Type.String(),
+  contractAddress: AddressSchema,
   blockNumber: Type.Number(),
   transactionHash: Type.String(),
   topics: Type.Array(Type.String()),

--- a/src/server/schemas/marketplaceV3/directListing/index.ts
+++ b/src/server/schemas/marketplaceV3/directListing/index.ts
@@ -1,11 +1,13 @@
 import { Type } from "@sinclair/typebox";
+import { AddressSchema } from "../../address";
 import { nftMetadataSchema } from "../../nft";
-import { currencyValueSchema, Status } from "../../sharedApiSchemas";
+import { Status, currencyValueSchema } from "../../sharedApiSchemas";
 
 export const directListingV3InputSchema = Type.Object({
-  assetContractAddress: Type.String({
+  assetContractAddress: {
+    ...AddressSchema,
     description: "The address of the asset being listed.",
-  }),
+  },
   tokenId: Type.String({
     description: "The ID of the token to list.",
   }),
@@ -44,9 +46,10 @@ export const directListingV3InputSchema = Type.Object({
 });
 
 export const directListingV3OutputSchema = Type.Object({
-  assetContractAddress: Type.String({
+  assetContractAddress: {
+    ...AddressSchema,
     description: "The address of the asset being listed.",
-  }),
+  },
   tokenId: Type.String({
     description: "The ID of the token to list.",
   }),

--- a/src/server/schemas/marketplaceV3/englishAuction/index.ts
+++ b/src/server/schemas/marketplaceV3/englishAuction/index.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { AddressSchema } from "../../address";
 import { nftMetadataSchema } from "../../nft";
 import { Status } from "../../sharedApiSchemas";
 
@@ -14,9 +15,10 @@ currencyValueSchema.description =
   "The `CurrencyValue` of the listing. Useful for displaying the price information.";
 
 export const englishAuctionInputSchema = Type.Object({
-  assetContractAddress: Type.String({
+  assetContractAddress: {
+    ...AddressSchema,
     description: "The address of the asset being listed.",
-  }),
+  },
   tokenId: Type.String({
     description: "The ID of the token to list.",
   }),
@@ -64,9 +66,10 @@ export const englishAuctionInputSchema = Type.Object({
 });
 
 export const englishAuctionOutputSchema = Type.Object({
-  assetContractAddress: Type.String({
+  assetContractAddress: {
+    ...AddressSchema,
     description: "The address of the asset being listed.",
-  }),
+  },
   tokenId: Type.String({
     description: "The ID of the token to list.",
   }),

--- a/src/server/schemas/marketplaceV3/offer/index.ts
+++ b/src/server/schemas/marketplaceV3/offer/index.ts
@@ -1,11 +1,13 @@
 import { Type } from "@sinclair/typebox";
+import { AddressSchema } from "../../address";
 import { nftMetadataSchema } from "../../nft";
-import { currencyValueSchema, Status } from "../../sharedApiSchemas";
+import { Status, currencyValueSchema } from "../../sharedApiSchemas";
 
 export const OfferV3InputSchema = Type.Object({
-  assetContractAddress: Type.String({
+  assetContractAddress: {
+    ...AddressSchema,
     description: "The address of the asset being listed.",
-  }),
+  },
   tokenId: Type.String({
     description: "The ID of the token to list.",
   }),
@@ -31,9 +33,10 @@ export const OfferV3InputSchema = Type.Object({
 });
 
 export const OfferV3OutputSchema = Type.Object({
-  assetContractAddress: Type.String({
+  assetContractAddress: {
+    ...AddressSchema,
     description: "The address of the asset being listed.",
-  }),
+  },
   tokenId: Type.String({
     description: "The ID of the token to list.",
   }),
@@ -51,9 +54,10 @@ export const OfferV3OutputSchema = Type.Object({
   id: Type.String({
     description: "The id of the offer.",
   }),
-  offerorAddress: Type.String({
+  offerorAddress: {
+    ...AddressSchema,
     description: "The address of the creator of offer.",
-  }),
+  },
   currencyValue: Type.Optional(currencyValueSchema),
   totalPrice: Type.String({
     description: "The total offer amount for the NFTs.",

--- a/src/server/schemas/nft/index.ts
+++ b/src/server/schemas/nft/index.ts
@@ -1,5 +1,6 @@
 import { Static, Type } from "@sinclair/typebox";
 import { BigNumber } from "ethers";
+import { AddressSchema } from "../address";
 
 // NFTInput format compatible with v5 SDK
 export const nftInputSchema = Type.Partial(
@@ -210,10 +211,11 @@ export const signature721OutputSchema = Type.Object({
       which means you can deterministically generate the uid to prevent specific exploits.`,
   }),
   metadata: Type.Union([nftMetadataInputSchema, Type.String()]),
-  currencyAddress: Type.String({
+  currencyAddress: {
+    ...AddressSchema,
     description:
       "The address of the currency to pay for minting the tokens (use the price field to specify the price). Defaults to NATIVE_TOKEN_ADDRESS",
-  }),
+  },
   price: Type.Optional(
     Type.String({
       description:
@@ -326,10 +328,11 @@ export const signature1155OutputSchema = Type.Object({
       which means you can deterministically generate the uid to prevent specific exploits.`,
   }),
   metadata: Type.Union([nftMetadataInputSchema, Type.String()]),
-  currencyAddress: Type.String({
+  currencyAddress: {
+    ...AddressSchema,
     description:
       "The address of the currency to pay for minting the tokens (use the price field to specify the price). Defaults to NATIVE_TOKEN_ADDRESS",
-  }),
+  },
   price: Type.String({
     description:
       "If you want the user to pay for minting the tokens, you can specify the price per token. Defaults to 0.",

--- a/src/server/schemas/prebuilts/index.ts
+++ b/src/server/schemas/prebuilts/index.ts
@@ -5,97 +5,97 @@ import { AddressSchema } from "../address";
 const MAX_BPS = 10000;
 
 export const commonContractSchema = Type.Object({
-	name: Type.String(),
-	description: Type.Optional(Type.String()),
-	image: Type.Optional(Type.String()),
-	external_link: Type.Optional(Type.String()),
-	app_uri: Type.Optional(Type.String()),
-	defaultAdmin: Type.Optional(Type.String()),
+  name: Type.String(),
+  description: Type.Optional(Type.String()),
+  image: Type.Optional(Type.String()),
+  external_link: Type.Optional(Type.String()),
+  app_uri: Type.Optional(Type.String()),
+  defaultAdmin: Type.Optional(Type.String()),
 });
 
 export const splitRecipientInputSchema = Type.Object({
-	address: AddressSchema,
-	sharesBps: Type.Number({
-		exclusiveMinimum: 0,
-		maximum: MAX_BPS,
-	}),
+  address: AddressSchema,
+  sharesBps: Type.Number({
+    exclusiveMinimum: 0,
+    maximum: MAX_BPS,
+  }),
 });
 
 const percentSchema = Type.Number({
-	maximum: 100,
-	minimum: 0,
-	default: 0,
+  maximum: 100,
+  minimum: 0,
+  default: 0,
 });
 
 export const commonRoyaltySchema = Type.Object({
-	seller_fee_basis_points: Type.Number({
-		maximum: MAX_BPS,
-		minimum: 0,
-		default: 0,
-	}),
+  seller_fee_basis_points: Type.Number({
+    maximum: MAX_BPS,
+    minimum: 0,
+    default: 0,
+  }),
 
-	fee_recipient: Type.String({
-		default: constants.AddressZero,
-	}),
+  fee_recipient: Type.String({
+    default: constants.AddressZero,
+  }),
 });
 
 export const merkleSchema = Type.Optional(
-	Type.Object({
-		merkle: Type.Optional(Type.Record(Type.String(), Type.String())),
-	}),
+  Type.Object({
+    merkle: Type.Optional(Type.Record(Type.String(), Type.String())),
+  }),
 );
 
 export const commonSymbolSchema = Type.Object({
-	symbol: Type.String({
-		default: "",
-	}),
+  symbol: Type.String({
+    default: "",
+  }),
 });
 
 export const voteSettingsInputSchema = Type.Object({
-	voting_delay_in_blocks: Type.Number({
-		minimum: 0,
-		default: 0,
-	}),
-	voting_period_in_blocks: Type.Number({
-		minimum: 1,
-		default: 1,
-	}),
-	voting_token_address: AddressSchema,
-	voting_quorum_fraction: percentSchema,
-	proposal_token_threshold: Type.String({
-		default: "0",
-	}),
+  voting_delay_in_blocks: Type.Number({
+    minimum: 0,
+    default: 0,
+  }),
+  voting_period_in_blocks: Type.Number({
+    minimum: 1,
+    default: 1,
+  }),
+  voting_token_address: AddressSchema,
+  voting_quorum_fraction: percentSchema,
+  proposal_token_threshold: Type.String({
+    default: "0",
+  }),
 });
 
 export const commonPrimarySaleSchema = Type.Object({
-	primary_sale_recipient: Type.Optional(Type.String()),
+  primary_sale_recipient: Type.Optional(Type.String()),
 });
 
 export const commonPlatformFeeSchema = Type.Object({
-	platform_fee_basis_points: Type.Number({
-		maximum: MAX_BPS,
-		minimum: 0,
-		default: 0,
-	}),
-	platform_fee_recipient: Type.String({
-		default: constants.AddressZero,
-	}),
+  platform_fee_basis_points: Type.Number({
+    maximum: MAX_BPS,
+    minimum: 0,
+    default: 0,
+  }),
+  platform_fee_recipient: Type.String({
+    default: constants.AddressZero,
+  }),
 });
 
 export const commonTrustedForwarderSchema = Type.Object({
-	trusted_forwarders: Type.Array(Type.String(), { default: [] }),
+  trusted_forwarders: Type.Array(Type.String(), { default: [] }),
 });
 
 export const prebuiltDeployContractParamSchema = Type.Object({
-	chain: Type.String({
-		examples: ["80002"],
-		description: "Chain ID or name",
-	}),
+  chain: Type.String({
+    examples: ["80002"],
+    description: "Chain ID or name",
+  }),
 });
 
 export const prebuiltDeployResponseSchema = Type.Object({
-	result: Type.Object({
-		queueId: Type.Optional(Type.String()),
-		deployedAddress: Type.Optional(AddressSchema),
-	}),
+  result: Type.Object({
+    queueId: Type.Optional(Type.String()),
+    deployedAddress: Type.Optional(AddressSchema),
+  }),
 });

--- a/src/server/schemas/prebuilts/index.ts
+++ b/src/server/schemas/prebuilts/index.ts
@@ -5,97 +5,97 @@ import { AddressSchema } from "../address";
 const MAX_BPS = 10000;
 
 export const commonContractSchema = Type.Object({
-  name: Type.String(),
-  description: Type.Optional(Type.String()),
-  image: Type.Optional(Type.String()),
-  external_link: Type.Optional(Type.String()),
-  app_uri: Type.Optional(Type.String()),
-  defaultAdmin: Type.Optional(Type.String()),
+	name: Type.String(),
+	description: Type.Optional(Type.String()),
+	image: Type.Optional(Type.String()),
+	external_link: Type.Optional(Type.String()),
+	app_uri: Type.Optional(Type.String()),
+	defaultAdmin: Type.Optional(Type.String()),
 });
 
 export const splitRecipientInputSchema = Type.Object({
-  address: Type.String(),
-  sharesBps: Type.Number({
-    exclusiveMinimum: 0,
-    maximum: MAX_BPS,
-  }),
+	address: AddressSchema,
+	sharesBps: Type.Number({
+		exclusiveMinimum: 0,
+		maximum: MAX_BPS,
+	}),
 });
 
 const percentSchema = Type.Number({
-  maximum: 100,
-  minimum: 0,
-  default: 0,
+	maximum: 100,
+	minimum: 0,
+	default: 0,
 });
 
 export const commonRoyaltySchema = Type.Object({
-  seller_fee_basis_points: Type.Number({
-    maximum: MAX_BPS,
-    minimum: 0,
-    default: 0,
-  }),
+	seller_fee_basis_points: Type.Number({
+		maximum: MAX_BPS,
+		minimum: 0,
+		default: 0,
+	}),
 
-  fee_recipient: Type.String({
-    default: constants.AddressZero,
-  }),
+	fee_recipient: Type.String({
+		default: constants.AddressZero,
+	}),
 });
 
 export const merkleSchema = Type.Optional(
-  Type.Object({
-    merkle: Type.Optional(Type.Record(Type.String(), Type.String())),
-  }),
+	Type.Object({
+		merkle: Type.Optional(Type.Record(Type.String(), Type.String())),
+	}),
 );
 
 export const commonSymbolSchema = Type.Object({
-  symbol: Type.String({
-    default: "",
-  }),
+	symbol: Type.String({
+		default: "",
+	}),
 });
 
 export const voteSettingsInputSchema = Type.Object({
-  voting_delay_in_blocks: Type.Number({
-    minimum: 0,
-    default: 0,
-  }),
-  voting_period_in_blocks: Type.Number({
-    minimum: 1,
-    default: 1,
-  }),
-  voting_token_address: Type.String(),
-  voting_quorum_fraction: percentSchema,
-  proposal_token_threshold: Type.String({
-    default: "0",
-  }),
+	voting_delay_in_blocks: Type.Number({
+		minimum: 0,
+		default: 0,
+	}),
+	voting_period_in_blocks: Type.Number({
+		minimum: 1,
+		default: 1,
+	}),
+	voting_token_address: AddressSchema,
+	voting_quorum_fraction: percentSchema,
+	proposal_token_threshold: Type.String({
+		default: "0",
+	}),
 });
 
 export const commonPrimarySaleSchema = Type.Object({
-  primary_sale_recipient: Type.Optional(Type.String()),
+	primary_sale_recipient: Type.Optional(Type.String()),
 });
 
 export const commonPlatformFeeSchema = Type.Object({
-  platform_fee_basis_points: Type.Number({
-    maximum: MAX_BPS,
-    minimum: 0,
-    default: 0,
-  }),
-  platform_fee_recipient: Type.String({
-    default: constants.AddressZero,
-  }),
+	platform_fee_basis_points: Type.Number({
+		maximum: MAX_BPS,
+		minimum: 0,
+		default: 0,
+	}),
+	platform_fee_recipient: Type.String({
+		default: constants.AddressZero,
+	}),
 });
 
 export const commonTrustedForwarderSchema = Type.Object({
-  trusted_forwarders: Type.Array(Type.String(), { default: [] }),
+	trusted_forwarders: Type.Array(Type.String(), { default: [] }),
 });
 
 export const prebuiltDeployContractParamSchema = Type.Object({
-  chain: Type.String({
-    examples: ["80002"],
-    description: "Chain ID or name",
-  }),
+	chain: Type.String({
+		examples: ["80002"],
+		description: "Chain ID or name",
+	}),
 });
 
 export const prebuiltDeployResponseSchema = Type.Object({
-  result: Type.Object({
-    queueId: Type.Optional(Type.String()),
-    deployedAddress: Type.Optional(AddressSchema),
-  }),
+	result: Type.Object({
+		queueId: Type.Optional(Type.String()),
+		deployedAddress: Type.Optional(AddressSchema),
+	}),
 });

--- a/src/server/schemas/prebuilts/index.ts
+++ b/src/server/schemas/prebuilts/index.ts
@@ -1,5 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import { constants } from "ethers";
+import { AddressSchema } from "../address";
 
 const MAX_BPS = 10000;
 
@@ -95,6 +96,6 @@ export const prebuiltDeployContractParamSchema = Type.Object({
 export const prebuiltDeployResponseSchema = Type.Object({
   result: Type.Object({
     queueId: Type.Optional(Type.String()),
-    deployedAddress: Type.Optional(Type.String()),
+    deployedAddress: Type.Optional(AddressSchema),
   }),
 });

--- a/src/server/schemas/sharedApiSchemas.ts
+++ b/src/server/schemas/sharedApiSchemas.ts
@@ -6,337 +6,337 @@ import { StatusCodes } from "http-status-codes";
 import { AddressSchema } from "./address";
 
 export const baseReplyErrorSchema = Type.Object({
-	message: Type.Optional(Type.String()),
-	reason: Type.Optional(Type.Any()),
-	code: Type.Optional(Type.String()),
-	stack: Type.Optional(Type.String()),
-	statusCode: Type.Optional(Type.Number()),
+  message: Type.Optional(Type.String()),
+  reason: Type.Optional(Type.Any()),
+  code: Type.Optional(Type.String()),
+  stack: Type.Optional(Type.String()),
+  statusCode: Type.Optional(Type.Number()),
 });
 
 /**
  * Basic schema for Request Parameters
  */
 export const contractParamSchema = Type.Object({
-	chain: Type.String({
-		examples: ["80002"],
-		description: "Chain ID or name",
-	}),
-	contractAddress: {
-		...AddressSchema,
-		description: "Contract address",
-	},
+  chain: Type.String({
+    examples: ["80002"],
+    description: "Chain ID or name",
+  }),
+  contractAddress: {
+    ...AddressSchema,
+    description: "Contract address",
+  },
 });
 
 export const requestQuerystringSchema = Type.Object({
-	simulateTx: Type.Optional(
-		Type.Boolean({
-			description: "Simulate the transaction on-chain without executing",
-			default: false,
-		}),
-	),
+  simulateTx: Type.Optional(
+    Type.Boolean({
+      description: "Simulate the transaction on-chain without executing",
+      default: false,
+    }),
+  ),
 });
 
 export const prebuiltDeployParamSchema = Type.Object({
-	chain: Type.String({
-		examples: ["80002"],
-		description: "Chain ID or name",
-	}),
-	contractType: Type.String({
-		examples: Object.keys(PREBUILT_CONTRACTS_MAP),
-		description: "Contract type to deploy",
-	}),
+  chain: Type.String({
+    examples: ["80002"],
+    description: "Chain ID or name",
+  }),
+  contractType: Type.String({
+    examples: Object.keys(PREBUILT_CONTRACTS_MAP),
+    description: "Contract type to deploy",
+  }),
 });
 
 export const publishedDeployParamSchema = Type.Object({
-	chain: Type.String({
-		examples: ["80002"],
-		description: "Chain ID or name",
-	}),
-	publisher: Type.String({
-		examples: ["deployer.thirdweb.eth"],
-		description: "Address or ENS of the publisher of the contract",
-	}),
-	contractName: Type.String({
-		examples: ["AirdropERC20"],
-		description: "Name of the published contract to deploy",
-	}),
+  chain: Type.String({
+    examples: ["80002"],
+    description: "Chain ID or name",
+  }),
+  publisher: Type.String({
+    examples: ["deployer.thirdweb.eth"],
+    description: "Address or ENS of the publisher of the contract",
+  }),
+  contractName: Type.String({
+    examples: ["AirdropERC20"],
+    description: "Name of the published contract to deploy",
+  }),
 });
 
 /**
  * Basic schema for all Response Body
  */
 const replyBodySchema = Type.Object({
-	result: Type.Optional(
-		Type.Union([
-			Type.Number(),
-			Type.String(),
-			Type.Object({}),
-			Type.Array(Type.Any()),
-			Type.Boolean(),
-			Type.Tuple([Type.Any(), Type.Any()]),
-		]),
-	),
+  result: Type.Optional(
+    Type.Union([
+      Type.Number(),
+      Type.String(),
+      Type.Object({}),
+      Type.Array(Type.Any()),
+      Type.Boolean(),
+      Type.Tuple([Type.Any(), Type.Any()]),
+    ]),
+  ),
 });
 
 const replyErrorBodySchema = Type.Object({
-	error: Type.Optional(baseReplyErrorSchema),
+  error: Type.Optional(baseReplyErrorSchema),
 });
 
 export const standardResponseSchema = {
-	[StatusCodes.OK]: replyBodySchema,
-	[StatusCodes.BAD_REQUEST]: {
-		description: "Bad Request",
-		...replyErrorBodySchema,
-		examples: [
-			{
-				error: {
-					message: "",
-					code: "BAD_REQUEST",
-					statusCode: StatusCodes.BAD_REQUEST,
-				},
-			},
-		],
-	},
-	[StatusCodes.NOT_FOUND]: {
-		description: "Not Found",
-		...replyErrorBodySchema,
-		examples: [
-			{
-				error: {
-					message:
-						"Transaction not found with queueId 9eb88b00-f04f-409b-9df7-7dcc9003bc35",
-					code: "NOT_FOUND",
-					statusCode: StatusCodes.NOT_FOUND,
-				},
-			},
-		],
-	},
-	[StatusCodes.INTERNAL_SERVER_ERROR]: {
-		description: "Internal Server Error",
-		...replyErrorBodySchema,
-		examples: [
-			{
-				error: {
-					message:
-						"Transaction simulation failed with reason: types/values length mismatch",
-					code: "INTERNAL_SERVER_ERROR",
-					statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-				},
-			},
-		],
-	},
+  [StatusCodes.OK]: replyBodySchema,
+  [StatusCodes.BAD_REQUEST]: {
+    description: "Bad Request",
+    ...replyErrorBodySchema,
+    examples: [
+      {
+        error: {
+          message: "",
+          code: "BAD_REQUEST",
+          statusCode: StatusCodes.BAD_REQUEST,
+        },
+      },
+    ],
+  },
+  [StatusCodes.NOT_FOUND]: {
+    description: "Not Found",
+    ...replyErrorBodySchema,
+    examples: [
+      {
+        error: {
+          message:
+            "Transaction not found with queueId 9eb88b00-f04f-409b-9df7-7dcc9003bc35",
+          code: "NOT_FOUND",
+          statusCode: StatusCodes.NOT_FOUND,
+        },
+      },
+    ],
+  },
+  [StatusCodes.INTERNAL_SERVER_ERROR]: {
+    description: "Internal Server Error",
+    ...replyErrorBodySchema,
+    examples: [
+      {
+        error: {
+          message:
+            "Transaction simulation failed with reason: types/values length mismatch",
+          code: "INTERNAL_SERVER_ERROR",
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        },
+      },
+    ],
+  },
 };
 
 /**
  * Basic Fastify Partial schema for request/response
  */
 export const partialRouteSchema: FastifySchema = {
-	params: contractParamSchema,
-	response: standardResponseSchema,
+  params: contractParamSchema,
+  response: standardResponseSchema,
 };
 
 export interface contractSchemaTypes extends RouteGenericInterface {
-	Params: Static<typeof contractParamSchema>;
-	Reply: Static<typeof replyBodySchema>;
+  Params: Static<typeof contractParamSchema>;
+  Reply: Static<typeof replyBodySchema>;
 }
 
 export interface prebuiltDeploySchemaTypes extends RouteGenericInterface {
-	Params: Static<typeof prebuiltDeployParamSchema>;
-	Reply: Static<typeof replyBodySchema>;
+  Params: Static<typeof prebuiltDeployParamSchema>;
+  Reply: Static<typeof replyBodySchema>;
 }
 
 export interface publishedDeploySchemaTypes extends RouteGenericInterface {
-	Params: Static<typeof publishedDeployParamSchema>;
-	Reply: Static<typeof replyBodySchema>;
+  Params: Static<typeof publishedDeployParamSchema>;
+  Reply: Static<typeof replyBodySchema>;
 }
 
 export const transactionWritesResponseSchema = Type.Object({
-	result: Type.Object({
-		queueId: Type.String({
-			description: "Queue ID",
-		}),
-	}),
+  result: Type.Object({
+    queueId: Type.String({
+      description: "Queue ID",
+    }),
+  }),
 });
 
 export const simulateResponseSchema = Type.Object({
-	result: Type.Object({
-		success: Type.Boolean({
-			description: "Simulation Success",
-		}),
-	}),
+  result: Type.Object({
+    success: Type.Boolean({
+      description: "Simulation Success",
+    }),
+  }),
 });
 
 transactionWritesResponseSchema.example = {
-	result: {
-		queueId: "9eb88b00-f04f-409b-9df7-7dcc9003bc35",
-	},
+  result: {
+    queueId: "9eb88b00-f04f-409b-9df7-7dcc9003bc35",
+  },
 };
 
 /**
  * Basic schema for ERC721 Contract Request Parameters
  */
 export const erc20ContractParamSchema = Type.Object({
-	chain: Type.String({
-		examples: ["80002"],
-		description: "Chain ID or name",
-	}),
-	contractAddress: {
-		...AddressSchema,
-		examples: ["0x365b83D67D5539C6583b9c0266A548926Bf216F4"],
-		description: "ERC20 contract address",
-	},
+  chain: Type.String({
+    examples: ["80002"],
+    description: "Chain ID or name",
+  }),
+  contractAddress: {
+    ...AddressSchema,
+    examples: ["0x365b83D67D5539C6583b9c0266A548926Bf216F4"],
+    description: "ERC20 contract address",
+  },
 });
 
 /**
  * Basic schema for ERC721 Contract Request Parameters
  */
 export const erc1155ContractParamSchema = Type.Object({
-	chain: Type.String({
-		examples: ["80002"],
-		description: "Chain ID or name",
-	}),
-	contractAddress: {
-		...AddressSchema,
-		description: "ERC1155 contract address",
-	},
+  chain: Type.String({
+    examples: ["80002"],
+    description: "Chain ID or name",
+  }),
+  contractAddress: {
+    ...AddressSchema,
+    description: "ERC1155 contract address",
+  },
 });
 
 /**
  * Basic schema for ERC721 Contract Request Parameters
  */
 export const erc721ContractParamSchema = Type.Object({
-	chain: Type.String({
-		examples: ["80002"],
-		description: "Chain ID or name",
-	}),
-	contractAddress: {
-		...AddressSchema,
-		description: "ERC721 contract address",
-	},
+  chain: Type.String({
+    examples: ["80002"],
+    description: "Chain ID or name",
+  }),
+  contractAddress: {
+    ...AddressSchema,
+    description: "ERC721 contract address",
+  },
 });
 export const currencyValueSchema = Type.Object({
-	name: Type.String(),
-	symbol: Type.String(),
-	decimals: Type.Number(),
-	value: Type.String(),
-	displayValue: Type.String(),
+  name: Type.String(),
+  symbol: Type.String(),
+  decimals: Type.Number(),
+  value: Type.String(),
+  displayValue: Type.String(),
 });
 
 currencyValueSchema.description =
-	"The `CurrencyValue` of the listing. Useful for displaying the price information.";
+  "The `CurrencyValue` of the listing. Useful for displaying the price information.";
 
 export enum Status {
-	UNSET = 0,
-	Created = 1,
-	Completed = 2,
-	Cancelled = 3,
-	Active = 4,
-	Expired = 5,
+  UNSET = 0,
+  Created = 1,
+  Completed = 2,
+  Cancelled = 3,
+  Active = 4,
+  Expired = 5,
 }
 
 export const marketplaceV3ContractParamSchema = Type.Object({
-	chain: Type.String({
-		examples: ["80002"],
-		description: "Chain ID or name",
-	}),
-	contractAddress: {
-		...AddressSchema,
-		description: "Contract address",
-	},
+  chain: Type.String({
+    examples: ["80002"],
+    description: "Chain ID or name",
+  }),
+  contractAddress: {
+    ...AddressSchema,
+    description: "Contract address",
+  },
 });
 
 export const marketplaceFilterSchema = Type.Object({
-	count: Type.Optional(
-		Type.Number({
-			description: "Number of listings to fetch",
-		}),
-	),
-	offeror: Type.Optional(
-		Type.String({
-			description: "has offers from this Address",
-		}),
-	),
-	seller: Type.Optional(
-		Type.String({
-			description: "Being sold by this Address",
-		}),
-	),
-	start: Type.Optional(
-		Type.Number({
-			description: "Satrt from this index (pagination)",
-		}),
-	),
-	tokenContract: Type.Optional(
-		Type.String({
-			description: "Token contract address to show NFTs from",
-		}),
-	),
-	tokenId: Type.Optional(
-		Type.String({
-			description: "Only show NFTs with this ID",
-		}),
-	),
+  count: Type.Optional(
+    Type.Number({
+      description: "Number of listings to fetch",
+    }),
+  ),
+  offeror: Type.Optional(
+    Type.String({
+      description: "has offers from this Address",
+    }),
+  ),
+  seller: Type.Optional(
+    Type.String({
+      description: "Being sold by this Address",
+    }),
+  ),
+  start: Type.Optional(
+    Type.Number({
+      description: "Satrt from this index (pagination)",
+    }),
+  ),
+  tokenContract: Type.Optional(
+    Type.String({
+      description: "Token contract address to show NFTs from",
+    }),
+  ),
+  tokenId: Type.Optional(
+    Type.String({
+      description: "Only show NFTs with this ID",
+    }),
+  ),
 });
 
 export const walletDetailsSchema = Type.Object({
-	address: {
-		...AddressSchema,
-		description: "Wallet Address",
-	},
-	type: Type.String({
-		description: "Wallet Type",
-	}),
-	label: Type.Union([
-		Type.String({
-			description: "A label for your wallet",
-		}),
-		Type.Null(),
-	]),
-	awsKmsKeyId: Type.Union([
-		Type.String({
-			description: "AWS KMS Key ID",
-		}),
-		Type.Null(),
-	]),
-	awsKmsArn: Type.Union([
-		Type.String({
-			description: "AWS KMS Key ARN",
-		}),
-		Type.Null(),
-	]),
-	gcpKmsKeyId: Type.Union([
-		Type.String({
-			description: "GCP KMS Key ID",
-		}),
-		Type.Null(),
-	]),
-	gcpKmsKeyRingId: Type.Union([
-		Type.String({
-			description: "GCP KMS Key Ring ID",
-		}),
-		Type.Null(),
-	]),
-	gcpKmsLocationId: Type.Union([
-		Type.String({
-			description: "GCP KMS Location ID",
-		}),
-		Type.Null(),
-	]),
-	gcpKmsKeyVersionId: Type.Union([
-		Type.String({
-			description: "GCP KMS Key Version ID",
-		}),
-		Type.Null(),
-	]),
-	gcpKmsResourcePath: Type.Union([
-		Type.String({
-			description: "GCP KMS Resource Path",
-		}),
-		Type.Null(),
-	]),
+  address: {
+    ...AddressSchema,
+    description: "Wallet Address",
+  },
+  type: Type.String({
+    description: "Wallet Type",
+  }),
+  label: Type.Union([
+    Type.String({
+      description: "A label for your wallet",
+    }),
+    Type.Null(),
+  ]),
+  awsKmsKeyId: Type.Union([
+    Type.String({
+      description: "AWS KMS Key ID",
+    }),
+    Type.Null(),
+  ]),
+  awsKmsArn: Type.Union([
+    Type.String({
+      description: "AWS KMS Key ARN",
+    }),
+    Type.Null(),
+  ]),
+  gcpKmsKeyId: Type.Union([
+    Type.String({
+      description: "GCP KMS Key ID",
+    }),
+    Type.Null(),
+  ]),
+  gcpKmsKeyRingId: Type.Union([
+    Type.String({
+      description: "GCP KMS Key Ring ID",
+    }),
+    Type.Null(),
+  ]),
+  gcpKmsLocationId: Type.Union([
+    Type.String({
+      description: "GCP KMS Location ID",
+    }),
+    Type.Null(),
+  ]),
+  gcpKmsKeyVersionId: Type.Union([
+    Type.String({
+      description: "GCP KMS Key Version ID",
+    }),
+    Type.Null(),
+  ]),
+  gcpKmsResourcePath: Type.Union([
+    Type.String({
+      description: "GCP KMS Resource Path",
+    }),
+    Type.Null(),
+  ]),
 });
 
 export const contractSubscriptionConfigurationSchema = Type.Object({
-	maxBlocksToIndex: Type.Number(),
-	contractSubscriptionsRequeryDelaySeconds: Type.String(),
+  maxBlocksToIndex: Type.Number(),
+  contractSubscriptionsRequeryDelaySeconds: Type.String(),
 });

--- a/src/server/schemas/sharedApiSchemas.ts
+++ b/src/server/schemas/sharedApiSchemas.ts
@@ -6,336 +6,337 @@ import { StatusCodes } from "http-status-codes";
 import { AddressSchema } from "./address";
 
 export const baseReplyErrorSchema = Type.Object({
-  message: Type.Optional(Type.String()),
-  reason: Type.Optional(Type.Any()),
-  code: Type.Optional(Type.String()),
-  stack: Type.Optional(Type.String()),
-  statusCode: Type.Optional(Type.Number()),
+	message: Type.Optional(Type.String()),
+	reason: Type.Optional(Type.Any()),
+	code: Type.Optional(Type.String()),
+	stack: Type.Optional(Type.String()),
+	statusCode: Type.Optional(Type.Number()),
 });
 
 /**
  * Basic schema for Request Parameters
  */
 export const contractParamSchema = Type.Object({
-  chain: Type.String({
-    examples: ["80002"],
-    description: "Chain ID or name",
-  }),
-  contractAddress: {
-    ...AddressSchema,
-    description: "Contract address",
-  },
+	chain: Type.String({
+		examples: ["80002"],
+		description: "Chain ID or name",
+	}),
+	contractAddress: {
+		...AddressSchema,
+		description: "Contract address",
+	},
 });
 
 export const requestQuerystringSchema = Type.Object({
-  simulateTx: Type.Optional(
-    Type.Boolean({
-      description: "Simulate the transaction on-chain without executing",
-      default: false,
-    }),
-  ),
+	simulateTx: Type.Optional(
+		Type.Boolean({
+			description: "Simulate the transaction on-chain without executing",
+			default: false,
+		}),
+	),
 });
 
 export const prebuiltDeployParamSchema = Type.Object({
-  chain: Type.String({
-    examples: ["80002"],
-    description: "Chain ID or name",
-  }),
-  contractType: Type.String({
-    examples: Object.keys(PREBUILT_CONTRACTS_MAP),
-    description: "Contract type to deploy",
-  }),
+	chain: Type.String({
+		examples: ["80002"],
+		description: "Chain ID or name",
+	}),
+	contractType: Type.String({
+		examples: Object.keys(PREBUILT_CONTRACTS_MAP),
+		description: "Contract type to deploy",
+	}),
 });
 
 export const publishedDeployParamSchema = Type.Object({
-  chain: Type.String({
-    examples: ["80002"],
-    description: "Chain ID or name",
-  }),
-  publisher: Type.String({
-    examples: ["deployer.thirdweb.eth"],
-    description: "Address or ENS of the publisher of the contract",
-  }),
-  contractName: Type.String({
-    examples: ["AirdropERC20"],
-    description: "Name of the published contract to deploy",
-  }),
+	chain: Type.String({
+		examples: ["80002"],
+		description: "Chain ID or name",
+	}),
+	publisher: Type.String({
+		examples: ["deployer.thirdweb.eth"],
+		description: "Address or ENS of the publisher of the contract",
+	}),
+	contractName: Type.String({
+		examples: ["AirdropERC20"],
+		description: "Name of the published contract to deploy",
+	}),
 });
 
 /**
  * Basic schema for all Response Body
  */
 const replyBodySchema = Type.Object({
-  result: Type.Optional(
-    Type.Union([
-      Type.Number(),
-      Type.String(),
-      Type.Object({}),
-      Type.Array(Type.Any()),
-      Type.Boolean(),
-      Type.Tuple([Type.Any(), Type.Any()]),
-    ]),
-  ),
+	result: Type.Optional(
+		Type.Union([
+			Type.Number(),
+			Type.String(),
+			Type.Object({}),
+			Type.Array(Type.Any()),
+			Type.Boolean(),
+			Type.Tuple([Type.Any(), Type.Any()]),
+		]),
+	),
 });
 
 const replyErrorBodySchema = Type.Object({
-  error: Type.Optional(baseReplyErrorSchema),
+	error: Type.Optional(baseReplyErrorSchema),
 });
 
 export const standardResponseSchema = {
-  [StatusCodes.OK]: replyBodySchema,
-  [StatusCodes.BAD_REQUEST]: {
-    description: "Bad Request",
-    ...replyErrorBodySchema,
-    examples: [
-      {
-        error: {
-          message: "",
-          code: "BAD_REQUEST",
-          statusCode: StatusCodes.BAD_REQUEST,
-        },
-      },
-    ],
-  },
-  [StatusCodes.NOT_FOUND]: {
-    description: "Not Found",
-    ...replyErrorBodySchema,
-    examples: [
-      {
-        error: {
-          message:
-            "Transaction not found with queueId 9eb88b00-f04f-409b-9df7-7dcc9003bc35",
-          code: "NOT_FOUND",
-          statusCode: StatusCodes.NOT_FOUND,
-        },
-      },
-    ],
-  },
-  [StatusCodes.INTERNAL_SERVER_ERROR]: {
-    description: "Internal Server Error",
-    ...replyErrorBodySchema,
-    examples: [
-      {
-        error: {
-          message:
-            "Transaction simulation failed with reason: types/values length mismatch",
-          code: "INTERNAL_SERVER_ERROR",
-          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-        },
-      },
-    ],
-  },
+	[StatusCodes.OK]: replyBodySchema,
+	[StatusCodes.BAD_REQUEST]: {
+		description: "Bad Request",
+		...replyErrorBodySchema,
+		examples: [
+			{
+				error: {
+					message: "",
+					code: "BAD_REQUEST",
+					statusCode: StatusCodes.BAD_REQUEST,
+				},
+			},
+		],
+	},
+	[StatusCodes.NOT_FOUND]: {
+		description: "Not Found",
+		...replyErrorBodySchema,
+		examples: [
+			{
+				error: {
+					message:
+						"Transaction not found with queueId 9eb88b00-f04f-409b-9df7-7dcc9003bc35",
+					code: "NOT_FOUND",
+					statusCode: StatusCodes.NOT_FOUND,
+				},
+			},
+		],
+	},
+	[StatusCodes.INTERNAL_SERVER_ERROR]: {
+		description: "Internal Server Error",
+		...replyErrorBodySchema,
+		examples: [
+			{
+				error: {
+					message:
+						"Transaction simulation failed with reason: types/values length mismatch",
+					code: "INTERNAL_SERVER_ERROR",
+					statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+				},
+			},
+		],
+	},
 };
 
 /**
  * Basic Fastify Partial schema for request/response
  */
 export const partialRouteSchema: FastifySchema = {
-  params: contractParamSchema,
-  response: standardResponseSchema,
+	params: contractParamSchema,
+	response: standardResponseSchema,
 };
 
 export interface contractSchemaTypes extends RouteGenericInterface {
-  Params: Static<typeof contractParamSchema>;
-  Reply: Static<typeof replyBodySchema>;
+	Params: Static<typeof contractParamSchema>;
+	Reply: Static<typeof replyBodySchema>;
 }
 
 export interface prebuiltDeploySchemaTypes extends RouteGenericInterface {
-  Params: Static<typeof prebuiltDeployParamSchema>;
-  Reply: Static<typeof replyBodySchema>;
+	Params: Static<typeof prebuiltDeployParamSchema>;
+	Reply: Static<typeof replyBodySchema>;
 }
 
 export interface publishedDeploySchemaTypes extends RouteGenericInterface {
-  Params: Static<typeof publishedDeployParamSchema>;
-  Reply: Static<typeof replyBodySchema>;
+	Params: Static<typeof publishedDeployParamSchema>;
+	Reply: Static<typeof replyBodySchema>;
 }
 
 export const transactionWritesResponseSchema = Type.Object({
-  result: Type.Object({
-    queueId: Type.String({
-      description: "Queue ID",
-    }),
-  }),
+	result: Type.Object({
+		queueId: Type.String({
+			description: "Queue ID",
+		}),
+	}),
 });
 
 export const simulateResponseSchema = Type.Object({
-  result: Type.Object({
-    success: Type.Boolean({
-      description: "Simulation Success",
-    }),
-  }),
+	result: Type.Object({
+		success: Type.Boolean({
+			description: "Simulation Success",
+		}),
+	}),
 });
 
 transactionWritesResponseSchema.example = {
-  result: {
-    queueId: "9eb88b00-f04f-409b-9df7-7dcc9003bc35",
-  },
+	result: {
+		queueId: "9eb88b00-f04f-409b-9df7-7dcc9003bc35",
+	},
 };
 
 /**
  * Basic schema for ERC721 Contract Request Parameters
  */
 export const erc20ContractParamSchema = Type.Object({
-  chain: Type.String({
-    examples: ["80002"],
-    description: "Chain ID or name",
-  }),
-  contractAddress: {
-    ...AddressSchema,
-    examples: ["0x365b83D67D5539C6583b9c0266A548926Bf216F4"],
-    description: "ERC20 contract address",
-  },
+	chain: Type.String({
+		examples: ["80002"],
+		description: "Chain ID or name",
+	}),
+	contractAddress: {
+		...AddressSchema,
+		examples: ["0x365b83D67D5539C6583b9c0266A548926Bf216F4"],
+		description: "ERC20 contract address",
+	},
 });
 
 /**
  * Basic schema for ERC721 Contract Request Parameters
  */
 export const erc1155ContractParamSchema = Type.Object({
-  chain: Type.String({
-    examples: ["80002"],
-    description: "Chain ID or name",
-  }),
-  contractAddress: {
-    ...AddressSchema,
-    description: "ERC1155 contract address",
-  },
+	chain: Type.String({
+		examples: ["80002"],
+		description: "Chain ID or name",
+	}),
+	contractAddress: {
+		...AddressSchema,
+		description: "ERC1155 contract address",
+	},
 });
 
 /**
  * Basic schema for ERC721 Contract Request Parameters
  */
 export const erc721ContractParamSchema = Type.Object({
-  chain: Type.String({
-    examples: ["80002"],
-    description: "Chain ID or name",
-  }),
-  contractAddress: {
-    ...AddressSchema,
-    description: "ERC721 contract address",
-  },
+	chain: Type.String({
+		examples: ["80002"],
+		description: "Chain ID or name",
+	}),
+	contractAddress: {
+		...AddressSchema,
+		description: "ERC721 contract address",
+	},
 });
 export const currencyValueSchema = Type.Object({
-  name: Type.String(),
-  symbol: Type.String(),
-  decimals: Type.Number(),
-  value: Type.String(),
-  displayValue: Type.String(),
+	name: Type.String(),
+	symbol: Type.String(),
+	decimals: Type.Number(),
+	value: Type.String(),
+	displayValue: Type.String(),
 });
 
 currencyValueSchema.description =
-  "The `CurrencyValue` of the listing. Useful for displaying the price information.";
+	"The `CurrencyValue` of the listing. Useful for displaying the price information.";
 
 export enum Status {
-  UNSET = 0,
-  Created = 1,
-  Completed = 2,
-  Cancelled = 3,
-  Active = 4,
-  Expired = 5,
+	UNSET = 0,
+	Created = 1,
+	Completed = 2,
+	Cancelled = 3,
+	Active = 4,
+	Expired = 5,
 }
 
 export const marketplaceV3ContractParamSchema = Type.Object({
-  chain: Type.String({
-    examples: ["80002"],
-    description: "Chain ID or name",
-  }),
-  contractAddress: {
-    ...AddressSchema,
-    description: "Contract address",
-  },
+	chain: Type.String({
+		examples: ["80002"],
+		description: "Chain ID or name",
+	}),
+	contractAddress: {
+		...AddressSchema,
+		description: "Contract address",
+	},
 });
 
 export const marketplaceFilterSchema = Type.Object({
-  count: Type.Optional(
-    Type.Number({
-      description: "Number of listings to fetch",
-    }),
-  ),
-  offeror: Type.Optional(
-    Type.String({
-      description: "has offers from this Address",
-    }),
-  ),
-  seller: Type.Optional(
-    Type.String({
-      description: "Being sold by this Address",
-    }),
-  ),
-  start: Type.Optional(
-    Type.Number({
-      description: "Satrt from this index (pagination)",
-    }),
-  ),
-  tokenContract: Type.Optional(
-    Type.String({
-      description: "Token contract address to show NFTs from",
-    }),
-  ),
-  tokenId: Type.Optional(
-    Type.String({
-      description: "Only show NFTs with this ID",
-    }),
-  ),
+	count: Type.Optional(
+		Type.Number({
+			description: "Number of listings to fetch",
+		}),
+	),
+	offeror: Type.Optional(
+		Type.String({
+			description: "has offers from this Address",
+		}),
+	),
+	seller: Type.Optional(
+		Type.String({
+			description: "Being sold by this Address",
+		}),
+	),
+	start: Type.Optional(
+		Type.Number({
+			description: "Satrt from this index (pagination)",
+		}),
+	),
+	tokenContract: Type.Optional(
+		Type.String({
+			description: "Token contract address to show NFTs from",
+		}),
+	),
+	tokenId: Type.Optional(
+		Type.String({
+			description: "Only show NFTs with this ID",
+		}),
+	),
 });
 
 export const walletDetailsSchema = Type.Object({
-  address: Type.String({
-    description: "Wallet Address",
-  }),
-  type: Type.String({
-    description: "Wallet Type",
-  }),
-  label: Type.Union([
-    Type.String({
-      description: "A label for your wallet",
-    }),
-    Type.Null(),
-  ]),
-  awsKmsKeyId: Type.Union([
-    Type.String({
-      description: "AWS KMS Key ID",
-    }),
-    Type.Null(),
-  ]),
-  awsKmsArn: Type.Union([
-    Type.String({
-      description: "AWS KMS Key ARN",
-    }),
-    Type.Null(),
-  ]),
-  gcpKmsKeyId: Type.Union([
-    Type.String({
-      description: "GCP KMS Key ID",
-    }),
-    Type.Null(),
-  ]),
-  gcpKmsKeyRingId: Type.Union([
-    Type.String({
-      description: "GCP KMS Key Ring ID",
-    }),
-    Type.Null(),
-  ]),
-  gcpKmsLocationId: Type.Union([
-    Type.String({
-      description: "GCP KMS Location ID",
-    }),
-    Type.Null(),
-  ]),
-  gcpKmsKeyVersionId: Type.Union([
-    Type.String({
-      description: "GCP KMS Key Version ID",
-    }),
-    Type.Null(),
-  ]),
-  gcpKmsResourcePath: Type.Union([
-    Type.String({
-      description: "GCP KMS Resource Path",
-    }),
-    Type.Null(),
-  ]),
+	address: {
+		...AddressSchema,
+		description: "Wallet Address",
+	},
+	type: Type.String({
+		description: "Wallet Type",
+	}),
+	label: Type.Union([
+		Type.String({
+			description: "A label for your wallet",
+		}),
+		Type.Null(),
+	]),
+	awsKmsKeyId: Type.Union([
+		Type.String({
+			description: "AWS KMS Key ID",
+		}),
+		Type.Null(),
+	]),
+	awsKmsArn: Type.Union([
+		Type.String({
+			description: "AWS KMS Key ARN",
+		}),
+		Type.Null(),
+	]),
+	gcpKmsKeyId: Type.Union([
+		Type.String({
+			description: "GCP KMS Key ID",
+		}),
+		Type.Null(),
+	]),
+	gcpKmsKeyRingId: Type.Union([
+		Type.String({
+			description: "GCP KMS Key Ring ID",
+		}),
+		Type.Null(),
+	]),
+	gcpKmsLocationId: Type.Union([
+		Type.String({
+			description: "GCP KMS Location ID",
+		}),
+		Type.Null(),
+	]),
+	gcpKmsKeyVersionId: Type.Union([
+		Type.String({
+			description: "GCP KMS Key Version ID",
+		}),
+		Type.Null(),
+	]),
+	gcpKmsResourcePath: Type.Union([
+		Type.String({
+			description: "GCP KMS Resource Path",
+		}),
+		Type.Null(),
+	]),
 });
 
 export const contractSubscriptionConfigurationSchema = Type.Object({
-  maxBlocksToIndex: Type.Number(),
-  contractSubscriptionsRequeryDelaySeconds: Type.String(),
+	maxBlocksToIndex: Type.Number(),
+	contractSubscriptionsRequeryDelaySeconds: Type.String(),
 });

--- a/src/server/schemas/sharedApiSchemas.ts
+++ b/src/server/schemas/sharedApiSchemas.ts
@@ -3,6 +3,7 @@ import { PREBUILT_CONTRACTS_MAP } from "@thirdweb-dev/sdk";
 import { RouteGenericInterface } from "fastify";
 import { FastifySchema } from "fastify/types/schema";
 import { StatusCodes } from "http-status-codes";
+import { AddressSchema } from "./address";
 
 export const baseReplyErrorSchema = Type.Object({
   message: Type.Optional(Type.String()),
@@ -20,10 +21,10 @@ export const contractParamSchema = Type.Object({
     examples: ["80002"],
     description: "Chain ID or name",
   }),
-  contractAddress: Type.String({
-    examples: ["0xc8be6265C06aC376876b4F62670adB3c4d72EABA"],
-    description: "Contract address on the chain",
-  }),
+  contractAddress: {
+    ...AddressSchema,
+    description: "Contract address",
+  },
 });
 
 export const requestQuerystringSchema = Type.Object({
@@ -179,10 +180,11 @@ export const erc20ContractParamSchema = Type.Object({
     examples: ["80002"],
     description: "Chain ID or name",
   }),
-  contractAddress: Type.String({
+  contractAddress: {
+    ...AddressSchema,
     examples: ["0x365b83D67D5539C6583b9c0266A548926Bf216F4"],
-    description: "ERC20 Contract Address on the Chain",
-  }),
+    description: "ERC20 contract address",
+  },
 });
 
 /**
@@ -193,10 +195,10 @@ export const erc1155ContractParamSchema = Type.Object({
     examples: ["80002"],
     description: "Chain ID or name",
   }),
-  contractAddress: Type.String({
-    examples: ["0x19411143085F1ec7D21a7cc07000CBA5188C5e8e"],
-    description: "ERC1155 Contract Address on the Chain",
-  }),
+  contractAddress: {
+    ...AddressSchema,
+    description: "ERC1155 contract address",
+  },
 });
 
 /**
@@ -207,10 +209,10 @@ export const erc721ContractParamSchema = Type.Object({
     examples: ["80002"],
     description: "Chain ID or name",
   }),
-  contractAddress: Type.String({
-    examples: ["0xc8be6265C06aC376876b4F62670adB3c4d72EABA"],
-    description: "ERC721 Contract Address on the Chain",
-  }),
+  contractAddress: {
+    ...AddressSchema,
+    description: "ERC721 contract address",
+  },
 });
 export const currencyValueSchema = Type.Object({
   name: Type.String(),
@@ -237,10 +239,10 @@ export const marketplaceV3ContractParamSchema = Type.Object({
     examples: ["80002"],
     description: "Chain ID or name",
   }),
-  contractAddress: Type.String({
-    examples: ["0xE8Bf1a01106F3acD7F84acaf5D668D7C9eA11535"],
-    description: "Contract Address on the Chain",
-  }),
+  contractAddress: {
+    ...AddressSchema,
+    description: "Contract address",
+  },
 });
 
 export const marketplaceFilterSchema = Type.Object({

--- a/src/server/schemas/transaction/index.ts
+++ b/src/server/schemas/transaction/index.ts
@@ -2,6 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 import { Hex } from "thirdweb";
 import { stringify } from "thirdweb/utils";
 import { AnyTransaction } from "../../../utils/transaction/types";
+import { AddressSchema } from "../address";
 
 export const TransactionSchema = Type.Object({
   queueId: Type.Union([
@@ -180,10 +181,10 @@ export const TransactionSchema = Type.Object({
     }),
     Type.Null(),
   ]),
-  signerAddress: Type.Union([Type.String(), Type.Null()]),
-  accountAddress: Type.Union([Type.String(), Type.Null()]),
-  target: Type.Union([Type.String(), Type.Null()]),
-  sender: Type.Union([Type.String(), Type.Null()]),
+  signerAddress: Type.Union([AddressSchema, Type.Null()]),
+  accountAddress: Type.Union([AddressSchema, Type.Null()]),
+  target: Type.Union([AddressSchema, Type.Null()]),
+  sender: Type.Union([AddressSchema, Type.Null()]),
   initCode: Type.Union([Type.String(), Type.Null()]),
   callData: Type.Union([Type.String(), Type.Null()]),
   callGasLimit: Type.Union([Type.String(), Type.Null()]),

--- a/src/server/schemas/transactionReceipt.ts
+++ b/src/server/schemas/transactionReceipt.ts
@@ -1,10 +1,11 @@
 import { ContractTransactionReceipts } from "@prisma/client";
 import { Static, Type } from "@sinclair/typebox";
+import { AddressSchema } from "./address";
 
 export const transactionReceiptSchema = Type.Object({
   chainId: Type.Number(),
   blockNumber: Type.Number(),
-  contractAddress: Type.String(),
+  contractAddress: AddressSchema,
   transactionHash: Type.String(),
   blockHash: Type.String(),
   timestamp: Type.Number(),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on updating various schemas and routes to utilize the `AddressSchema` for validating address fields instead of using plain `Type.String()`. This enhances consistency and validation across the application.

### Detailed summary
- Replaced `Type.String()` with `AddressSchema` in multiple schemas and routes.
- Updated `signerAddress`, `contractAddress`, `walletAddress`, and `backendWalletAddress` fields to use `AddressSchema`.
- Ensured that all relevant endpoints and schemas are now using the standardized address validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->