### PR TITLE
Refactor serialisation params in getAwsKmsAccount and getGcpKmsAccount

### DIFF
--- a/src/server/utils/wallets/getAwsKmsAccount.ts
+++ b/src/server/utils/wallets/getAwsKmsAccount.ts
@@ -54,7 +54,7 @@ export async function getAwsKmsAccount(
     const s = `0x${signature.s.toString("hex")}` as Hex;
     const v = BigInt(signature.v);
 
-    const yParity = signature.v % 2 === 0 ? 1 : (0 as 0 | 1);
+    const yParity: 0 | 1 = signature.v % 2 === 0 ? 1 : 0;
 
     const signedTx = serializeTransaction({
       transaction: tx,

--- a/src/server/utils/wallets/getAwsKmsAccount.ts
+++ b/src/server/utils/wallets/getAwsKmsAccount.ts
@@ -52,15 +52,16 @@ export async function getAwsKmsAccount(
 
     const r = `0x${signature.r.toString("hex")}` as Hex;
     const s = `0x${signature.s.toString("hex")}` as Hex;
-    const v = signature.v;
+    const v = BigInt(signature.v);
 
-    const yParity = v % 2 === 0 ? 1 : (0 as 0 | 1);
+    const yParity = signature.v % 2 === 0 ? 1 : (0 as 0 | 1);
 
     const signedTx = serializeTransaction({
       transaction: tx,
       signature: {
         r,
         s,
+        v,
         yParity,
       },
     });

--- a/src/server/utils/wallets/getGcpKmsAccount.ts
+++ b/src/server/utils/wallets/getGcpKmsAccount.ts
@@ -72,15 +72,16 @@ export async function getGcpKmsAccount(
 
     const r = signature.r.toString() as Hex;
     const s = signature.s.toString() as Hex;
-    const v = signature.v;
+    const v = BigInt(signature.v);
 
-    const yParity = v % 2 === 0 ? 1 : (0 as 0 | 1);
+    const yParity = signature.v % 2 === 0 ? 1 : (0 as 0 | 1);
 
     const signedTx = serializeTransaction({
       transaction: tx,
       signature: {
         r,
         s,
+        v,
         yParity,
       },
     });

--- a/src/server/utils/wallets/getGcpKmsAccount.ts
+++ b/src/server/utils/wallets/getGcpKmsAccount.ts
@@ -74,7 +74,7 @@ export async function getGcpKmsAccount(
     const s = signature.s.toString() as Hex;
     const v = BigInt(signature.v);
 
-    const yParity = signature.v % 2 === 0 ? 1 : (0 as 0 | 1);
+    const yParity: 0 | 1 = signature.v % 2 === 0 ? 1 : 0;
 
     const signedTx = serializeTransaction({
       transaction: tx,


### PR DESCRIPTION
legacy transaction flow serialisation does this:
```
      // EIP-155 (explicit chainId)
      if (chainId > 0)
        return BigInt(chainId * 2) + BigInt(35n + signature.v - 27n)
```
this requires a bigint `v`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of the `v` value in the signature for both `getGcpKmsAccount.ts` and `getAwsKmsAccount.ts`. It converts `v` to a `BigInt` and explicitly defines `yParity` as a type of `0 | 1`.

### Detailed summary
- Changed `const v = signature.v;` to `const v = BigInt(signature.v);` in both files.
- Updated `yParity` calculation to explicitly type it as `0 | 1`.
- Adjusted `yParity` assignment to use `signature.v` instead of `v`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->