### PR TITLE
chore: always parse function name for transaction receipts

### DIFF
--- a/src/worker/tasks/processTransactionReceiptsWorker.ts
+++ b/src/worker/tasks/processTransactionReceiptsWorker.ts
@@ -1,17 +1,17 @@
-import { Prisma } from "@prisma/client";
-import { AbiEvent } from "abitype";
-import { Job, Processor, Worker } from "bullmq";
+import type { Prisma } from "@prisma/client";
+import type { AbiEvent } from "abitype";
+import { Worker, type Job, type Processor } from "bullmq";
 import superjson from "superjson";
 import {
-  Address,
-  ThirdwebContract,
   eth_getBlockByNumber,
   eth_getTransactionReceipt,
   getContract,
   getRpcClient,
+  type Address,
+  type ThirdwebContract,
 } from "thirdweb";
 import { resolveContractAbi } from "thirdweb/contract";
-import { Abi, Hash, decodeFunctionData } from "viem";
+import { decodeFunctionData, type Abi, type Hash } from "viem";
 import { bulkInsertContractTransactionReceipts } from "../../db/contractTransactionReceipts/createContractTransactionReceipts";
 import { WebhooksEventTypes } from "../../schema/webhooks";
 import { getChain } from "../../utils/chain";
@@ -20,8 +20,8 @@ import { normalizeAddress } from "../../utils/primitiveTypes";
 import { redis } from "../../utils/redis/redis";
 import { thirdwebClient } from "../../utils/sdk";
 import {
-  EnqueueProcessTransactionReceiptsData,
   ProcessTransactionReceiptsQueue,
+  type EnqueueProcessTransactionReceiptsData,
 } from "../queues/processTransactionReceiptsQueue";
 import { logWorkerExceptions } from "../queues/queues";
 import { SendWebhookQueue } from "../queues/sendWebhookQueue";
@@ -55,9 +55,8 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
   }
 
   // Enqueue webhooks.
-  const webhooksByContractAddress = await getWebhooksByContractAddresses(
-    chainId,
-  );
+  const webhooksByContractAddress =
+    await getWebhooksByContractAddresses(chainId);
   for (const transactionReceipt of insertedReceipts) {
     const webhooks =
       webhooksByContractAddress[transactionReceipt.contractAddress] ?? [];
@@ -154,17 +153,16 @@ const getFormattedTransactionReceipts = async ({
         continue;
       }
 
-      let functionName: string | undefined = undefined;
-      if (config.functions.length > 0) {
-        functionName = await getFunctionName({
-          contract: config.contract,
-          data: transaction.input,
-        });
-
-        if (!config.functions.includes(functionName)) {
-          // This transaction is not for a subscribed function name.
-          continue;
-        }
+      const functionName = await getFunctionName({
+        contract: config.contract,
+        data: transaction.input,
+      });
+      if (
+        config.functions.length > 0 &&
+        !config.functions.includes(functionName)
+      ) {
+        // This transaction is not for a subscribed function name.
+        continue;
       }
 
       // Store the transaction and receipt.


### PR DESCRIPTION
Tested correctness locally: `functionName` is set when not filtering by any functions.

Benchmarks of calling `resolveContractAbi` multiple times:
```
760.94ms
42.75ms
44.68ms
46.22ms
41.20ms
39.41ms
37.33ms
48.18ms
39.59ms
40.57ms
```
 

<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating type imports and improving code readability in the `src/worker/tasks/processTransactionReceiptsWorker.ts` file. It also refines the handling of function names for transaction receipts.

### Detailed summary
- Changed import statements to use `type` for type-only imports.
- Updated the handling of `const webhooksByContractAddress` for better readability.
- Refactored the function name retrieval logic to streamline checks against subscribed function names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->