### PR TITLE
fix: gracefully handle functionName

### DIFF
--- a/src/worker/tasks/processTransactionReceiptsWorker.ts
+++ b/src/worker/tasks/processTransactionReceiptsWorker.ts
@@ -153,15 +153,21 @@ const getFormattedTransactionReceipts = async ({
         continue;
       }
 
-      const functionName = await getFunctionName({
-        contract: config.contract,
-        data: transaction.input,
-      });
+      let functionName: string | undefined;
+      try {
+        functionName = await getFunctionName({
+          contract: config.contract,
+          data: transaction.input,
+        });
+      } catch {
+        // Unable to parse function. Continue.
+      }
+
       if (
         config.functions.length > 0 &&
-        !config.functions.includes(functionName)
+        (!functionName || !config.functions.includes(functionName))
       ) {
-        // This transaction is not for a subscribed function name.
+        // Function not found, or this transaction is not for a subscribed function.
         continue;
       }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances error handling in the `processTransactionReceiptsWorker.ts` file by wrapping the function name retrieval in a `try-catch` block. It ensures that if the function name cannot be parsed, the process continues without interruption.

### Detailed summary
- Introduced a `try-catch` block around the `getFunctionName` call to handle potential errors.
- Changed `const` to `let` for `functionName` to allow for undefined assignment.
- Updated the condition to check if `functionName` is undefined or not included in `config.functions`.
- Modified comments for clarity regarding function name checks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->