### PR TITLE
Revert "fix: Add servers to OpenAPI response"

### DIFF
--- a/src/server/middleware/open-api.ts
+++ b/src/server/middleware/open-api.ts
@@ -16,13 +16,6 @@ export const withOpenApi = async (server: FastifyInstance) => {
           url: "http://www.apache.org/licenses/LICENSE-2.0.html",
         },
       },
-      servers: [
-        {
-          // This will appear in API documentation.
-          url: "https://YOUR_ENGINE_URL",
-          description: "Provide your Engine URL",
-        },
-      ],
       components: {
         securitySchemes: {
           bearerAuth: {


### PR DESCRIPTION
Reverts thirdweb-dev/engine#717

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `servers` section from the OpenAPI specification in the `src/server/middleware/open-api.ts` file, which defines the API server details.

### Detailed summary
- Removed the entire `servers` array, including:
  - The object containing the `url` and `description` for the API server.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->