### PR TITLE
decrypt wallet credential before use

### DIFF
--- a/src/utils/cache/getWallet.ts
+++ b/src/utils/cache/getWallet.ts
@@ -10,6 +10,8 @@ import { splitAwsKmsArn } from "../../server/utils/wallets/awsKmsArn";
 import { splitGcpKmsResourcePath } from "../../server/utils/wallets/gcpKmsResourcePath";
 import { getLocalWallet } from "../../server/utils/wallets/getLocalWallet";
 import { getSmartWallet } from "../../server/utils/wallets/getSmartWallet";
+import { decrypt } from "../crypto";
+import { env } from "../env";
 import { getConfig } from "./getConfig";
 
 export const walletsCache = new Map<string, EVMWallet>();
@@ -64,9 +66,9 @@ export const getWallet = async <TWallet extends EVMWallet>({
         walletDetails.awsKmsAccessKeyId ??
         config.walletConfiguration.aws?.awsAccessKeyId;
 
-      const secretAccessKey =
-        walletDetails.awsKmsSecretAccessKey ??
-        config.walletConfiguration.aws?.awsSecretAccessKey;
+      const secretAccessKey = walletDetails.awsKmsSecretAccessKey
+        ? decrypt(walletDetails.awsKmsSecretAccessKey, env.ENCRYPTION_PASSWORD)
+        : config.walletConfiguration.aws?.awsSecretAccessKey;
 
       if (!(accessKeyId && secretAccessKey)) {
         throw new Error(

--- a/src/utils/cache/getWallet.ts
+++ b/src/utils/cache/getWallet.ts
@@ -97,9 +97,12 @@ export const getWallet = async <TWallet extends EVMWallet>({
       const email =
         walletDetails.gcpApplicationCredentialEmail ??
         config.walletConfiguration.gcp?.gcpApplicationCredentialEmail;
-      const privateKey =
-        walletDetails.gcpApplicationCredentialPrivateKey ??
-        config.walletConfiguration.gcp?.gcpApplicationCredentialPrivateKey;
+      const privateKey = walletDetails.gcpApplicationCredentialPrivateKey
+        ? decrypt(
+            walletDetails.gcpApplicationCredentialPrivateKey,
+            env.ENCRYPTION_PASSWORD,
+          )
+        : config.walletConfiguration.gcp?.gcpApplicationCredentialPrivateKey;
 
       if (!(email && privateKey)) {
         throw new Error(


### PR DESCRIPTION
fixes KMS errors on v4 SDK routes with errors:
```
The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
```
Repro case:
Get on v2.0.22+ Engine
Add AWS creds
Create an AWS wallet
Call sign-message
Result: the above auth error

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `getWallet` function in `src/utils/cache/getWallet.ts` to enhance security by decrypting sensitive AWS and GCP credentials using the `decrypt` function and an `ENCRYPTION_PASSWORD` from the environment.

### Detailed summary
- Added `decrypt` and `env` imports.
- Modified `secretAccessKey` to decrypt if `awsKmsSecretAccessKey` is provided.
- Modified `privateKey` to decrypt if `gcpApplicationCredentialPrivateKey` is provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->