### PR TITLE
fix: lower Redis batch size

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,8 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "[prisma]": {
     "editor.defaultFormatter": "Prisma.prisma"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
   }
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -134,7 +134,6 @@ export const env = createEnv({
       process.env.CONFIRM_TRANSACTION_QUEUE_CONCURRENCY,
     ENGINE_MODE: process.env.ENGINE_MODE,
     REDIS_MAXMEMORY: process.env.REDIS_MAXMEMORY,
-    // @deprecated
     __EXPERIMENTAL_REDIS_BATCH_SIZE:
       process.env.__EXPERIMENTAL_REDIS_BATCH_SIZE,
     TRANSACTION_HISTORY_COUNT: process.env.TRANSACTION_HISTORY_COUNT,

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -90,6 +90,10 @@ export const env = createEnv({
     // Sets the max amount of memory Redis can use.
     // "0" means use all available memory.
     REDIS_MAXMEMORY: z.string().default("0"),
+    // Sets the max batch Redis will handle in batch operations like MGET and UNLINK.
+    // This will be removed if a consistent batch size works for all use cases.
+    // ioredis has issues with batches over 100k+ (source: https://github.com/redis/ioredis/issues/801).
+    __EXPERIMENTAL_REDIS_BATCH_SIZE: z.coerce.number().default(50_000),
     // Sets the number of recent transactions to store. Older transactions are pruned periodically.
     // In testing, 100k transactions consumes ~300mb memory.
     TRANSACTION_HISTORY_COUNT: z.coerce.number().default(100_000),
@@ -130,6 +134,9 @@ export const env = createEnv({
       process.env.CONFIRM_TRANSACTION_QUEUE_CONCURRENCY,
     ENGINE_MODE: process.env.ENGINE_MODE,
     REDIS_MAXMEMORY: process.env.REDIS_MAXMEMORY,
+    // @deprecated
+    __EXPERIMENTAL_REDIS_BATCH_SIZE:
+      process.env.__EXPERIMENTAL_REDIS_BATCH_SIZE,
     TRANSACTION_HISTORY_COUNT: process.env.TRANSACTION_HISTORY_COUNT,
     GLOBAL_RATE_LIMIT_PER_MIN: process.env.GLOBAL_RATE_LIMIT_PER_MIN,
     DD_TRACER_ACTIVATED: process.env.DD_TRACER_ACTIVATED,

--- a/src/worker/tasks/pruneTransactionsWorker.ts
+++ b/src/worker/tasks/pruneTransactionsWorker.ts
@@ -1,4 +1,4 @@
-import { Job, Processor, Worker } from "bullmq";
+import { Worker, type Job, type Processor } from "bullmq";
 import { TransactionDB } from "../../db/transactions/db";
 import { pruneNonceMaps } from "../../db/wallets/nonceMap";
 import { env } from "../../utils/env";


### PR DESCRIPTION
Using an experimental configuration here so I can iterate without rebuilding Docker. The intent is to not keep the env var around after we align on a consistent batch size that doesn't cause a 1-4gb memory host to run out of memory

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new experimental configuration for Redis batch size and updates the `TransactionDB` class to utilize this configuration in batch operations. It also modifies the editor settings for TypeScript formatting.

### Detailed summary
- Added `__EXPERIMENTAL_REDIS_BATCH_SIZE` to `env` with a default value of `50,000`.
- Updated `TransactionDB` to use `env.__EXPERIMENTAL_REDIS_BATCH_SIZE` for batch processing instead of a hardcoded value.
- Changed editor settings in `.vscode/settings.json` to set TypeScript formatter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->