### PR TITLE
use arm-runners, upgrade actions, refactor merge manifest stage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,52 +5,90 @@ on:
     branches:
       - main
 
+env:
+  REGISTRY_IMAGE: thirdweb/engine
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
-
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and Push Docker Image
-        uses: docker/build-push-action@v2
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: prod
+          tags: thirdweb/engine:nightly-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           platforms: ${{ matrix.platform }}
-          push: true
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
-          tags: thirdweb/engine:nightly-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
-          build-args: |
-            ENGINE_VERSION=nightly
+          build-args: ENGINE_VERSION=nightly
 
-  merge-manifests:
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Create and Push Multi-arch Manifest (nightly)
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
         run: |
-          docker manifest create thirdweb/engine:nightly \
-            thirdweb/engine:nightly-amd64 \
-            thirdweb/engine:nightly-arm64
-          docker manifest push thirdweb/engine:nightly
+          docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:nightly \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:nightly

--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -4,68 +4,104 @@ on:
   release:
     types: [created] # This listens to release creation events
 
+env:
+  REGISTRY_IMAGE: thirdweb/engine
+
 jobs:
-  buildImageForNewTag:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm64
     env:
-      LATEST_TAG: ${{ (github.event.release.target_commitish == 'main') && 'thirdweb/engine:latest' || '' }}
+      LATEST_TAG: ${{ github.event.release.target_commitish == 'main' && 'thirdweb/engine:latest' || '' }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.release.target_commitish }}
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: prod
           platforms: ${{ matrix.platform }}
-          push: true
+          tags: |
+              ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+              ${{ env.LATEST_TAG != '' && format('thirdweb/engine:latest-{0}', matrix.platform == 'linux/amd64' && 'amd64' || 'arm64') || '' }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
-          tags: |
-            thirdweb/engine:${{ github.event.release.tag_name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
-            ${{ env.LATEST_TAG != '' && format('thirdweb/engine:latest-{0}', matrix.platform == 'linux/amd64' && 'amd64' || 'arm64') || '' }}
-          build-args: |
-            ENGINE_VERSION=${{ github.event.release.tag_name }}
+          build-args: ENGINE_VERSION=${{ github.event.release.tag_name }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
   merge-manifests:
-    needs: buildImageForNewTag
+    needs: build
     runs-on: ubuntu-latest
     env:
-      LATEST_TAG: ${{ (github.event.release.target_commitish == 'main') && 'thirdweb/engine:latest' || '' }}
+      LATEST_TAG: ${{ github.event.release.target_commitish == 'main' && 'thirdweb/engine:latest' || '' }}
     steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Create and Push Multi-arch Manifest (release tag)
+        working-directory: /tmp/digests
         run: |
-          docker manifest create thirdweb/engine:${{ github.event.release.tag_name }} \
-            thirdweb/engine:${{ github.event.release.tag_name }}-amd64 \
-            thirdweb/engine:${{ github.event.release.tag_name }}-arm64
-          docker manifest push thirdweb/engine:${{ github.event.release.tag_name }}
+          docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }} \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
-      - name: Create and Push Latest Tag (if applicable)
+      - name: Create and Push Multi-arch Manifest (latest tag) (if applicable)
         if: ${{ env.LATEST_TAG != '' }}
         run: |
-          docker manifest create thirdweb/engine:latest \
-            thirdweb/engine:latest-amd64 \
-            thirdweb/engine:latest-arm64
-          docker manifest push thirdweb/engine:latest
+          docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:latest \
+            ${{ env.REGISTRY_IMAGE }}@sha256:${{ steps.build.outputs.digest }}
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating GitHub Actions workflows for building and pushing Docker images. It introduces a matrix strategy for multi-architecture support, updates action versions, and enhances digest handling for better image management.

### Detailed summary
- Added `env` variable `REGISTRY_IMAGE` for image registry.
- Implemented a matrix strategy for `linux/amd64` and `linux/arm64`.
- Updated GitHub Actions versions from `v2` to `v3` and `v6`.
- Introduced digest export and upload steps.
- Replaced Docker manifest commands with `buildx imagetools` commands for image creation and inspection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->