### PR TITLE
fix matrix workflow build error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           cache-to: |
             type=gha,scope=${{ matrix.platform }},mode=max
             type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }},mode=max
-          tags: thirdweb/engine:nightly-${{ matrix.platform }}
+          tags: thirdweb/engine:nightly-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           build-args: |
             ENGINE_VERSION=nightly
 
@@ -55,6 +55,6 @@ jobs:
       - name: Create and Push Multi-arch Manifest (nightly)
         run: |
           docker manifest create thirdweb/engine:nightly \
-            thirdweb/engine:nightly-linux/amd64 \
-            thirdweb/engine:nightly-linux/arm64
+            thirdweb/engine:nightly-amd64 \
+            thirdweb/engine:nightly-arm64
           docker manifest push thirdweb/engine:nightly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
-# Main Branch Build Workflow for Docker Image supporting multiple architectures
 name: Build on Main Merge
 
 on:
@@ -8,13 +7,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-32
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: main # checkout the main branch to build nightly
+          ref: main
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -30,10 +32,27 @@ jobs:
         with:
           context: .
           target: prod
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: thirdweb/engine:nightly
+          tags: thirdweb/engine:nightly-${{ matrix.platform }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
             ENGINE_VERSION=nightly
+
+  merge-manifests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create and Push Multi-arch Manifest
+        run: |
+          docker manifest create thirdweb/engine:nightly \
+            thirdweb/engine:nightly-linux/amd64 \
+            thirdweb/engine:nightly-linux/arm64
+          docker manifest push thirdweb/engine:nightly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build on Main Merge
+name: Build Nightly on Main Merge
 
 on:
   push:
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          ref: main
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -34,9 +32,13 @@ jobs:
           target: prod
           platforms: ${{ matrix.platform }}
           push: true
+          cache-from: |
+            type=gha,scope=${{ matrix.platform }}
+            type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }}
+          cache-to: |
+            type=gha,scope=${{ matrix.platform }},mode=max
+            type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }},mode=max
           tags: thirdweb/engine:nightly-${{ matrix.platform }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             ENGINE_VERSION=nightly
 
@@ -50,7 +52,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Create and Push Multi-arch Manifest
+      - name: Create and Push Multi-arch Manifest (nightly)
         run: |
           docker manifest create thirdweb/engine:nightly \
             thirdweb/engine:nightly-linux/amd64 \

--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -6,8 +6,10 @@ on:
 
 jobs:
   buildImageForNewTag:
-    runs-on: ubuntu-latest-32
-    # Set environment variables
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     env:
       LATEST_TAG: ${{ (github.event.release.target_commitish == 'main') && 'thirdweb/engine:latest' || '' }}
 
@@ -15,7 +17,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          # Fetches the branch at which the release was made
           ref: ${{ github.event.release.target_commitish }}
 
       - name: Set up Docker Buildx
@@ -32,12 +33,37 @@ jobs:
         with:
           context: .
           target: prod
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: |
-            thirdweb/engine:${{ github.event.release.tag_name }}
-            ${{ env.LATEST_TAG }}
+          tags: thirdweb/engine:${{ github.event.release.tag_name }}-${{ matrix.platform }}
           build-args: |
             ENGINE_VERSION=${{ github.event.release.tag_name }}
+
+  merge-manifests:
+    needs: buildImageForNewTag
+    runs-on: ubuntu-latest
+    env:
+      LATEST_TAG: ${{ (github.event.release.target_commitish == 'main') && 'thirdweb/engine:latest' || '' }}
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create and Push Multi-arch Manifest
+        run: |
+          docker manifest create thirdweb/engine:${{ github.event.release.tag_name }} \
+            thirdweb/engine:${{ github.event.release.tag_name }}-linux/amd64 \
+            thirdweb/engine:${{ github.event.release.tag_name }}-linux/arm64
+          docker manifest push thirdweb/engine:${{ github.event.release.tag_name }}
+
+      - name: Create and Push Latest Tag (if applicable)
+        if: ${{ env.LATEST_TAG != '' }}
+        run: |
+          docker manifest create thirdweb/engine:latest \
+            thirdweb/engine:${{ github.event.release.tag_name }}-linux/amd64 \
+            thirdweb/engine:${{ github.event.release.tag_name }}-linux/arm64
+          docker manifest push thirdweb/engine:latest

--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -41,7 +41,9 @@ jobs:
           cache-to: |
             type=gha,scope=${{ matrix.platform }},mode=max
             type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }},mode=max
-          tags: thirdweb/engine:${{ github.event.release.tag_name }}-${{ matrix.platform }}
+          tags: |
+            thirdweb/engine:${{ github.event.release.tag_name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+            ${{ env.LATEST_TAG != '' && format('thirdweb/engine:latest-{0}', matrix.platform == 'linux/amd64' && 'amd64' || 'arm64') || '' }}
           build-args: |
             ENGINE_VERSION=${{ github.event.release.tag_name }}
 
@@ -57,17 +59,17 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Create and Push Multi-arch Manifest
+      - name: Create and Push Multi-arch Manifest (release tag)
         run: |
           docker manifest create thirdweb/engine:${{ github.event.release.tag_name }} \
-            thirdweb/engine:${{ github.event.release.tag_name }}-linux/amd64 \
-            thirdweb/engine:${{ github.event.release.tag_name }}-linux/arm64
+            thirdweb/engine:${{ github.event.release.tag_name }}-amd64 \
+            thirdweb/engine:${{ github.event.release.tag_name }}-arm64
           docker manifest push thirdweb/engine:${{ github.event.release.tag_name }}
 
       - name: Create and Push Latest Tag (if applicable)
         if: ${{ env.LATEST_TAG != '' }}
         run: |
           docker manifest create thirdweb/engine:latest \
-            thirdweb/engine:${{ github.event.release.tag_name }}-linux/amd64 \
-            thirdweb/engine:${{ github.event.release.tag_name }}-linux/arm64
+            thirdweb/engine:latest-amd64 \
+            thirdweb/engine:latest-arm64
           docker manifest push thirdweb/engine:latest

--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -35,8 +35,12 @@ jobs:
           target: prod
           platforms: ${{ matrix.platform }}
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha,scope=${{ matrix.platform }}
+            type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }}
+          cache-to: |
+            type=gha,scope=${{ matrix.platform }},mode=max
+            type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }},mode=max
           tags: thirdweb/engine:${{ github.event.release.tag_name }}-${{ matrix.platform }}
           build-args: |
             ENGINE_VERSION=${{ github.event.release.tag_name }}


### PR DESCRIPTION
This fixes build errors caused due to multiple `/` characters in the image tag

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflows to support multi-architecture builds and improve naming conventions for Docker images. It modifies existing jobs to utilize a matrix strategy for `linux/amd64` and `linux/arm64`, enhancing build efficiency and organization.

### Detailed summary
- Renamed job from `Build on Main Merge` to `Build Nightly on Main Merge`.
- Changed `runs-on` from `ubuntu-latest-32` to `ubuntu-latest`.
- Introduced matrix strategy for platforms in both workflows.
- Updated Docker build steps to use matrix platforms.
- Added caching configuration for multi-architecture builds.
- Created and pushed multi-arch manifests for nightly and release tags.
- Added login steps to DockerHub for both workflows.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->