### PR TITLE
fix: Retry webhooks only for 5xx

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -94,10 +94,10 @@ export const env = createEnv({
     // In testing, 100k transactions consumes ~300mb memory.
     TRANSACTION_HISTORY_COUNT: z.coerce.number().default(100_000),
     // Sets the number of recent completed jobs in each queue.
-    QUEUE_COMPLETE_HISTORY_COUNT: z.coerce.number().default(10_000),
+    QUEUE_COMPLETE_HISTORY_COUNT: z.coerce.number().default(2_000),
     // Sets the number of recent failed jobs in each queue.
     // These limits are higher to debug failed jobs.
-    QUEUE_FAIL_HISTORY_COUNT: z.coerce.number().default(25_000),
+    QUEUE_FAIL_HISTORY_COUNT: z.coerce.number().default(20_000),
     // Sets the number of recent nonces to map to queue IDs.
     NONCE_MAP_COUNT: z.coerce.number().default(10_000),
   },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update environment variables and type definitions for improved configuration and better error handling in webhook processing.

### Detailed summary
- Updated `QUEUE_COMPLETE_HISTORY_COUNT` and `QUEUE_FAIL_HISTORY_COUNT` in `env.ts`.
- Refactored type imports in `sendWebhookWorker.ts` for clarity.
- Improved error handling logic in `sendWebhookWorker.ts` for webhook requests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->