### PR TITLE
fix: limit 'to' check in getPopulatedOrErroredTransaction to UserOp only

### DIFF
--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -425,7 +425,7 @@ export const getPopulatedOrErroredTransaction = async (
     const to = queuedTransaction.to ?? queuedTransaction.target;
 
     if (!from) throw new Error("Invalid transaction parameters: from");
-    if (!to) throw new Error("Invalid transaction parameters: to");
+    if (queuedTransaction.isUserOp && !to) throw new Error("Invalid transaction parameters: to");
 
     const populatedTransaction = await toSerializableTransaction({
       from: getChecksumAddress(from),


### PR DESCRIPTION
Hi. As this is my first PR for this repository, there might be some aspects of my approach that are lacking. I would greatly appreciate any feedback or suggestions you may have.

## Changes

Resolve an issue where the "Invalid transaction parameters: to" error occurs and prevents execution when deploying a published contract (`/deploy/{chain}/{publisher}/{contractName}`) in cases where it's not a UserOp.

### Bug Details

In the commit fc035fcec85e95afb8d48ecd547e205546f8f9ab, the constant `to` and its corresponding check were added to the function `getPopulatedOrErroredTransaction` in src/worker/tasks/sendTransactionWorker.ts.

https://github.com/thirdweb-dev/engine/blob/c122473126e627c73df73d8d7548753d5868b2da/src/worker/tasks/sendTransactionWorker.ts#L425

On the other hand, in src/db/transactions/queueTx.ts, for a QueuedTransaction intended for deploying a Published contract that is not a UserOp, the 'to' field is set to undefined, and the 'target' field is not set at all, as shown below:
https://github.com/thirdweb-dev/engine/blob/c122473126e627c73df73d8d7548753d5868b2da/src/db/transactions/queueTx.ts#L93


### Proposed Solution

Limit the check for the constant `to` in `getPopulatedOrErroredTransaction` to only when it's a UserOp.


## How this PR will be tested

- [x] After modifying the code, I started the engine locally and executed a POST request to `/deploy/{chain}/{publisher}/{contractName}`. I then verified that the transaction issued as a result of this request was successfully mined.

## Output
``` bash
curl -X 'GET' \
  'http://localhost:3005/transaction/status/DAF-2c13acb8-4872-6d0b-9570-aa0baa691c2a' \
  -H 'accept: application/json' \
...
```

``` json
{
  "result": {
    "queueId": "DAF-2c13acb8-4872-6d0b-9570-aa0baa691c2a",
    "status": "mined",
    "chainId": "80002",
    ...
    "transactionHash": "0x29a937cd1f650458d91c9e0d68708d31642c22176dbb4647241ab057a9c8f75d",
    "queuedAt": "2024-09-29T05:31:46.033Z",
    "sentAt": "2024-09-29T05:31:49.301Z",
    "minedAt": "2024-09-29T05:31:57.372Z",
    ...
  }
}
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the validation logic for transaction parameters in the `sendTransactionWorker.ts` file to ensure that the `to` parameter is only required for user operations.

### Detailed summary
- Changed the condition for throwing an error for the `to` parameter.
- The error for the `to` parameter is now only thrown if `queuedTransaction.isUserOp` is true.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->