### PR TITLE
Handle empty output in ABI for /write

### DIFF
--- a/src/scripts/generate-sdk.ts
+++ b/src/scripts/generate-sdk.ts
@@ -1,8 +1,9 @@
-import { execSync } from "child_process";
-import fs from "fs";
-import { kill } from "process";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import { kill } from "node:process";
 
-const ENGINE_OPENAPI_URL = "https://demo.web3api.thirdweb.com/json";
+// requires engine to be running locally
+const ENGINE_OPENAPI_URL = "http://localhost:3005/json";
 
 async function main() {
   try {
@@ -22,7 +23,8 @@ async function main() {
 
     const code = fs
       .readFileSync("./sdk/src/Engine.ts", "utf-8")
-      .replace(`export class Engine`, `class EngineLogic`).concat(`
+      .replace("export class Engine", "class EngineLogic")
+      .concat(`
 export class Engine extends EngineLogic {
   constructor(config: { url: string; accessToken: string; }) {
     super({ BASE: config.url, TOKEN: config.accessToken });

--- a/src/server/middleware/error.ts
+++ b/src/server/middleware/error.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
+import { stringify } from "thirdweb/utils";
 import { ZodError } from "zod";
 import { env } from "../../utils/env";
 import { parseEthersError } from "../../utils/ethers";
@@ -21,6 +22,13 @@ export const createCustomError = (
   statusCode,
   code,
 });
+
+export function formatError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return stringify(error);
+}
 
 export const customDateTimestampError = (date: string): CustomError =>
   createCustomError(

--- a/src/server/routes/transaction/blockchain/getLogs.ts
+++ b/src/server/routes/transaction/blockchain/getLogs.ts
@@ -1,15 +1,15 @@
-import { Type, type Static } from "@sinclair/typebox";
+import { type Static, Type } from "@sinclair/typebox";
 import type { AbiEvent } from "abitype";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import superjson from "superjson";
 import {
+  type Hex,
   eth_getTransactionReceipt,
   getContract,
   getRpcClient,
   parseEventLogs,
   prepareEvent,
-  type Hex,
 } from "thirdweb";
 import { resolveContractAbi } from "thirdweb/contract";
 import { TransactionDB } from "../../../../db/transactions/db";
@@ -72,6 +72,7 @@ const ParsedLogSchema = Type.Object({
 });
 
 export const responseBodySchema = Type.Object({
+  // TODO: this breaks the SDK generation, returning Any works though
   result: Type.Union([
     // ParsedLogSchema is listed before LogSchema because it is more specific.
     Type.Array(ParsedLogSchema),

--- a/src/server/routes/transaction/blockchain/getLogs.ts
+++ b/src/server/routes/transaction/blockchain/getLogs.ts
@@ -1,15 +1,15 @@
-import { type Static, Type } from "@sinclair/typebox";
+import { Type, type Static } from "@sinclair/typebox";
 import type { AbiEvent } from "abitype";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import superjson from "superjson";
 import {
-  type Hex,
   eth_getTransactionReceipt,
   getContract,
   getRpcClient,
   parseEventLogs,
   prepareEvent,
+  type Hex,
 } from "thirdweb";
 import { resolveContractAbi } from "thirdweb/contract";
 import { TransactionDB } from "../../../../db/transactions/db";
@@ -54,30 +54,31 @@ const LogSchema = Type.Object({
   blockHash: Type.String(),
   logIndex: Type.Number(),
   removed: Type.Boolean(),
+
+  // Additional properties only for parsed logs
+  eventName: Type.Optional(
+    Type.String({
+      description: "Event name, only returned when `parseLogs` is true",
+    }),
+  ),
+  args: Type.Optional(
+    Type.Unknown({
+      description: "Event arguments. Only returned when `parseLogs` is true",
+      examples: [
+        {
+          from: "0xdeadbeeefdeadbeeefdeadbeeefdeadbeeefdead",
+          to: "0xdeadbeeefdeadbeeefdeadbeeefdeadbeeefdead",
+          value: "1000000000000000000n",
+        },
+      ],
+    }),
+  ),
 });
 
-const ParsedLogSchema = Type.Object({
-  ...LogSchema.properties,
-  eventName: Type.String(),
-  args: Type.Unknown({
-    description: "Event arguments.",
-    examples: [
-      {
-        from: "0xdeadbeeefdeadbeeefdeadbeeefdeadbeeefdead",
-        to: "0xdeadbeeefdeadbeeefdeadbeeefdeadbeeefdead",
-        value: "1000000000000000000n",
-      },
-    ],
-  }),
-});
-
+// DO NOT USE type.union
+// this is known to cause issues with the generated types
 export const responseBodySchema = Type.Object({
-  // TODO: this breaks the SDK generation, returning Any works though
-  result: Type.Union([
-    // ParsedLogSchema is listed before LogSchema because it is more specific.
-    Type.Array(ParsedLogSchema),
-    Type.Array(LogSchema),
-  ]),
+  result: Type.Array(LogSchema),
 });
 
 responseBodySchema.example = {
@@ -222,7 +223,7 @@ export async function getTransactionLogs(fastify: FastifyInstance) {
 
       reply.status(StatusCodes.OK).send({
         result: superjson.serialize(parsedLogs).json as Static<
-          typeof ParsedLogSchema
+          typeof LogSchema
         >[],
       });
     },

--- a/src/server/schemas/contract/index.ts
+++ b/src/server/schemas/contract/index.ts
@@ -1,4 +1,4 @@
-import { Type, type Static } from "@sinclair/typebox";
+import { type Static, Type } from "@sinclair/typebox";
 import type { contractSchemaTypes } from "../sharedApiSchemas";
 
 /**
@@ -60,6 +60,9 @@ export const abiSchema = Type.Object({
   outputs: Type.Optional(Type.Array(abiTypeSchema)),
   stateMutability: Type.Optional(Type.String()),
 });
+
+export const abiArraySchema = Type.Array(abiSchema);
+export type AbiSchemaType = Static<typeof abiArraySchema>;
 
 export const contractEventSchema = Type.Record(Type.String(), Type.Any());
 

--- a/src/server/utils/abi.ts
+++ b/src/server/utils/abi.ts
@@ -1,0 +1,17 @@
+import type { Abi } from "thirdweb/utils";
+import type { AbiSchemaType } from "../schemas/contract";
+
+export function sanitizeAbi(abi: AbiSchemaType | undefined): Abi | undefined {
+  if (!abi) return undefined;
+  return abi.map((item) => {
+    if (item.type === "function") {
+      return {
+        ...item,
+        // older versions of engine allowed passing in empty inputs/outputs, but necesasry for abi validation
+        inputs: item.inputs || [],
+        outputs: item.outputs || [],
+      };
+    }
+    return item;
+  }) as Abi;
+}

--- a/src/utils/cache/getContractv5.ts
+++ b/src/utils/cache/getContractv5.ts
@@ -1,11 +1,12 @@
-import { getContract } from "thirdweb";
+import { type ThirdwebContract, getContract } from "thirdweb";
+import type { Abi } from "thirdweb/utils";
 import { thirdwebClient } from "../../utils/sdk";
 import { getChain } from "../chain";
 
 interface GetContractParams {
   chainId: number;
   contractAddress: string;
-  abi?: any;
+  abi?: Abi;
 }
 
 // Using new v5 SDK
@@ -13,7 +14,7 @@ export const getContractV5 = async ({
   chainId,
   contractAddress,
   abi,
-}: GetContractParams) => {
+}: GetContractParams): Promise<ThirdwebContract> => {
   const definedChain = await getChain(chainId);
 
   // get a contract
@@ -25,5 +26,5 @@ export const getContractV5 = async ({
     // the chain the contract is deployed on
     chain: definedChain,
     abi,
-  });
+  }) as ThirdwebContract; // not using type inference here;
 };

--- a/src/utils/transaction/queueTransation.ts
+++ b/src/utils/transaction/queueTransation.ts
@@ -1,10 +1,10 @@
 import type { Static } from "@sinclair/typebox";
 import { StatusCodes } from "http-status-codes";
 import {
-  encode,
   type Address,
   type Hex,
   type PreparedTransaction,
+  encode,
 } from "thirdweb";
 import { stringify } from "thirdweb/utils";
 import { createCustomError } from "../../server/middleware/error";

--- a/test/e2e/tests/smoke.test.ts
+++ b/test/e2e/tests/smoke.test.ts
@@ -12,16 +12,13 @@ describe("Smoke Test", () => {
       backendWallet,
       {
         amount: "0",
-        currencyAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         to: backendWallet,
       },
     );
 
-    expect(res.result.queueId).toBeDefined();
-
     const transactionStatus = await pollTransactionStatus(
       engine,
-      res.result.queueId!,
+      res.result.queueId,
       true,
     );
 

--- a/test/e2e/tests/write.test.ts
+++ b/test/e2e/tests/write.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import assert from "node:assert";
 import type { Address } from "thirdweb";
 import { zeroAddress } from "viem";
 import type { ApiError } from "../../../sdk/dist/thirdweb-dev-engine.cjs";
@@ -15,7 +16,7 @@ describe("Write Tests", () => {
   beforeAll(async () => {
     const { engine: _engine, backendWallet: _backendWallet } = await setup();
     engine = _engine;
-    backendWallet = _backendWallet;
+    backendWallet = _backendWallet as Address;
 
     const res = await engine.deploy.deployToken(
       CONFIG.CHAIN.id.toString(),
@@ -32,16 +33,18 @@ describe("Write Tests", () => {
     );
 
     expect(res.result.queueId).toBeDefined();
+    assert(res.result.queueId, "queueId must be defined");
     expect(res.result.deployedAddress).toBeDefined();
 
     const transactionStatus = await pollTransactionStatus(
       engine,
-      res.result.queueId!,
+      res.result.queueId,
       true,
     );
 
     expect(transactionStatus.minedAt).toBeDefined();
-    tokenContractAddress = res.result.deployedAddress!;
+    assert(res.result.deployedAddress, "deployedAddress must be defined");
+    tokenContractAddress = res.result.deployedAddress;
     console.log("tokenContractAddress", tokenContractAddress);
   });
 
@@ -60,7 +63,7 @@ describe("Write Tests", () => {
 
     const writeTransactionStatus = await pollTransactionStatus(
       engine,
-      writeRes.result.queueId!,
+      writeRes.result.queueId,
       true,
     );
 
@@ -82,7 +85,7 @@ describe("Write Tests", () => {
 
     const writeTransactionStatus = await pollTransactionStatus(
       engine,
-      writeRes.result.queueId!,
+      writeRes.result.queueId,
       true,
     );
 
@@ -118,7 +121,7 @@ describe("Write Tests", () => {
 
     const writeTransactionStatus = await pollTransactionStatus(
       engine,
-      writeRes.result.queueId!,
+      writeRes.result.queueId,
       true,
     );
 
@@ -132,7 +135,7 @@ describe("Write Tests", () => {
       backendWallet,
       {
         functionName: "setContractURI",
-        args: ["https://abi-test.com"],q
+        args: ["https://abi-test.com"],
         abi: [
           {
             inputs: [
@@ -153,7 +156,7 @@ describe("Write Tests", () => {
 
     const writeTransactionStatus = await pollTransactionStatus(
       engine,
-      writeRes.result.queueId!,
+      writeRes.result.queueId,
       true,
     );
 

--- a/test/e2e/utils/engine.ts
+++ b/test/e2e/utils/engine.ts
@@ -16,8 +16,8 @@ export const createChain = async (engine: Engine) => {
   const chains = await engine.configuration.getChainsConfiguration();
 
   if (chains.result) {
-    const parsedChains = JSON.parse(chains.result);
-    if (parsedChains.find((chain: any) => chain.chainId === CONFIG.CHAIN.id)) {
+    const parsedChains = chains.result;
+    if (parsedChains.find((chain) => chain.chainId === CONFIG.CHAIN.id)) {
       console.log("Anvil chain already exists in engine");
       return;
     }

--- a/test/e2e/utils/wallets.ts
+++ b/test/e2e/utils/wallets.ts
@@ -10,7 +10,7 @@ export const ANVIL_PKEY_C =
 export const ANVIL_PKEY_D =
   "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6";
 
-const client = createThirdwebClient({
+export const client = createThirdwebClient({
   secretKey: process.env.THIRDWEB_API_SECRET_KEY as string,
 });
 


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the codebase by refining type definitions, improving error handling, and updating the structure of transaction-related functionalities. It also introduces new schemas and modifies existing ones to ensure better validation and usability.

### Detailed summary
- Changed `client` to `export const client` in `test/e2e/utils/wallets.ts`.
- Updated transaction handling in `test/e2e/tests/smoke.test.ts` for better type safety.
- Simplified chain parsing logic in `test/e2e/utils/engine.ts`.
- Added `abiArraySchema` and `AbiSchemaType` in `src/server/schemas/contract/index.ts`.
- Created `sanitizeAbi` function in `src/server/utils/abi.ts` for ABI validation.
- Introduced `formatError` function in `src/server/middleware/error.ts` to standardize error formatting.
- Changed `abi` type from `any` to `Abi` in `src/utils/cache/getContractv5.ts`.
- Updated `getContractV5` return type to `Promise<ThirdwebContract>`.
- Modified `writeToContract` to use `sanitizeAbi` for ABI processing.
- Enhanced error handling in `test/e2e/tests/write.test.ts` with assertions on response properties.
- Added tests for writing to contracts with non-standard ABI in `test/e2e/tests/write.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->