### PR TITLE
GCP KMS bugfix

### DIFF
--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -126,7 +126,10 @@ export const getAccount = async (args: {
         clientOptions: {
           credentials: {
             client_email: gcpApplicationCredentialEmail,
-            private_key: gcpApplicationCredentialPrivateKey,
+            // https://stackoverflow.com/questions/74131595/error-error1e08010cdecoder-routinesunsupported-with-google-auth-library
+            private_key: gcpApplicationCredentialPrivateKey
+              .split(String.raw`\n`)
+              .join("\n"),
           },
         },
       });

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -126,10 +126,7 @@ export const getAccount = async (args: {
         clientOptions: {
           credentials: {
             client_email: gcpApplicationCredentialEmail,
-            // https://stackoverflow.com/questions/74131595/error-error1e08010cdecoder-routinesunsupported-with-google-auth-library
-            private_key: gcpApplicationCredentialPrivateKey
-              .split(String.raw`\n`)
-              .join("\n"),
+            private_key: gcpApplicationCredentialPrivateKey,
           },
         },
       });


### PR DESCRIPTION
Fixes a bug related to GCP application credential private key serialisation/deserialisation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of `private_key` in `clientOptions.credentials` for compatibility with both new and older keys in the `getGcpKmsAccount.ts` file.

### Detailed summary
- Added a check to see if `clientOptions.credentials` exists.
- If `private_key` is present, it sanitizes the key by replacing newline characters for backwards compatibility.
- Included a comment regarding a previous bug related to `cryptoKeyVersion`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->