### PR TITLE
chore: Increase nonce check to alert after 5 minutes

### DIFF
--- a/src/worker/tasks/nonceHealthCheckWorker.ts
+++ b/src/worker/tasks/nonceHealthCheckWorker.ts
@@ -13,8 +13,8 @@ import { logWorkerExceptions } from "../queues/queues";
 // Configuration
 
 // Number of consecutive periods to check
-// Checking over multiple periods helps to avoid false positives due to timing issues
-const CHECK_PERIODS = 3;
+// Checking over multiple periods avoids false positives due to intermittent stale RPC responses.
+const CHECK_PERIODS = 5;
 
 // Frequency of the worker
 const RUN_FREQUENCY_SECONDS = 60; // Run every minute


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the `CHECK_PERIODS` constant in the `nonceHealthCheckWorker.ts` file to increase the number of periods checked, which aims to improve the reliability of the health check by reducing false positives from RPC responses.

### Detailed summary
- Updated the comment for `CHECK_PERIODS` to clarify its purpose.
- Changed the value of `CHECK_PERIODS` from `3` to `5`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->