### PR TITLE
Add test for sending userops

### DIFF
--- a/test/e2e/tests/userop.test.ts
+++ b/test/e2e/tests/userop.test.ts
@@ -1,17 +1,16 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { type Address, getAddress } from "thirdweb";
 import { sepolia } from "thirdweb/chains";
-import { isContractDeployed } from "thirdweb/utils";
-import { DEFAULT_ACCOUNT_FACTORY_V0_6 } from "thirdweb/wallets/smart";
 import type { setupEngine } from "../utils/engine";
 import { pollTransactionStatus } from "../utils/transactions";
-import { client } from "../utils/wallets";
 import { setup } from "./setup";
 
 describe("Userop Tests", () => {
   let engine: ReturnType<typeof setupEngine>;
   let backendWallet: Address;
   let accountAddress: Address;
+
+  const accountFactoryAddress = "0xD8a284BdF6fda948ac684ba72445e65e1f7b982A";
 
   beforeAll(async () => {
     const { engine: _engine, backendWallet: _backendWallet } = await setup();
@@ -21,33 +20,10 @@ describe("Userop Tests", () => {
     const addr = await engine.accountFactory.predictAccountAddress(
       backendWallet,
       sepolia.id.toString(),
-      DEFAULT_ACCOUNT_FACTORY_V0_6,
+      accountFactoryAddress,
     );
 
-    const _accountAddress = getAddress(addr.result);
-
-    const isDeployed = await isContractDeployed({
-      client,
-      chain: sepolia,
-      address: _accountAddress,
-    });
-
-    if (!isDeployed) {
-      const res = await engine.accountFactory.createAccount(
-        sepolia.id.toString(),
-        DEFAULT_ACCOUNT_FACTORY_V0_6,
-        backendWallet,
-        {
-          adminAddress: backendWallet,
-        },
-      );
-
-      if (!res.result.deployedAddress) {
-        throw new Error("Account address not found");
-      }
-    }
-
-    accountAddress = _accountAddress;
+    accountAddress = getAddress(addr.result);
   });
 
   test("Should send a nft claim userop", async () => {
@@ -63,7 +39,7 @@ describe("Userop Tests", () => {
       false,
       undefined,
       accountAddress,
-      DEFAULT_ACCOUNT_FACTORY_V0_6,
+      accountFactoryAddress,
     );
 
     expect(writeRes.result.queueId).toBeDefined();

--- a/test/e2e/tests/userop.test.ts
+++ b/test/e2e/tests/userop.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { type Address, getAddress } from "thirdweb";
+import { sepolia } from "thirdweb/chains";
+import { isContractDeployed } from "thirdweb/utils";
+import { DEFAULT_ACCOUNT_FACTORY_V0_6 } from "thirdweb/wallets/smart";
+import type { setupEngine } from "../utils/engine";
+import { pollTransactionStatus } from "../utils/transactions";
+import { client } from "../utils/wallets";
+import { setup } from "./setup";
+
+describe("Userop Tests", () => {
+  let engine: ReturnType<typeof setupEngine>;
+  let backendWallet: Address;
+  let accountAddress: Address;
+
+  beforeAll(async () => {
+    const { engine: _engine, backendWallet: _backendWallet } = await setup();
+    engine = _engine;
+    backendWallet = _backendWallet as Address;
+
+    const addr = await engine.accountFactory.predictAccountAddress(
+      backendWallet,
+      sepolia.id.toString(),
+      DEFAULT_ACCOUNT_FACTORY_V0_6,
+    );
+
+    const _accountAddress = getAddress(addr.result);
+
+    const isDeployed = await isContractDeployed({
+      client,
+      chain: sepolia,
+      address: _accountAddress,
+    });
+
+    if (!isDeployed) {
+      const res = await engine.accountFactory.createAccount(
+        sepolia.id.toString(),
+        DEFAULT_ACCOUNT_FACTORY_V0_6,
+        backendWallet,
+        {
+          adminAddress: backendWallet,
+        },
+      );
+
+      if (!res.result.deployedAddress) {
+        throw new Error("Account address not found");
+      }
+    }
+
+    accountAddress = _accountAddress;
+  });
+
+  test("Should send a nft claim userop", async () => {
+    const writeRes = await engine.erc1155.erc1155ClaimTo(
+      sepolia.id.toString(),
+      "0xe2cb0eb5147b42095c2FfA6F7ec953bb0bE347D8",
+      backendWallet,
+      {
+        quantity: "1",
+        receiver: accountAddress,
+        tokenId: "0",
+      },
+      false,
+      undefined,
+      accountAddress,
+      DEFAULT_ACCOUNT_FACTORY_V0_6,
+    );
+
+    expect(writeRes.result.queueId).toBeDefined();
+
+    const writeTransactionStatus = await pollTransactionStatus(
+      engine,
+      writeRes.result.queueId,
+      true,
+    );
+
+    expect(writeTransactionStatus.minedAt).toBeDefined();
+  });
+});

--- a/test/e2e/utils/transactions.ts
+++ b/test/e2e/utils/transactions.ts
@@ -7,6 +7,7 @@ type Timing = {
   queuedAt?: number;
   sentAt?: number;
   minedAt?: number;
+  errorMessage?: string;
 };
 
 export const sendNoOpTransaction = async (
@@ -65,7 +66,7 @@ export const pollTransactionStatus = async (
   log = false,
 ) => {
   let mined = false;
-  let timing = {} as Timing;
+  const timing: Timing = {};
 
   while (!mined) {
     await sleep(Math.random() * CONFIG.STAGGER_MAX);
@@ -77,7 +78,8 @@ export const pollTransactionStatus = async (
     }
 
     if (res.result.errorMessage) {
-      console.error(`Transaction Error:`, res.result.errorMessage);
+      console.error("Transaction Error:", res.result.errorMessage);
+      timing.errorMessage = res.result.errorMessage;
       return timing;
     }
 
@@ -96,6 +98,7 @@ export const pollTransactionStatus = async (
 
     if (res.result.status === "errored") {
       console.error("Transaction errored:", res.result.errorMessage);
+      timing.errorMessage = res.result.errorMessage ?? undefined;
       return timing;
     }
 


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the error handling in the `pollTransactionStatus` function and adding user operation tests in the `userop.test.ts` file. It introduces an `errorMessage` property and improves transaction error logging.

### Detailed summary
- Added `errorMessage` property to the `Timing` type in `transactions.ts`.
- Changed `timing` to be a constant in `pollTransactionStatus`.
- Improved error logging in `pollTransactionStatus`.
- Added a suite of user operation tests in `userop.test.ts`.
- Implemented tests for sending NFT claims and handling permission errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->