### PR TITLE
bump sdk version

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thirdweb-dev/engine",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "dist/thirdweb-dev-engine.cjs.js",
   "module": "dist/thirdweb-dev-engine.esm.js",
   "files": [

--- a/src/scripts/generate-sdk.ts
+++ b/src/scripts/generate-sdk.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { kill } from "node:process";
 
-const ENGINE_OPENAPI_URL = "http://localhost:3005/json";
+const ENGINE_OPENAPI_URL = "https://demo.web3api.thirdweb.com/json";
 const REPLACE_LOG_FILE = "sdk/replacement_log.txt";
 
 type BasicOpenAPISpec = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `version` of the `@thirdweb-dev/engine` package and modifies the `ENGINE_OPENAPI_URL` in the `src/scripts/generate-sdk.ts` file to point to a new URL.

### Detailed summary
- Updated `version` in `sdk/package.json` from `0.0.15` to `0.0.16`.
- Changed `ENGINE_OPENAPI_URL` in `src/scripts/generate-sdk.ts` from `http://localhost:3005/json` to `https://demo.web3api.thirdweb.com/json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->