### PR TITLE
Fix: Support cloudflare proxy IP

### DIFF
--- a/src/scripts/apply-migrations.ts
+++ b/src/scripts/apply-migrations.ts
@@ -26,7 +26,7 @@ const main = async () => {
 
     logger({
       level: "info",
-      message: "Completed migrations without errors.",
+      message: "Completed migrations successfully.",
       service: "server",
     });
   } catch (e) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -50,14 +50,23 @@ export const initServer = async () => {
     };
   }
 
+  // env.TRUST_PROXY is used to determine if the X-Forwarded-For header should be trusted.
+  // This option is force enabled for cloud-hosted Engines.
+  // See: https://fastify.dev/docs/latest/Reference/Server/#trustproxy
+  const trustProxy = env.TRUST_PROXY || !!env.ENGINE_TIER;
+  if (trustProxy) {
+    logger({
+      service: "server",
+      level: "info",
+      message: "Server is enabled with trustProxy.",
+    });
+  }
+
   // Start the server with middleware.
   const server: FastifyInstance = fastify({
     connectionTimeout: SERVER_CONNECTION_TIMEOUT,
     disableRequestLogging: true,
-    // env.TRUST_PROXY is used to determine if the X-Forwarded-For header should be trusted.
-    // This option is force enabled for cloud-hosted Engines.
-    // See: https://fastify.dev/docs/latest/Reference/Server/#trustproxy
-    trustProxy: env.TRUST_PROXY || !!env.ENGINE_TIER,
+    trustProxy,
     ...(env.ENABLE_HTTPS ? httpsObject : {}),
   }).withTypeProvider<TypeBoxTypeProvider>();
 

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -408,12 +408,6 @@ const handleAccessToken = async (
       message: `Unauthorized IP address: ${req.ip}`,
     });
 
-    logger({
-      service: "server",
-      level: "error",
-      message: `[DEBUG] Request headers: ${JSON.stringify(req.headers)}`,
-    });
-
     return {
       isAuthed: false,
       error:
@@ -532,10 +526,20 @@ const hashRequestBody = (req: FastifyRequest): string => {
  */
 const checkIpInAllowlist = async (req: FastifyRequest) => {
   const config = await getConfig();
-
   if (config.ipAllowlist.length === 0) {
     return true;
   }
 
-  return config.ipAllowlist.includes(req.ip);
+  let ip = req.ip;
+  if (req.headers["cf-connecting-ip"]) {
+    ip = req.headers["cf-connecting-ip"] as string;
+  }
+
+  logger({
+    service: "server",
+    level: "error",
+    message: `[DEBUG] Request ip: ${ip}`,
+  });
+
+  return config.ipAllowlist.includes(ip);
 };

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -525,17 +525,16 @@ const hashRequestBody = (req: FastifyRequest): string => {
  */
 const checkIpInAllowlist = async (
   req: FastifyRequest,
-): Promise<
-  { isAllowed: false; ip: string } | { isAllowed: true; ip?: string }
-> => {
-  const config = await getConfig();
-  if (config.ipAllowlist.length === 0) {
-    return { isAllowed: true };
+): Promise<{ isAllowed: boolean; ip: string }> => {
+  let ip = req.ip;
+  const trustProxy = env.TRUST_PROXY || !!env.ENGINE_TIER;
+  if (trustProxy && req.headers["cf-connecting-ip"]) {
+    ip = req.headers["cf-connecting-ip"] as string;
   }
 
-  let ip = req.ip;
-  if (req.headers["cf-connecting-ip"]) {
-    ip = req.headers["cf-connecting-ip"] as string;
+  const config = await getConfig();
+  if (config.ipAllowlist.length === 0) {
+    return { isAllowed: true, ip };
   }
 
   return {

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -411,7 +411,7 @@ const handleAccessToken = async (
     logger({
       service: "server",
       level: "error",
-      message: `[DEBUG] Request headers: ${req.headers}`,
+      message: `[DEBUG] Request headers: ${JSON.stringify(req.headers)}`,
     });
 
     return {

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -407,6 +407,13 @@ const handleAccessToken = async (
       level: "error",
       message: `Unauthorized IP address: ${req.ip}`,
     });
+
+    logger({
+      service: "server",
+      level: "error",
+      message: `[DEBUG] Request headers: ${req.headers}`,
+    });
+
     return {
       isAuthed: false,
       error:


### PR DESCRIPTION
Support cloudflare proxy IP only if trustProxy is enabled.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving logging messages, enhancing IP address checking functionality, and refactoring the `checkIpInAllowlist` function to return more detailed information about IP checks.

### Detailed summary
- Updated log message in `src/scripts/apply-migrations.ts` for migration completion.
- Added logging for `trustProxy` status in `src/server/index.ts`.
- Refactored `checkIpInAllowlist` in `src/server/middleware/auth.ts` to return an object containing `isAllowed` and `ip`.
- Updated error messages to include the checked IP instead of the request IP.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->