### PR TITLE
fix: correct conversion of legacy typo-containing strings in getGcpKmsAccount

### DIFF
--- a/src/server/utils/wallets/getGcpKmsAccount.ts
+++ b/src/server/utils/wallets/getGcpKmsAccount.ts
@@ -52,12 +52,12 @@ export async function getGcpKmsAccount(
     }
   }
 
-  // we had a bug previously where we previously called it "cryptoKeyVersion" instead of "cryptoKeyVersions"
+  // we had a bug previously where we previously called it "cryptoKeysVersion" instead of "cryptoKeyVersions"
   // if we detect that, we'll fix it here
   // TODO: remove this as a breaking change
   const name = unprocessedName.includes("cryptoKeyVersions")
     ? unprocessedName
-    : unprocessedName.replace("cryptoKeyVersion", "cryptoKeyVersions");
+    : unprocessedName.replace("cryptoKeysVersion", "cryptoKeyVersions");
 
   const signer = new CloudKmsSigner(name, clientOptions);
 


### PR DESCRIPTION
## Background
I discovered that Google KMS-based Backend wallets created with previous versions of Thirdweb Engine were not functioning correctly with v2.0.24.  I encountered the following error when attempting to use these wallets:

```
3 INVALID_ARGUMENT: Resource name 'projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEY_RING]/cryptoKeys/[KEY]/cryptoKeysVersion/1' does not match pattern 'projects/([^/]{1,100})/locations/([a-zA-Z0-9_-]{1,63})/keyRings/([a-zA-Z0-9_-]{1,63})/cryptoKeys/([a-zA-Z0-9_-]{1,63})/cryptoKeyVersions/([a-zA-Z0-9_-]{1,63})'.
```

## Changes
### Detailed Description
* In commit 4e8cc3057424bcc8870ff2e4b306afe610462b17, a conversion process was added to `getGcpKmsAccount` to handle typos in the `name` field.  The original conversion changed `cryptoKeyVersion` to `cryptoKeyVersions`. I believe the intended conversion should have been from `cryptoKeysVersion` to `cryptoKeyVersions`.
* This PR corrects this conversion logic to ensure proper handling of legacy wallet details.

### Reference
For context, here's an example of where `cryptoKeysVersion` was incorrectly set in versions prior to v2.0.21:
https://github.com/thirdweb-dev/engine/blob/277052774ce67426776123b446bf133fd0ecd8c6/src/server/utils/wallets/createGcpKmsWallet.ts#L63


## How this PR will be tested
I tested it locally as follows.

1. Created a Google KMS-based wallet in a local environment using a version prior to v2.0.21.
2. Imported the wallet, ensuring the wallet_details included `cryptoKeysVersion`.
3. Started the server using version v2.0.24 and confirmed the occurrence of the error mentioned at the beginning of this PR.
4. Applied the fix proposed in this PR.
5. Restarted the server with the fixed version.
6. Repeated the same process and verified that the transaction was successfully mined without any errors.


## Output




<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses a bug in the `getGcpKmsAccount.ts` file related to incorrect naming of a variable. It corrects the string replacement for the variable `cryptoKeyVersions` to ensure proper functionality.

### Detailed summary
- Updated comment to reflect the correction from `cryptoKeyVersion` to `cryptoKeysVersion`.
- Changed the string replacement in the `name` variable from `"cryptoKeyVersion"` to `"cryptoKeysVersion"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->