### PR TITLE
fix: Assert strict ABI type validation

### DIFF
--- a/src/server/routes/contract/metadata/abi.ts
+++ b/src/server/routes/contract/metadata/abi.ts
@@ -1,8 +1,10 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { getContract } from "../../../../utils/cache/getContract";
-import { abiSchema } from "../../../schemas/contract";
+import { resolveContractAbi } from "thirdweb/contract";
+import { Abi } from "thirdweb/utils";
+import { getContractV5 } from "../../../../utils/cache/getContractv5";
+import { AbiSchema } from "../../../schemas/contract/abi";
 import {
   contractParamSchema,
   standardResponseSchema,
@@ -13,7 +15,7 @@ const requestSchema = contractParamSchema;
 
 // OUTPUT
 const responseSchema = Type.Object({
-  result: Type.Array(abiSchema),
+  result: AbiSchema,
 });
 
 responseSchema.example = {
@@ -79,15 +81,15 @@ export async function getABI(fastify: FastifyInstance) {
       const { chain, contractAddress } = request.params;
 
       const chainId = await getChainIdFromChain(chain);
-      const contract = await getContract({
+      const contract = await getContractV5({
         chainId,
         contractAddress,
       });
 
-      let returnData = contract.abi;
+      const abi: Abi = await resolveContractAbi(contract);
 
       reply.status(StatusCodes.OK).send({
-        result: returnData,
+        result: abi,
       });
     },
   });

--- a/src/server/routes/contract/metadata/functions.ts
+++ b/src/server/routes/contract/metadata/functions.ts
@@ -1,8 +1,10 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { getContract } from "../../../../utils/cache/getContract";
-import { abiFunctionSchema } from "../../../schemas/contract";
+import { resolveContractAbi } from "thirdweb/contract";
+import { Abi, AbiFunction } from "thirdweb/utils";
+import { getContractV5 } from "../../../../utils/cache/getContractv5";
+import { AbiFunctionSchema } from "../../../schemas/contract/abi";
 import {
   contractParamSchema,
   standardResponseSchema,
@@ -13,7 +15,7 @@ const requestSchema = contractParamSchema;
 
 // OUTPUT
 const responseSchema = Type.Object({
-  result: Type.Array(abiFunctionSchema),
+  result: Type.Array(AbiFunctionSchema),
 });
 
 responseSchema.example = {
@@ -76,15 +78,18 @@ export async function extractFunctions(fastify: FastifyInstance) {
       const { chain, contractAddress } = request.params;
 
       const chainId = await getChainIdFromChain(chain);
-      const contract = await getContract({
+      const contract = await getContractV5({
         chainId,
         contractAddress,
       });
 
-      let returnData = await contract.publishedMetadata.extractFunctions();
+      const abi: Abi = await resolveContractAbi(contract);
+      const functions = abi.filter(
+        (abiItem): abiItem is AbiFunction => abiItem.type === "function",
+      );
 
       reply.status(StatusCodes.OK).send({
-        result: returnData,
+        result: functions,
       });
     },
   });

--- a/src/server/routes/contract/write/write.ts
+++ b/src/server/routes/contract/write/write.ts
@@ -6,7 +6,7 @@ import { stringify, type AbiFunction } from "thirdweb/utils";
 import { getContractV5 } from "../../../../utils/cache/getContractv5";
 import { queueTransaction } from "../../../../utils/transaction/queueTransation";
 import { createCustomError } from "../../../middleware/error";
-import { abiSchema } from "../../../schemas/contract";
+import { AbiSchema } from "../../../schemas/contract/abi";
 import {
   contractParamSchema,
   requestQuerystringSchema,
@@ -30,7 +30,7 @@ const writeRequestBodySchema = Type.Object({
     description: "The arguments to call on the function",
   }),
   ...txOverridesWithValueSchema.properties,
-  abi: Type.Optional(Type.Array(abiSchema)),
+  abi: Type.Optional(AbiSchema),
 });
 
 // LOGIC

--- a/src/server/schemas/contract/abi.ts
+++ b/src/server/schemas/contract/abi.ts
@@ -1,0 +1,104 @@
+import { Static, Type } from "@sinclair/typebox";
+
+const AbiInternalTypeSchema = Type.String();
+
+// Source: https://abitype.dev/api/types#abistatemutability
+const AbiStateMutabilitySchema = Type.Union([
+  Type.Literal("pure"),
+  Type.Literal("view"),
+  Type.Literal("nonpayable"),
+  Type.Literal("payable"),
+]);
+
+// Source: https://abitype.dev/api/types#abiparameter
+const AbiParameterSchema = Type.Union([
+  Type.Object({
+    type: Type.String(),
+    name: Type.Optional(Type.String()),
+    internalType: Type.Optional(AbiInternalTypeSchema),
+  }),
+  Type.Object({
+    type: Type.Union([
+      Type.Literal("tuple"),
+      Type.RegExp(/^tuple\[\w+\]$/), // Matches `tuple[someString]`
+    ]),
+    name: Type.Optional(Type.String()),
+    internalType: Type.Optional(AbiInternalTypeSchema),
+    components: Type.Array(Type.Any()), // Reference to itself
+  }),
+]);
+
+// Source: https://abitype.dev/api/types#abieventparameter
+const AbiEventParameterSchema = Type.Intersect([
+  AbiParameterSchema,
+  Type.Object({
+    indexed: Type.Optional(Type.Boolean()),
+  }),
+]);
+
+// Source: https://abitype.dev/api/types#abifunction
+export const AbiFunctionSchema = Type.Object({
+  type: Type.Literal("function"),
+  name: Type.String(),
+  constant: Type.Optional(Type.Boolean()),
+  gas: Type.Optional(Type.Number()),
+  inputs: Type.Readonly(Type.Array(AbiParameterSchema)),
+  outputs: Type.Readonly(Type.Array(AbiParameterSchema)),
+  payable: Type.Optional(Type.Boolean()),
+  stateMutability: AbiStateMutabilitySchema,
+});
+
+// Source: https://abitype.dev/api/types#abievent
+export const AbiEventSchema = Type.Object({
+  type: Type.Literal("event"),
+  name: Type.String(),
+  anonymous: Type.Optional(Type.Boolean()),
+  inputs: Type.Readonly(Type.Array(AbiEventParameterSchema)),
+});
+type x = Static<typeof AbiEventSchema>;
+
+// Source: https://abitype.dev/api/types#abierror
+export const AbiErrorSchema = Type.Object({
+  type: Type.Literal("error"),
+  inputs: Type.Array(AbiParameterSchema),
+  name: Type.String(),
+});
+
+// Source: https://abitype.dev/api/types#abiconstructor
+export const AbiConstructorSchema = Type.Object({
+  type: Type.Literal("constructor"),
+  inputs: Type.Array(AbiParameterSchema),
+  payable: Type.Optional(Type.Boolean()),
+  stateMutability: Type.Union([
+    Type.Literal("payable"),
+    Type.Literal("nonpayable"),
+  ]),
+});
+
+// Source: https://abitype.dev/api/types#abifallback
+export const AbiFallbackSchema = Type.Object({
+  type: Type.Literal("fallback"),
+  payable: Type.Optional(Type.Boolean()),
+  stateMutability: Type.Union([
+    Type.Literal("payable"),
+    Type.Literal("nonpayable"),
+  ]),
+});
+
+// Source: https://abitype.dev/api/types#abireceive
+export const AbiReceiveSchema = Type.Object({
+  type: Type.Literal("receive"),
+  stateMutability: Type.Literal("payable"),
+});
+
+// Source: https://abitype.dev/api/types#abi
+export const AbiSchema = Type.Array(
+  Type.Union([
+    AbiConstructorSchema,
+    AbiErrorSchema,
+    AbiEventSchema,
+    AbiFallbackSchema,
+    AbiFunctionSchema,
+    AbiReceiveSchema,
+  ]),
+);

--- a/src/server/schemas/contract/index.ts
+++ b/src/server/schemas/contract/index.ts
@@ -21,46 +21,6 @@ export interface readSchema extends contractSchemaTypes {
   Querystring: Static<typeof readRequestQuerySchema>;
 }
 
-const abiTypeSchema = Type.Object({
-  type: Type.Optional(Type.String()),
-  name: Type.Optional(Type.String()),
-  internalType: Type.Optional(Type.String()),
-  stateMutability: Type.Optional(Type.String()),
-  components: Type.Optional(
-    Type.Array(
-      Type.Object({
-        type: Type.Optional(Type.String()),
-        name: Type.Optional(Type.String()),
-        internalType: Type.Optional(Type.String()),
-      }),
-    ),
-  ),
-});
-
-export const abiFunctionSchema = Type.Object({
-  name: Type.String(),
-  inputs: Type.Array(abiTypeSchema),
-  outputs: Type.Array(abiTypeSchema),
-  comment: Type.Optional(Type.String()),
-  signature: Type.String(),
-  stateMutability: Type.String(),
-});
-
-export const abiEventSchema = Type.Object({
-  name: Type.String(),
-  inputs: Type.Array(abiTypeSchema),
-  outputs: Type.Array(abiTypeSchema),
-  comment: Type.Optional(Type.String()),
-});
-
-export const abiSchema = Type.Object({
-  type: Type.String(),
-  name: Type.Optional(Type.String()),
-  inputs: Type.Optional(Type.Array(abiTypeSchema)),
-  outputs: Type.Optional(Type.Array(abiTypeSchema)),
-  stateMutability: Type.Optional(Type.String()),
-});
-
 export const contractEventSchema = Type.Record(Type.String(), Type.Any());
 
 export const rolesResponseSchema = Type.Object({

--- a/src/utils/cache/getContract.ts
+++ b/src/utils/cache/getContract.ts
@@ -1,17 +1,14 @@
-import { Static, Type } from "@sinclair/typebox";
+import type { Abi } from "@thirdweb-dev/sdk";
 import { StatusCodes } from "http-status-codes";
 import { createCustomError } from "../../server/middleware/error";
-import { abiSchema } from "../../server/schemas/contract";
 import { getSdk } from "./getSdk";
-
-const abiArraySchema = Type.Array(abiSchema);
 
 interface GetContractParams {
   chainId: number;
   walletAddress?: string;
   accountAddress?: string;
   contractAddress: string;
-  abi?: Static<typeof abiArraySchema>;
+  abi?: Abi;
 }
 
 export const getContract = async ({


### PR DESCRIPTION
Asserts type validation matching ABIType schema.
Tested by pasting in an entire [NFT contract ABI](https://contract.thirdweb.com/abi/84532/0xBe98166C528Ab837770dCA844bba66eA206deCFf).

<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the handling of `ABI` (Application Binary Interface) in the contract-related code. It introduces a new schema for `ABI` and refactors functions to utilize the new structure, improving type safety and consistency across the codebase.

### Detailed summary
- Changed `abi` type from `Static<typeof abiArraySchema>` to `Abi` in `getContract.ts`.
- Updated `write.ts`, `metadata/abi.ts`, `events.ts`, and `functions.ts` to use `AbiSchema` instead of `abiSchema`.
- Refactored `getContract` calls to `getContractV5`.
- Introduced new `Abi` schemas in `abi.ts` for better structure and validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->