### PR TITLE
fix: Return 400 on invalid backend wallet

### DIFF
--- a/src/utils/cache/getWallet.ts
+++ b/src/utils/cache/getWallet.ts
@@ -1,9 +1,11 @@
 import type { EVMWallet } from "@thirdweb-dev/wallets";
 import { AwsKmsWallet } from "@thirdweb-dev/wallets/evm/wallets/aws-kms";
 import { GcpKmsWallet } from "@thirdweb-dev/wallets/evm/wallets/gcp-kms";
+import { StatusCodes } from "http-status-codes";
 import { getWalletDetails } from "../../db/wallets/getWalletDetails";
 import type { PrismaTransaction } from "../../schema/prisma";
 import { WalletType } from "../../schema/wallet";
+import { createCustomError } from "../../server/middleware/error";
 import { splitAwsKmsArn } from "../../server/utils/wallets/awsKmsArn";
 import { splitGcpKmsResourcePath } from "../../server/utils/wallets/gcpKmsResourcePath";
 import { getLocalWallet } from "../../server/utils/wallets/getLocalWallet";
@@ -40,7 +42,11 @@ export const getWallet = async <TWallet extends EVMWallet>({
   });
 
   if (!walletDetails) {
-    throw new Error(`No configured wallet found with address ${walletAddress}`);
+    throw createCustomError(
+      `No configured wallet found with address ${walletAddress}`,
+      StatusCodes.BAD_REQUEST,
+      "BAD_REQUEST",
+    );
   }
 
   const config = await getConfig();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances error handling in the `getWallet` function by utilizing a custom error creation method and an HTTP status code for better clarity and consistency in responses.

### Detailed summary
- Added import for `StatusCodes` from `http-status-codes`.
- Added import for `createCustomError` from `../../server/middleware/error`.
- Replaced the generic `Error` throw with `createCustomError`, including the message, `StatusCodes.BAD_REQUEST`, and a custom error code `"BAD_REQUEST"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->