### PR TITLE
fix: stringify error objects

### DIFF
--- a/src/server/routes/contract/write/write.ts
+++ b/src/server/routes/contract/write/write.ts
@@ -2,7 +2,7 @@ import { Type, type Static } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { prepareContractCall, resolveMethod } from "thirdweb";
-import type { AbiFunction } from "thirdweb/utils";
+import { stringify, type AbiFunction } from "thirdweb/utils";
 import { getContractV5 } from "../../../../utils/cache/getContractv5";
 import { queueTransaction } from "../../../../utils/transaction/queueTransation";
 import { createCustomError } from "../../../middleware/error";
@@ -83,7 +83,11 @@ export async function writeToContract(fastify: FastifyInstance) {
       try {
         method = await resolveMethod(functionName)(contract);
       } catch (e: any) {
-        throw createCustomError(`${e}`, StatusCodes.BAD_REQUEST, "BAD_REQUEST");
+        throw createCustomError(
+          stringify(e),
+          StatusCodes.BAD_REQUEST,
+          "BAD_REQUEST",
+        );
       }
       const transaction = prepareContractCall({
         contract,

--- a/src/utils/transaction/queueTransation.ts
+++ b/src/utils/transaction/queueTransation.ts
@@ -6,6 +6,7 @@ import {
   type Hex,
   type PreparedTransaction,
 } from "thirdweb";
+import { stringify } from "thirdweb/utils";
 import { createCustomError } from "../../server/middleware/error";
 import type { txOverridesWithValueSchema } from "../../server/schemas/txOverrides";
 import { parseTransactionOverrides } from "../../server/utils/transactionOverrides";
@@ -41,7 +42,11 @@ export async function queueTransaction(args: QueuedTransactionParams) {
   try {
     data = await encode(transaction);
   } catch (e) {
-    throw createCustomError(`${e}`, StatusCodes.BAD_REQUEST, "BAD_REQUEST");
+    throw createCustomError(
+      stringify(e),
+      StatusCodes.BAD_REQUEST,
+      "BAD_REQUEST",
+    );
   }
 
   const insertedTransaction: InsertedTransaction = {

--- a/src/worker/tasks/sendTransactionWorker.ts
+++ b/src/worker/tasks/sendTransactionWorker.ts
@@ -151,7 +151,7 @@ const _sendUserOp = async (
     const erroredTransaction: ErroredTransaction = {
       ...queuedTransaction,
       status: "errored",
-      errorMessage: `${e}`,
+      errorMessage: stringify(e),
     };
     job.log(
       `Failed to populate transaction: ${erroredTransaction.errorMessage}`,
@@ -231,7 +231,7 @@ const _sendTransaction = async (
     const erroredTransaction: ErroredTransaction = {
       ...queuedTransaction,
       status: "errored",
-      errorMessage: `${e}`,
+      errorMessage: stringify(e),
     };
     job.log(
       `Failed to populate transaction: ${erroredTransaction.errorMessage}`,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling by replacing string interpolation with the `stringify` function for better error message formatting across multiple files.

### Detailed summary
- In `src/worker/tasks/sendTransactionWorker.ts`, replaced `${e}` with `stringify(e)` for `errorMessage`.
- In `src/utils/transaction/queueTransation.ts`, updated error handling to use `stringify(e)` instead of `${e}`.
- In `src/server/routes/contract/write/write.ts`, changed error handling to use `stringify(e)` instead of `${e}`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->