### PR TITLE
fix: nonce resync worker returns too early with multiple sender wallets

### DIFF
--- a/src/worker/tasks/nonceResyncWorker.ts
+++ b/src/worker/tasks/nonceResyncWorker.ts
@@ -1,4 +1,4 @@
-import { Job, Processor, Worker } from "bullmq";
+import { Worker, type Job, type Processor } from "bullmq";
 import { eth_getTransactionCount, getRpcClient } from "thirdweb";
 import {
   inspectNonce,
@@ -58,7 +58,7 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
       inspectNonce(chainId, walletAddress),
     ]);
 
-    if (isNaN(transactionCount)) {
+    if (Number.isNaN(transactionCount)) {
       job.log(
         `Received invalid onchain transaction count for ${walletAddress}: ${transactionCount}`,
       );
@@ -67,7 +67,7 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
         message: `[nonceResyncWorker] Received invalid onchain transaction count for ${walletAddress}: ${transactionCount}`,
         service: "worker",
       });
-      return;
+      continue;
     }
 
     const lastUsedNonceOnchain = transactionCount - 1;
@@ -90,7 +90,7 @@ const handler: Processor<any, void, string> = async (job: Job<string>) => {
         message: `[nonceResyncWorker] No need to resync nonce for ${walletAddress}`,
         service: "worker",
       });
-      return;
+      continue;
     }
 
     //  for each nonce between last used db nonce and last used onchain nonce


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling in the `nonceResyncWorker` by refining the conditions that check for invalid transaction counts. It replaces the `isNaN` function with `Number.isNaN` for better type safety and changes `return` statements to `continue` for flow control.

### Detailed summary
- Replaced `isNaN(transactionCount)` with `Number.isNaN(transactionCount)` for improved type safety.
- Changed `return` statements to `continue` in error handling to maintain loop execution.
- Minor formatting adjustments in log messages for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->