### PR TITLE
Refactor Dockerfile to cache node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,11 @@ RUN apt-get -y install python3-pip
 # Copy package.json and yarn.lock first to leverage Docker cache
 COPY package.json yarn.lock ./
 
-# Install all dependencies (including devDependencies)
-RUN yarn install --frozen-lockfile --production=false --network-timeout 1000000
-
 # Copy the rest of your code
 COPY . .
+
+# Install all dependencies (including devDependencies)
+RUN yarn install --frozen-lockfile --production=false --network-timeout 1000000
 
 # Build the project
 RUN yarn build && \


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on optimizing the Docker build process for a Node.js application by restructuring the installation of dependencies and separating the production dependencies into a distinct stage.

### Detailed summary
- Added `python3-pip` installation.
- Changed the copying order to first include `package.json` and `yarn.lock` for caching.
- Simplified dependency installation by removing the redundant second install step.
- Introduced a new build stage `prod-deps` for installing only production dependencies.
- Updated the `COPY` command to pull `node_modules` from the `prod-deps` stage instead of the `build` stage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->