### PR TITLE
refactor: Update getAwsKmsAccount and getGcpKmsAccount to use hashMessage

### DIFF
--- a/src/server/utils/wallets/getAwsKmsAccount.ts
+++ b/src/server/utils/wallets/getAwsKmsAccount.ts
@@ -8,7 +8,7 @@ import {
   type Address,
 } from "thirdweb";
 import { serializeTransaction } from "thirdweb/transaction";
-import { toBytes } from "thirdweb/utils";
+import { hashMessage } from "thirdweb/utils";
 import type { Account } from "thirdweb/wallets";
 import type {
   SignableMessage,
@@ -78,16 +78,7 @@ export async function getAwsKmsAccount(
   }: {
     message: SignableMessage;
   }): Promise<Hex> {
-    let messageHash: Hex;
-    if (typeof message === "string") {
-      const prefixedMessage = `\x19Ethereum Signed Message:\n${message.length}${message}`;
-      messageHash = keccak256(toBytes(prefixedMessage));
-    } else if ("raw" in message) {
-      messageHash = keccak256(message.raw);
-    } else {
-      throw new Error("Invalid message format");
-    }
-
+    const messageHash = hashMessage(message);
     const signature = await signer.sign(
       Buffer.from(messageHash.slice(2), "hex"),
     );

--- a/src/server/utils/wallets/getGcpKmsAccount.ts
+++ b/src/server/utils/wallets/getGcpKmsAccount.ts
@@ -8,7 +8,7 @@ import {
   keccak256,
 } from "thirdweb";
 import { serializeTransaction } from "thirdweb/transaction";
-import { toBytes } from "thirdweb/utils";
+import { hashMessage } from "thirdweb/utils";
 import type { Account } from "thirdweb/wallets";
 import type {
   SignableMessage,
@@ -98,16 +98,7 @@ export async function getGcpKmsAccount(
   }: {
     message: SignableMessage;
   }): Promise<Hex> {
-    let messageHash: Hex;
-    if (typeof message === "string") {
-      const prefixedMessage = `\x19Ethereum Signed Message:\n${message.length}${message}`;
-      messageHash = keccak256(toBytes(prefixedMessage));
-    } else if ("raw" in message) {
-      messageHash = keccak256(message.raw);
-    } else {
-      throw new Error("Invalid message format");
-    }
-
+    const messageHash = hashMessage(message);
     const signature = await signer.sign(Bytes.fromString(messageHash));
     return signature.bytes.toString() as Hex;
   }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the message hashing mechanism in the `getAwsKmsAccount` and `getGcpKmsAccount` functions to use `hashMessage` instead of manually creating a prefixed message and hashing it with `toBytes`.

### Detailed summary
- Replaced the import of `toBytes` with `hashMessage` in both `getAwsKmsAccount.ts` and `getGcpKmsAccount.ts`.
- Simplified the message hashing logic by directly using `hashMessage(message)` instead of manually handling string and raw message cases.
- Removed the previous error handling for invalid message formats.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->