### PR TITLE
Remove Registry Cache in gh workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,8 @@ jobs:
           target: prod
           platforms: ${{ matrix.platform }}
           push: true
-          cache-from: |
-            type=gha,scope=${{ matrix.platform }}
-            type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }}
-          cache-to: |
-            type=gha,scope=${{ matrix.platform }},mode=max
-            type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }},mode=max
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
           tags: thirdweb/engine:nightly-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           build-args: |
             ENGINE_VERSION=nightly

--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -35,12 +35,8 @@ jobs:
           target: prod
           platforms: ${{ matrix.platform }}
           push: true
-          cache-from: |
-            type=gha,scope=${{ matrix.platform }}
-            type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }}
-          cache-to: |
-            type=gha,scope=${{ matrix.platform }},mode=max
-            type=registry,ref=thirdweb/engine:buildcache-${{ matrix.platform }},mode=max
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
           tags: |
             thirdweb/engine:${{ github.event.release.tag_name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
             ${{ env.LATEST_TAG != '' && format('thirdweb/engine:latest-{0}', matrix.platform == 'linux/amd64' && 'amd64' || 'arm64') || '' }}


### PR DESCRIPTION
removed dockerhub registry cache, using only gh action cache (like original)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the caching configuration in the GitHub Actions workflows for building Docker images. It simplifies the syntax for `cache-from` and `cache-to` parameters in two workflow files.

### Detailed summary
- Updated `.github/workflows/main.yml`:
  - Changed `cache-from` to a single line format.
  - Changed `cache-to` to a single line format.
  
- Updated `.github/workflows/tagBasedImageBuild.yml`:
  - Changed `cache-from` to a single line format.
  - Changed `cache-to` to a single line format.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->