### PR TITLE
remove digest based merge strategy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -36,59 +31,32 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push by digest
+      - name: Build and push image
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           target: prod
+          push: true
           tags: thirdweb/engine:nightly-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
           build-args: ENGINE_VERSION=nightly
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
+  merge-manifests:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
+      - name: Create and Push Multi-arch Manifest
         run: |
-          docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:nightly \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:nightly
+          docker manifest create thirdweb/engine:nightly \
+            thirdweb/engine:nightly-amd64 \
+            thirdweb/engine:nightly-arm64
+          docker manifest push thirdweb/engine:nightly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create and Push Multi-arch Manifest
         run: |
-          docker manifest create thirdweb/engine:nightly \
-            thirdweb/engine:nightly-amd64 \
-            thirdweb/engine:nightly-arm64
-          docker manifest push thirdweb/engine:nightly
+          docker manifest create ${{ env.REGISTRY_IMAGE }}:nightly \
+            ${{ env.REGISTRY_IMAGE }}:nightly-amd64 \
+            ${{ env.REGISTRY_IMAGE }}:nightly-arm64
+          docker manifest push ${{ env.REGISTRY_IMAGE }}:nightly

--- a/.github/workflows/tagBasedImageBuild.yml
+++ b/.github/workflows/tagBasedImageBuild.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           ref: ${{ github.event.release.target_commitish }}
 
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -46,27 +41,13 @@ jobs:
           context: .
           target: prod
           platforms: ${{ matrix.platform }}
+          push: true
           tags: |
               ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
               ${{ env.LATEST_TAG != '' && format('thirdweb/engine:latest-{0}', matrix.platform == 'linux/amd64' && 'amd64' || 'arm64') || '' }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
           build-args: ENGINE_VERSION=${{ github.event.release.tag_name }}
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
 
   merge-manifests:
     needs: build
@@ -74,34 +55,24 @@ jobs:
     env:
       LATEST_TAG: ${{ github.event.release.target_commitish == 'main' && 'thirdweb/engine:latest' || '' }}
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Create and Push Multi-arch Manifest (release tag)
-        working-directory: /tmp/digests
+      - name:  Create and Push Multi-arch Manifest (release tag)
         run: |
-          docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }} \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          docker manifest create ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }} \
+            ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }}-amd64 \
+            ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }}-arm64
+          docker manifest push ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }}
 
-      - name: Create and Push Multi-arch Manifest (latest tag) (if applicable)
+
+      - name:  Create and Push Multi-arch Manifest (latest tag) (if applicable)
         if: ${{ env.LATEST_TAG != '' }}
         run: |
-          docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:latest \
-            ${{ env.REGISTRY_IMAGE }}@sha256:${{ steps.build.outputs.digest }}
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ github.event.release.tag_name }}
+          docker manifest create ${{ env.REGISTRY_IMAGE }}:latest \
+            ${{ env.REGISTRY_IMAGE }}:latest-arm64 \
+            ${{ env.REGISTRY_IMAGE }}:latest-amd64
+          docker manifest push ${{ env.REGISTRY_IMAGE }}:latest


### PR DESCRIPTION
cannot push using digest and tag an image at the same time, so reverting back to tag based merge strategy.
digest based strategy was needed because older versions of `docker/build-push-action` created a manifest instead of a single image even when a single `platform` was specified.

`docker/build-push-action@v6` should have fixed this issue, and tag based merge shoudl work.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates GitHub Actions workflows to enhance Docker image building and manifest creation. It simplifies steps, improves image tagging, and ensures multi-architecture support.

### Detailed summary
- Renamed `Build and push by digest` to `Build and push image`.
- Added `push: true` to build configurations.
- Updated manifest creation commands for multi-arch support.
- Removed unnecessary steps for digest export and upload.
- Consolidated and clarified Docker build arguments and tags.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->