### PR TITLE
fix: use boolEnvSchema to correctly coerce .env string values

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -18,6 +18,13 @@ export const JsonSchema = z.string().refine(
   { message: "Invalid JSON string" },
 );
 
+const boolEnvSchema = (defaultBool: boolean) =>
+  z
+    .string()
+    .default(defaultBool ? "true" : "false")
+    .refine((s) => s === "true" || s === "false", "must be 'true' or 'false'")
+    .transform((s) => s === "true");
+
 export const UrlSchema = z
   .string()
   .refine(
@@ -53,15 +60,15 @@ export const env = createEnv({
       ),
     PORT: z.coerce.number().default(3005),
     HOST: z.string().default("0.0.0.0"),
-    ENABLE_HTTPS: z.coerce.boolean().default(false),
+    ENABLE_HTTPS: boolEnvSchema(false),
     HTTPS_PASSPHRASE: z.string().default("thirdweb-engine"),
-    TRUST_PROXY: z.coerce.boolean().default(false),
+    TRUST_PROXY: boolEnvSchema(false),
     CLIENT_ANALYTICS_URL: z
       .union([UrlSchema, z.literal("")])
       .default("https://c.thirdweb.com/event"),
     SDK_BATCH_TIME_LIMIT: z.coerce.number().default(0),
     SDK_BATCH_SIZE_LIMIT: z.coerce.number().default(100),
-    ENABLE_KEYPAIR_AUTH: z.coerce.boolean().default(false),
+    ENABLE_KEYPAIR_AUTH: boolEnvSchema(false),
     CONTRACT_SUBSCRIPTIONS_DELAY_SECONDS: z.coerce
       .number()
       .nonnegative()
@@ -73,11 +80,11 @@ export const env = createEnv({
       .enum(["default", "sandbox", "server_only", "worker_only"])
       .default("default"),
     GLOBAL_RATE_LIMIT_PER_MIN: z.coerce.number().default(400 * 60),
-    DD_TRACER_ACTIVATED: z.coerce.boolean().default(false),
+    DD_TRACER_ACTIVATED: boolEnvSchema(false),
 
     // Prometheus
     METRICS_PORT: z.coerce.number().default(4001),
-    METRICS_ENABLED: z.coerce.boolean().default(true),
+    METRICS_ENABLED: boolEnvSchema(true),
 
     /**
      * Limits


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new utility function `boolEnvSchema` to standardize the handling of boolean environment variables in the `src/utils/env.ts` file, replacing direct boolean coercion with this new schema for better validation and transformation.

### Detailed summary
- Added `boolEnvSchema` function to validate boolean environment variables.
- Replaced `z.coerce.boolean().default(false)` with `boolEnvSchema(false)` for:
  - `ENABLE_HTTPS`
  - `TRUST_PROXY`
  - `ENABLE_KEYPAIR_AUTH`
  - `DD_TRACER_ACTIVATED`
- Replaced `z.coerce.boolean().default(true)` with `boolEnvSchema(true)` for:
  - `METRICS_ENABLED`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->