### PR TITLE
fix: Add servers to OpenAPI response

### DIFF
--- a/src/server/middleware/open-api.ts
+++ b/src/server/middleware/open-api.ts
@@ -16,6 +16,13 @@ export const withOpenApi = async (server: FastifyInstance) => {
           url: "http://www.apache.org/licenses/LICENSE-2.0.html",
         },
       },
+      servers: [
+        {
+          // This will appear in API documentation.
+          url: "https://YOUR_ENGINE_URL",
+          description: "Provide your Engine URL",
+        },
+      ],
       components: {
         securitySchemes: {
           bearerAuth: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new `servers` section to the OpenAPI configuration in the `src/server/middleware/open-api.ts` file, providing a template for users to specify their engine URL in the API documentation.

### Detailed summary
- Added a `servers` array to the OpenAPI configuration.
- Included an object within `servers` with:
  - `url`: Placeholder for the engine URL.
  - `description`: Clarifies the purpose of the URL in the documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->