### PR TITLE
chore: Alias /openapi.json to /json

### DIFF
--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -25,6 +25,7 @@ import { logger } from "../../utils/logger";
 import { sendWebhookRequest } from "../../utils/webhook";
 import { Permission } from "../schemas/auth";
 import { ADMIN_QUEUES_BASEPATH } from "./adminRoutes";
+import { OPENAPI_ROUTES } from "./open-api";
 
 export type TAuthData = never;
 export type TAuthSession = { permissions: string };
@@ -211,7 +212,7 @@ const handlePublicEndpoints = (req: FastifyRequest): AuthResponse => {
       req.url === "/favicon.ico" ||
       req.url === "/" ||
       req.url === "/system/health" ||
-      req.url === "/json" ||
+      OPENAPI_ROUTES.includes(req.url) ||
       req.url.startsWith("/auth/user") ||
       req.url.startsWith("/transaction/status")
     ) {

--- a/src/server/middleware/logs.ts
+++ b/src/server/middleware/logs.ts
@@ -2,14 +2,15 @@ import type { FastifyInstance } from "fastify";
 import { stringify } from "thirdweb/utils";
 import { logger } from "../../utils/logger";
 import { ADMIN_QUEUES_BASEPATH } from "./adminRoutes";
+import { OPENAPI_ROUTES } from "./open-api";
 
 const SKIP_LOG_PATHS = new Set([
   "",
   "/",
   "/favicon.ico",
   "/system/health",
-  "/json",
   "/static",
+  ...OPENAPI_ROUTES,
   // Skip these routes case of importing sensitive details.
   "/backend-wallet/import",
   "/configuration/wallets",

--- a/src/server/middleware/open-api.ts
+++ b/src/server/middleware/open-api.ts
@@ -1,13 +1,16 @@
 import swagger from "@fastify/swagger";
 import type { FastifyInstance } from "fastify";
 
+export const OPENAPI_ROUTES = ["/json", "/openapi.json"];
+
 export const withOpenApi = async (server: FastifyInstance) => {
   await server.register(swagger, {
     openapi: {
       info: {
         title: "thirdweb Engine",
-        description: "The open-source server for scalable web3 apps.",
-        version: "0.0.2",
+        description:
+          "Engine is an open-source, backend server that reads, writes, and deploys contracts at production scale.",
+        version: "1.0.0",
         license: {
           name: "Apache 2.0",
           url: "http://www.apache.org/licenses/LICENSE-2.0.html",
@@ -31,8 +34,9 @@ export const withOpenApi = async (server: FastifyInstance) => {
     },
   });
 
-  // Exports the /json endpoint without the Swagger UI.
-  server.get("/json", {}, async (_, res) => {
-    res.send(server.swagger());
-  });
+  for (const path of OPENAPI_ROUTES) {
+    server.get(path, {}, async (_, res) => {
+      res.send(server.swagger());
+    });
+  }
 };

--- a/src/server/middleware/rateLimit.ts
+++ b/src/server/middleware/rateLimit.ts
@@ -1,12 +1,15 @@
-import { FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { env } from "../../utils/env";
 import { redis } from "../../utils/redis/redis";
 import { createCustomError } from "./error";
+import { OPENAPI_ROUTES } from "./open-api";
+
+const SKIP_RATELIMIT_PATHS = ["/", ...OPENAPI_ROUTES];
 
 export const withRateLimit = async (server: FastifyInstance) => {
   server.addHook("onRequest", async (request, reply) => {
-    if (request.url === "/" || request.url === "/json") {
+    if (SKIP_RATELIMIT_PATHS.includes(request.url)) {
       return;
     }
 

--- a/src/server/routes/home.ts
+++ b/src/server/routes/home.ts
@@ -1,5 +1,5 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 
 const responseBodySchema = Type.Object({
@@ -22,7 +22,7 @@ export async function home(fastify: FastifyInstance) {
         [StatusCodes.OK]: responseBodySchema,
       },
     },
-    handler: async (req, res) => {
+    handler: async (_, res) => {
       return res.status(StatusCodes.OK).send({
         message:
           "Engine is set up successfully. Manage your Engine from https://thirdweb.com/dashboard/engine.",

--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -3,6 +3,7 @@ import { UsageEvent } from "@thirdweb-dev/service-utils/cf-worker";
 import { FastifyInstance } from "fastify";
 import { Address, Hex } from "thirdweb";
 import { ADMIN_QUEUES_BASEPATH } from "../server/middleware/adminRoutes";
+import { OPENAPI_ROUTES } from "../server/middleware/open-api";
 import { contractParamSchema } from "../server/schemas/sharedApiSchemas";
 import { walletWithAddressParamSchema } from "../server/schemas/wallet";
 import { getChainIdFromChain } from "../server/utils/chain";
@@ -49,8 +50,8 @@ const SKIP_USAGE_PATHS = new Set([
   "/",
   "/favicon.ico",
   "/system/health",
-  "/json",
   "/static",
+  ...OPENAPI_ROUTES,
 ]);
 
 export const withServerUsageReporting = (server: FastifyInstance) => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `OPENAPI_ROUTES` constant to streamline the handling of OpenAPI-related routes across multiple middleware and route files, enhancing code maintainability and readability.

### Detailed summary
- Added `OPENAPI_ROUTES` to `src/server/middleware/open-api.ts`.
- Updated `SKIP_LOG_PATHS` and `SKIP_RATELIMIT_PATHS` to include `OPENAPI_ROUTES`.
- Modified `handlePublicEndpoints` to check for `OPENAPI_ROUTES`.
- Refactored the handler in `src/server/routes/home.ts` to use a parameter.
- Used `OPENAPI_ROUTES` for route registration in `withOpenApi`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->