### PR TITLE
chore: Migrate transfer endpoints to v5 SDK

### DIFF
--- a/sdk/src/services/BackendWalletService.ts
+++ b/sdk/src/services/BackendWalletService.ts
@@ -421,7 +421,7 @@ export class BackendWalletService {
              */
             transactionHash: string;
             /**
-             * An amount in native token (decimals allowed). Example: "1.5"
+             * An amount in native token (decimals allowed). Example: "0.1"
              */
             amount: string;
         };

--- a/sdk/src/services/Erc1155Service.ts
+++ b/sdk/src/services/Erc1155Service.ts
@@ -1743,17 +1743,21 @@ export class Erc1155Service {
         xBackendWalletAddress: string,
         requestBody: {
             /**
-             * Address of the wallet to transfer to
+             * The recipient address.
              */
             to: string;
             /**
-             * the tokenId to transfer
+             * The token ID to transfer.
              */
             tokenId: string;
             /**
-             * the amount of tokens to transfer
+             * The amount of tokens to transfer.
              */
             amount: string;
+            /**
+             * A valid hex string
+             */
+            data?: string;
             txOverrides?: {
                 /**
                  * Gas limit for the transaction
@@ -1838,21 +1842,25 @@ export class Erc1155Service {
         xBackendWalletAddress: string,
         requestBody: {
             /**
-             * Address of the token owner
+             * The sender address.
              */
             from: string;
             /**
-             * Address of the wallet to transferFrom to
+             * The recipient address.
              */
             to: string;
             /**
-             * the tokenId to transferFrom
+             * The token ID to transfer.
              */
             tokenId: string;
             /**
-             * the amount of tokens to transfer
+             * The amount of tokens to transfer.
              */
             amount: string;
+            /**
+             * A valid hex string
+             */
+            data?: string;
             txOverrides?: {
                 /**
                  * Gas limit for the transaction

--- a/sdk/src/services/Erc20Service.ts
+++ b/sdk/src/services/Erc20Service.ts
@@ -673,17 +673,17 @@ export class Erc20Service {
      * @returns any Default Response
      * @throws ApiError
      */
-    public erc20Transfer(
+    public transfer(
         chain: string,
         contractAddress: string,
         xBackendWalletAddress: string,
         requestBody: {
             /**
-             * Address of the wallet you want to send the tokens to
+             * The recipient address.
              */
             toAddress: string;
             /**
-             * The amount of tokens you want to send
+             * The amount of tokens to transfer.
              */
             amount: string;
             txOverrides?: {
@@ -770,15 +770,15 @@ export class Erc20Service {
         xBackendWalletAddress: string,
         requestBody: {
             /**
-             * Address of the wallet sending the tokens
+             * The sender address.
              */
             fromAddress: string;
             /**
-             * Address of the wallet you want to send the tokens to
+             * The recipient address.
              */
             toAddress: string;
             /**
-             * The amount of tokens you want to send
+             * The amount of tokens to transfer.
              */
             amount: string;
             txOverrides?: {

--- a/sdk/src/services/Erc721Service.ts
+++ b/sdk/src/services/Erc721Service.ts
@@ -735,11 +735,11 @@ export class Erc721Service {
         xBackendWalletAddress: string,
         requestBody: {
             /**
-             * Address of the wallet to transfer to
+             * The recipient address.
              */
             to: string;
             /**
-             * The tokenId to transfer
+             * The token ID to transfer.
              */
             tokenId: string;
             txOverrides?: {
@@ -826,15 +826,15 @@ export class Erc721Service {
         xBackendWalletAddress: string,
         requestBody: {
             /**
-             * Address of the token owner
+             * The sender address.
              */
             from: string;
             /**
-             * Address of the wallet to transferFrom to
+             * The recipient address.
              */
             to: string;
             /**
-             * the tokenId to transferFrom
+             * The token ID to transfer.
              */
             tokenId: string;
             txOverrides?: {

--- a/src/scripts/generate-sdk.ts
+++ b/src/scripts/generate-sdk.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { kill } from "node:process";
 
-const ENGINE_OPENAPI_URL = "https://demo.web3api.thirdweb.com/json";
+const ENGINE_OPENAPI_URL = "http://127.0.0.1:3010/json";
 const REPLACE_LOG_FILE = "sdk/replacement_log.txt";
 
 type BasicOpenAPISpec = {

--- a/src/scripts/generate-sdk.ts
+++ b/src/scripts/generate-sdk.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { kill } from "node:process";
 
-const ENGINE_OPENAPI_URL = "http://127.0.0.1:3010/json";
+const ENGINE_OPENAPI_URL = "https://demo.web3api.thirdweb.com/json";
 const REPLACE_LOG_FILE = "sdk/replacement_log.txt";
 
 type BasicOpenAPISpec = {

--- a/src/server/routes/contract/extensions/erc1155/write/transfer.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/transfer.ts
@@ -8,6 +8,7 @@ import { getChecksumAddress } from "../../../../../../utils/primitiveTypes";
 import { thirdwebClient } from "../../../../../../utils/sdk";
 import { queueTransaction } from "../../../../../../utils/transaction/queueTransation";
 import { AddressSchema } from "../../../../../schemas/address";
+import { NumberStringSchema } from "../../../../../schemas/number";
 import {
   erc1155ContractParamSchema,
   requestQuerystringSchema,
@@ -23,13 +24,15 @@ const requestSchema = erc1155ContractParamSchema;
 const requestBodySchema = Type.Object({
   to: {
     ...AddressSchema,
-    description: "Address of the wallet to transfer to",
+    description: "The recipient address.",
   },
   tokenId: Type.String({
-    description: "the tokenId to transfer",
+    ...NumberStringSchema,
+    description: "The token ID to transfer.",
   }),
   amount: Type.String({
-    description: "the amount of tokens to transfer",
+    ...NumberStringSchema,
+    description: "The amount of tokens to transfer.",
   }),
   ...txOverridesWithValueSchema.properties,
 });
@@ -87,7 +90,7 @@ export async function erc1155transfer(fastify: FastifyInstance) {
       const transaction = safeTransferFrom({
         contract,
         from: getChecksumAddress(walletAddress),
-        to,
+        to: getChecksumAddress(to),
         tokenId: BigInt(tokenId),
         value: BigInt(amount),
         data: "0x",
@@ -96,7 +99,7 @@ export async function erc1155transfer(fastify: FastifyInstance) {
       const queueId = await queueTransaction({
         transaction,
         fromAddress: getChecksumAddress(walletAddress),
-        toAddress: getChecksumAddress(to),
+        toAddress: getChecksumAddress(contractAddress),
         accountAddress: getChecksumAddress(accountAddress),
         accountFactoryAddress: getChecksumAddress(accountFactoryAddress),
         accountSalt,

--- a/src/server/routes/contract/extensions/erc1155/write/transferFrom.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/transferFrom.ts
@@ -1,13 +1,13 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { getContract } from "thirdweb";
+import { getContract, type Hex } from "thirdweb";
 import { safeTransferFrom } from "thirdweb/extensions/erc1155";
 import { getChain } from "../../../../../../utils/chain";
 import { getChecksumAddress } from "../../../../../../utils/primitiveTypes";
 import { thirdwebClient } from "../../../../../../utils/sdk";
 import { queueTransaction } from "../../../../../../utils/transaction/queueTransation";
-import { AddressSchema } from "../../../../../schemas/address";
+import { AddressSchema, HexSchema } from "../../../../../schemas/address";
 import { NumberStringSchema } from "../../../../../schemas/number";
 import {
   erc1155ContractParamSchema,
@@ -38,6 +38,7 @@ const requestBodySchema = Type.Object({
     ...NumberStringSchema,
     description: "The amount of tokens to transfer.",
   },
+  data: Type.Optional(HexSchema),
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -79,7 +80,7 @@ export async function erc1155transferFrom(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { chain, contractAddress } = request.params;
       const { simulateTx } = request.query;
-      const { from, to, tokenId, amount, txOverrides } = request.body;
+      const { from, to, tokenId, amount, data, txOverrides } = request.body;
       const {
         "x-backend-wallet-address": walletAddress,
         "x-account-address": accountAddress,
@@ -101,7 +102,7 @@ export async function erc1155transferFrom(fastify: FastifyInstance) {
         to: getChecksumAddress(to),
         tokenId: BigInt(tokenId),
         value: BigInt(amount),
-        data: "0x",
+        data: (data as Hex | undefined) ?? "0x",
       });
 
       const queueId = await queueTransaction({

--- a/src/server/routes/contract/extensions/erc1155/write/transferFrom.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/transferFrom.ts
@@ -8,6 +8,7 @@ import { getChecksumAddress } from "../../../../../../utils/primitiveTypes";
 import { thirdwebClient } from "../../../../../../utils/sdk";
 import { queueTransaction } from "../../../../../../utils/transaction/queueTransation";
 import { AddressSchema } from "../../../../../schemas/address";
+import { NumberStringSchema } from "../../../../../schemas/number";
 import {
   erc1155ContractParamSchema,
   requestQuerystringSchema,
@@ -23,18 +24,20 @@ const requestSchema = erc1155ContractParamSchema;
 const requestBodySchema = Type.Object({
   from: {
     ...AddressSchema,
-    description: "Address of the token owner",
+    description: "The sender address.",
   },
   to: {
     ...AddressSchema,
-    description: "Address of the wallet to transfer to",
+    description: "The recipient address.",
   },
-  tokenId: Type.String({
-    description: "the tokenId to transferFrom",
-  }),
-  amount: Type.String({
-    description: "the amount of tokens to transfer",
-  }),
+  tokenId: {
+    ...NumberStringSchema,
+    description: "The token ID to transfer.",
+  },
+  amount: {
+    ...NumberStringSchema,
+    description: "The amount of tokens to transfer.",
+  },
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -94,8 +97,8 @@ export async function erc1155transferFrom(fastify: FastifyInstance) {
 
       const transaction = safeTransferFrom({
         contract,
-        from,
-        to,
+        from: getChecksumAddress(from),
+        to: getChecksumAddress(to),
         tokenId: BigInt(tokenId),
         value: BigInt(amount),
         data: "0x",
@@ -104,7 +107,7 @@ export async function erc1155transferFrom(fastify: FastifyInstance) {
       const queueId = await queueTransaction({
         transaction,
         fromAddress: getChecksumAddress(walletAddress),
-        toAddress: getChecksumAddress(to),
+        toAddress: getChecksumAddress(contractAddress),
         accountAddress: getChecksumAddress(accountAddress),
         accountFactoryAddress: getChecksumAddress(accountFactoryAddress),
         accountSalt,

--- a/src/server/routes/contract/extensions/erc1155/write/transferFrom.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/transferFrom.ts
@@ -1,8 +1,13 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { queueTx } from "../../../../../../db/transactions/queueTx";
-import { getContract } from "../../../../../../utils/cache/getContract";
+import { getContract } from "thirdweb";
+import { safeTransferFrom } from "thirdweb/extensions/erc1155";
+import { getChain } from "../../../../../../utils/chain";
+import { getChecksumAddress } from "../../../../../../utils/primitiveTypes";
+import { thirdwebClient } from "../../../../../../utils/sdk";
+import { queueTransaction } from "../../../../../../utils/transaction/queueTransation";
+import { AddressSchema } from "../../../../../schemas/address";
 import {
   erc1155ContractParamSchema,
   requestQuerystringSchema,
@@ -16,12 +21,14 @@ import { getChainIdFromChain } from "../../../../../utils/chain";
 // INPUTS
 const requestSchema = erc1155ContractParamSchema;
 const requestBodySchema = Type.Object({
-  from: Type.String({
+  from: {
+    ...AddressSchema,
     description: "Address of the token owner",
-  }),
-  to: Type.String({
-    description: "Address of the wallet to transferFrom to",
-  }),
+  },
+  to: {
+    ...AddressSchema,
+    description: "Address of the wallet to transfer to",
+  },
   tokenId: Type.String({
     description: "the tokenId to transferFrom",
   }),
@@ -74,29 +81,38 @@ export async function erc1155transferFrom(fastify: FastifyInstance) {
         "x-backend-wallet-address": walletAddress,
         "x-account-address": accountAddress,
         "x-idempotency-key": idempotencyKey,
+        "x-account-factory-address": accountFactoryAddress,
+        "x-account-salt": accountSalt,
       } = request.headers as Static<typeof walletWithAAHeaderSchema>;
 
       const chainId = await getChainIdFromChain(chain);
       const contract = await getContract({
-        chainId,
-        contractAddress,
-        walletAddress,
-        accountAddress,
+        client: thirdwebClient,
+        chain: await getChain(chainId),
+        address: contractAddress,
       });
-      const tx = await contract.erc1155.transferFrom.prepare(
+
+      const transaction = safeTransferFrom({
+        contract,
         from,
         to,
-        tokenId,
-        amount,
-      );
+        tokenId: BigInt(tokenId),
+        value: BigInt(amount),
+        data: "0x",
+      });
 
-      const queueId = await queueTx({
-        tx,
-        chainId,
-        simulateTx,
-        extension: "erc1155",
-        idempotencyKey,
+      const queueId = await queueTransaction({
+        transaction,
+        fromAddress: getChecksumAddress(walletAddress),
+        toAddress: getChecksumAddress(to),
+        accountAddress: getChecksumAddress(accountAddress),
+        accountFactoryAddress: getChecksumAddress(accountFactoryAddress),
+        accountSalt,
         txOverrides,
+        idempotencyKey,
+        shouldSimulate: simulateTx,
+        functionName: "safeTransferFrom",
+        extension: "erc1155",
       });
 
       reply.status(StatusCodes.OK).send({

--- a/src/server/routes/contract/extensions/erc721/write/transfer.ts
+++ b/src/server/routes/contract/extensions/erc721/write/transfer.ts
@@ -1,8 +1,14 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { queueTx } from "../../../../../../db/transactions/queueTx";
-import { getContract } from "../../../../../../utils/cache/getContract";
+import { getContract } from "thirdweb";
+import { transferFrom } from "thirdweb/extensions/erc721";
+import { getChain } from "../../../../../../utils/chain";
+import { getChecksumAddress } from "../../../../../../utils/primitiveTypes";
+import { thirdwebClient } from "../../../../../../utils/sdk";
+import { queueTransaction } from "../../../../../../utils/transaction/queueTransation";
+import { AddressSchema } from "../../../../../schemas/address";
+import { NumberStringSchema } from "../../../../../schemas/number";
 import {
   contractParamSchema,
   requestQuerystringSchema,
@@ -13,15 +19,16 @@ import { txOverridesWithValueSchema } from "../../../../../schemas/txOverrides";
 import { walletWithAAHeaderSchema } from "../../../../../schemas/wallet";
 import { getChainIdFromChain } from "../../../../../utils/chain";
 
-// INPUTS
 const requestSchema = contractParamSchema;
 const requestBodySchema = Type.Object({
-  to: Type.String({
-    description: "Address of the wallet to transfer to",
-  }),
-  tokenId: Type.String({
-    description: "The tokenId to transfer",
-  }),
+  to: {
+    ...AddressSchema,
+    description: "The recipient address.",
+  },
+  tokenId: {
+    ...NumberStringSchema,
+    description: "The token ID to transfer.",
+  },
   ...txOverridesWithValueSchema.properties,
 });
 
@@ -63,24 +70,36 @@ export async function erc721transfer(fastify: FastifyInstance) {
         "x-backend-wallet-address": walletAddress,
         "x-account-address": accountAddress,
         "x-idempotency-key": idempotencyKey,
+        "x-account-factory-address": accountFactoryAddress,
+        "x-account-salt": accountSalt,
       } = request.headers as Static<typeof walletWithAAHeaderSchema>;
 
       const chainId = await getChainIdFromChain(chain);
       const contract = await getContract({
-        chainId,
-        contractAddress,
-        walletAddress,
-        accountAddress,
+        client: thirdwebClient,
+        chain: await getChain(chainId),
+        address: contractAddress,
       });
-      const tx = await contract.erc721.transfer.prepare(to, tokenId);
 
-      const queueId = await queueTx({
-        tx,
-        chainId,
-        simulateTx,
-        extension: "erc721",
-        idempotencyKey,
+      const transaction = transferFrom({
+        contract,
+        from: getChecksumAddress(walletAddress),
+        to: getChecksumAddress(to),
+        tokenId: BigInt(tokenId),
+      });
+
+      const queueId = await queueTransaction({
+        transaction,
+        fromAddress: getChecksumAddress(walletAddress),
+        toAddress: getChecksumAddress(contractAddress),
+        accountAddress: getChecksumAddress(accountAddress),
+        accountFactoryAddress: getChecksumAddress(accountFactoryAddress),
+        accountSalt,
         txOverrides,
+        idempotencyKey,
+        shouldSimulate: simulateTx,
+        functionName: "transferFrom",
+        extension: "erc721",
       });
 
       reply.status(StatusCodes.OK).send({

--- a/src/server/schemas/address.ts
+++ b/src/server/schemas/address.ts
@@ -21,3 +21,8 @@ export const TransactionHashSchema = Type.RegExp(/^0x[a-fA-F0-9]{64}$/, {
     "0x1f31b57601a6f90312fd5e57a2924bc8333477de579ee37b197a0681ab438431",
   ],
 });
+
+export const HexSchema = Type.RegExp(/^0x[a-fA-F0-9]*$/, {
+  description: "A valid hex string",
+  examples: ["0x68656c6c6f20776f726c64"],
+});

--- a/src/server/schemas/number.ts
+++ b/src/server/schemas/number.ts
@@ -1,11 +1,15 @@
 import { Type } from "@sinclair/typebox";
 
 export const TokenAmountStringSchema = Type.RegExp(/^\d+(\.\d+)?$/, {
-  description: 'An amount in native token (decimals allowed). Example: "1.5"',
+  description: 'An amount in native token (decimals allowed). Example: "0.1"',
   examples: ["0.1"],
 });
 
 export const WeiAmountStringSchema = Type.RegExp(/^\d+$/, {
-  description: 'An amount in wei (no decimals). Example: "100000000"',
+  description: 'An amount in wei (no decimals). Example: "50000000000"',
   examples: ["50000000000"],
+});
+
+export const NumberStringSchema = Type.RegExp(/^\d+$/, {
+  examples: ["42"],
 });

--- a/src/utils/transaction/queueTransation.ts
+++ b/src/utils/transaction/queueTransation.ts
@@ -26,7 +26,10 @@ export type QueuedTransactionParams = {
   >;
   idempotencyKey?: string;
   shouldSimulate?: boolean;
+  /** For display purposes only. */
   functionName?: string;
+  /** For display purposes only. */
+  extension?: string;
 };
 
 /**
@@ -48,6 +51,7 @@ export async function queueTransaction(args: QueuedTransactionParams) {
     idempotencyKey,
     shouldSimulate,
     functionName,
+    extension,
   } = args;
 
   let data: Hex;
@@ -66,8 +70,9 @@ export async function queueTransaction(args: QueuedTransactionParams) {
     from: fromAddress,
     to: toAddress,
     data,
-    functionName: functionName,
     value: await resolvePromisedValue(transaction.value),
+    functionName,
+    extension,
     ...parseTransactionOverrides(txOverrides),
     ...(accountAddress
       ? {

--- a/test/e2e/tests/routes/erc1155-transfer.test.ts
+++ b/test/e2e/tests/routes/erc1155-transfer.test.ts
@@ -1,0 +1,156 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import assert from "node:assert";
+import { ZERO_ADDRESS, type Address } from "thirdweb";
+import { CONFIG } from "../../config";
+import { getEngineBackendWalletB, type setupEngine } from "../../utils/engine";
+import { pollTransactionStatus } from "../../utils/transactions";
+import { setup } from "../setup";
+
+describe("ER1155 transfer", () => {
+  let tokenContractAddress: string;
+  let engine: ReturnType<typeof setupEngine>;
+  let backendWalletA: Address;
+  let backendWalletB: Address;
+
+  beforeAll(async () => {
+    const setupRes = await setup();
+    engine = setupRes.engine;
+    backendWalletA = setupRes.backendWallet;
+    backendWalletB = await getEngineBackendWalletB(engine);
+
+    const deployRes = await engine.deploy.deployEdition(
+      CONFIG.CHAIN.id.toString(),
+      backendWalletA,
+      {
+        contractMetadata: {
+          name: "test token",
+          platform_fee_basis_points: 0,
+          platform_fee_recipient: ZERO_ADDRESS,
+          seller_fee_basis_points: 0,
+          fee_recipient: ZERO_ADDRESS,
+          symbol: "TT",
+          trusted_forwarders: [],
+        },
+      },
+    );
+    assert(deployRes.result.queueId);
+    console.log("Waiting: deploying contract...");
+    await pollTransactionStatus(engine, deployRes.result.queueId, false);
+
+    assert(deployRes.result.deployedAddress, "deployedAddress must be defined");
+    tokenContractAddress = deployRes.result.deployedAddress;
+
+    const mintToRes0 = await engine.erc1155.mintTo(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        receiver: backendWalletA,
+        metadataWithSupply: {
+          metadata: "ipfs://test",
+          supply: "10",
+        },
+      },
+    );
+    console.log("Waiting: minting token ID 0...");
+    await pollTransactionStatus(engine, mintToRes0.result.queueId, false);
+
+    const mintToRes1 = await engine.erc1155.mintTo(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        receiver: backendWalletB,
+        metadataWithSupply: {
+          metadata: "ipfs://test",
+          supply: "10",
+        },
+      },
+    );
+    console.log("Waiting: minting token ID 1...");
+    await pollTransactionStatus(engine, mintToRes1.result.queueId, false);
+  });
+
+  const getBalance = async (walletAddress: Address, tokenId: string) => {
+    const balanceOfRes = await engine.erc1155.balanceOf(
+      walletAddress,
+      tokenId,
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+    );
+    return balanceOfRes.result ? BigInt(balanceOfRes.result) : 0n;
+  };
+
+  test("Calling transfer succeeds", async () => {
+    const balanceStart = await getBalance(backendWalletA, "0");
+
+    const transferRes = await engine.erc1155.transfer(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        to: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        tokenId: "0",
+        amount: "1",
+        data: "0xabc",
+      },
+    );
+    console.log("Waiting: transferring token...");
+    await pollTransactionStatus(engine, transferRes.result.queueId, false);
+
+    const balanceEnd = await getBalance(backendWalletA, "0");
+    expect(balanceStart - balanceEnd).toEqual(1n);
+  });
+
+  test("Calling transferFrom succeds after allowance", async () => {
+    let balanceStart = await getBalance(backendWalletB, "1");
+    // Expected to fail.
+    const transferFromRes = await engine.erc1155.transferFrom(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        from: backendWalletB,
+        to: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        tokenId: "1",
+        amount: "1",
+        data: "0xabc",
+      },
+    );
+    console.log("Waiting: transferring token...");
+    await pollTransactionStatus(engine, transferFromRes.result.queueId, false);
+
+    let balanceEnd = await getBalance(backendWalletB, "1");
+    expect(balanceStart - balanceEnd).toEqual(0n);
+
+    const setAllowanceRes = await engine.erc1155.setApprovalForAll(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletB,
+      {
+        operator: backendWalletA,
+        approved: true,
+      },
+    );
+    await pollTransactionStatus(engine, setAllowanceRes.result.queueId, false);
+
+    balanceStart = await getBalance(backendWalletB, "1");
+    const transferFromRes2 = await engine.erc1155.transferFrom(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        from: backendWalletB,
+        to: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        tokenId: "1",
+        amount: "1",
+        data: "0xabc",
+      },
+    );
+    console.log("Waiting: transferring token...");
+    await pollTransactionStatus(engine, transferFromRes2.result.queueId, false);
+
+    balanceEnd = await getBalance(backendWalletB, "1");
+    expect(balanceStart - balanceEnd).toEqual(1n);
+  });
+});

--- a/test/e2e/tests/routes/erc20-transfer.test.ts
+++ b/test/e2e/tests/routes/erc20-transfer.test.ts
@@ -1,0 +1,143 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import assert from "node:assert";
+import { ZERO_ADDRESS, toWei, type Address } from "thirdweb";
+import { CONFIG } from "../../config";
+import { getEngineBackendWalletB, type setupEngine } from "../../utils/engine";
+import { pollTransactionStatus } from "../../utils/transactions";
+import { setup } from "./../setup";
+
+describe("ERC20 transfer", () => {
+  let tokenContractAddress: string;
+  let engine: ReturnType<typeof setupEngine>;
+  let backendWalletA: Address;
+  let backendWalletB: Address;
+
+  beforeAll(async () => {
+    const setupRes = await setup();
+    engine = setupRes.engine;
+    backendWalletA = setupRes.backendWallet;
+    backendWalletB = await getEngineBackendWalletB(engine);
+
+    const deployRes = await engine.deploy.deployToken(
+      CONFIG.CHAIN.id.toString(),
+      backendWalletA,
+      {
+        contractMetadata: {
+          name: "test token",
+          platform_fee_basis_points: 0,
+          platform_fee_recipient: ZERO_ADDRESS,
+          symbol: "TT",
+          trusted_forwarders: [],
+        },
+      },
+    );
+    assert(deployRes.result.queueId);
+    console.log("Waiting: deploying contract...");
+    await pollTransactionStatus(engine, deployRes.result.queueId, false);
+
+    assert(deployRes.result.deployedAddress, "deployedAddress must be defined");
+    tokenContractAddress = deployRes.result.deployedAddress;
+
+    const mintToResA = await engine.erc20.mintTo(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        toAddress: backendWalletA,
+        amount: "10",
+      },
+    );
+    console.log("Waiting: minting tokens...");
+    await pollTransactionStatus(engine, mintToResA.result.queueId, false);
+
+    const mintToResB = await engine.erc20.mintTo(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        toAddress: backendWalletB,
+        amount: "10",
+      },
+    );
+    console.log("Waiting: minting tokens...");
+    await pollTransactionStatus(engine, mintToResB.result.queueId, false);
+  });
+
+  const getBalance = async (walletAddress: Address) => {
+    const balanceOfRes = await engine.erc20.balanceOf(
+      walletAddress,
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+    );
+    return balanceOfRes.result.value;
+  };
+
+  test("Calling transfer succeeds", async () => {
+    const balanceStart = await getBalance(backendWalletA);
+
+    const transferRes = await engine.erc20.transfer(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        toAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        amount: "2.5",
+      },
+    );
+    console.log("Waiting: transferring token...");
+    await pollTransactionStatus(engine, transferRes.result.queueId, false);
+
+    const balanceEnd = await getBalance(backendWalletA);
+    expect(BigInt(balanceStart) - BigInt(balanceEnd)).toEqual(toWei("2.5"));
+  });
+
+  test("Calling transferFrom succeeds after allowance", async () => {
+    const setAllowanceRes = await engine.erc20.setAllowance(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletB,
+      {
+        spenderAddress: backendWalletA,
+        amount: "2.5",
+      },
+    );
+    await pollTransactionStatus(engine, setAllowanceRes.result.queueId, false);
+
+    const balanceStart = await getBalance(backendWalletB);
+    const transferFromRes = await engine.erc20.transferFrom(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        fromAddress: backendWalletB,
+        toAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        amount: "2.5",
+      },
+    );
+    console.log("Waiting: transferring token...");
+    await pollTransactionStatus(engine, transferFromRes.result.queueId, false);
+
+    const balanceEnd = await getBalance(backendWalletB);
+    expect(BigInt(balanceStart) - BigInt(balanceEnd)).toEqual(toWei("2.5"));
+  });
+
+  test("Calling transferFrom fails without allowance", async () => {
+    const balanceStart = await getBalance(backendWalletB);
+    // Expected to fail.
+    const transferFromRes = await engine.erc20.transferFrom(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        fromAddress: backendWalletB,
+        toAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        amount: "2.5",
+      },
+    );
+    console.log("Waiting: transferring token...");
+    await pollTransactionStatus(engine, transferFromRes.result.queueId, false);
+
+    const balanceEnd = await getBalance(backendWalletB);
+    expect(BigInt(balanceStart) - BigInt(balanceEnd)).toEqual(0n);
+  });
+});

--- a/test/e2e/tests/routes/erc721-transfer.test.ts
+++ b/test/e2e/tests/routes/erc721-transfer.test.ts
@@ -1,0 +1,156 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import assert from "node:assert";
+import { ZERO_ADDRESS, type Address } from "thirdweb";
+import { CONFIG } from "../../config";
+import { getEngineBackendWalletB, type setupEngine } from "../../utils/engine";
+import { pollTransactionStatus } from "../../utils/transactions";
+import { setup } from "../setup";
+
+describe("ERC721 transfer", () => {
+  let tokenContractAddress: string;
+  let engine: ReturnType<typeof setupEngine>;
+  let backendWalletA: Address;
+  let backendWalletB: Address;
+
+  beforeAll(async () => {
+    const setupRes = await setup();
+    engine = setupRes.engine;
+    backendWalletA = setupRes.backendWallet;
+    backendWalletB = await getEngineBackendWalletB(engine);
+
+    const deployRes = await engine.deploy.deployNftCollection(
+      CONFIG.CHAIN.id.toString(),
+      backendWalletA,
+      {
+        contractMetadata: {
+          name: "test token",
+          platform_fee_basis_points: 0,
+          platform_fee_recipient: ZERO_ADDRESS,
+          seller_fee_basis_points: 0,
+          fee_recipient: ZERO_ADDRESS,
+          symbol: "TT",
+          trusted_forwarders: [],
+        },
+      },
+    );
+    assert(deployRes.result.queueId);
+    console.log("Waiting: deploying contract...");
+    await pollTransactionStatus(engine, deployRes.result.queueId, false);
+
+    assert(deployRes.result.deployedAddress, "deployedAddress must be defined");
+    tokenContractAddress = deployRes.result.deployedAddress;
+  });
+
+  const getBalance = async (walletAddress: Address) => {
+    const balanceOfRes = await engine.erc721.balanceOf(
+      walletAddress,
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+    );
+    return balanceOfRes.result ? BigInt(balanceOfRes.result) : 0n;
+  };
+
+  test("Calling transfer succeeds", async () => {
+    const mintToRes = await engine.erc721.mintTo(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        receiver: backendWalletA,
+        metadata: "ipfs://test",
+      },
+    );
+    console.log("Waiting: minting tokens...");
+    await pollTransactionStatus(engine, mintToRes.result.queueId, false);
+
+    const balanceStart = await getBalance(backendWalletA);
+    const transferRes = await engine.erc721.transfer(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        to: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        tokenId: "0",
+      },
+    );
+    console.log("Waiting: transferring token...");
+    await pollTransactionStatus(engine, transferRes.result.queueId, false);
+
+    const balanceEnd = await getBalance(backendWalletA);
+    expect(balanceStart - balanceEnd).toEqual(1n);
+  });
+
+  test("Calling transferFrom succeeds after allowance", async () => {
+    const mintToRes = await engine.erc721.mintTo(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        receiver: backendWalletB,
+        metadata: "ipfs://test",
+      },
+    );
+    console.log("Waiting: minting tokens...");
+    await pollTransactionStatus(engine, mintToRes.result.queueId, false);
+
+    const balanceStart = await getBalance(backendWalletB);
+    const setAllowanceRes = await engine.erc721.setApprovalForToken(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletB,
+      {
+        operator: backendWalletA,
+        tokenId: "1",
+      },
+    );
+    await pollTransactionStatus(engine, setAllowanceRes.result.queueId, false);
+
+    const transferFromRes = await engine.erc721.transferFrom(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        from: backendWalletB,
+        to: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        tokenId: "1",
+      },
+    );
+    console.log("Waiting: transferring token...");
+    await pollTransactionStatus(engine, transferFromRes.result.queueId, false);
+
+    const balanceEnd = await getBalance(backendWalletB);
+    expect(balanceStart - balanceEnd).toEqual(1n);
+  });
+
+  test("Calling transferFrom fails without allowance", async () => {
+    const mintToRes = await engine.erc721.mintTo(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        receiver: backendWalletB,
+        metadata: "ipfs://test",
+      },
+    );
+    console.log("Waiting: minting tokens...");
+    await pollTransactionStatus(engine, mintToRes.result.queueId, false);
+
+    // Expected to fail.
+    const balanceStart = await getBalance(backendWalletB);
+    const transferFromRes = await engine.erc721.transferFrom(
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+      backendWalletA,
+      {
+        from: backendWalletB,
+        to: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        tokenId: "2",
+      },
+    );
+    console.log("Waiting: transferring token...");
+    await pollTransactionStatus(engine, transferFromRes.result.queueId, false);
+
+    const balanceEnd = await getBalance(backendWalletB);
+    expect(balanceStart - balanceEnd).toEqual(0n);
+  });
+});

--- a/test/e2e/tests/setup.ts
+++ b/test/e2e/tests/setup.ts
@@ -6,7 +6,7 @@ import {
   setupEngine,
 } from "../utils/engine";
 
-import type { Address } from "viem";
+import type { Address } from "thirdweb";
 import { CONFIG } from "../config";
 import { startAnvil, stopAnvil } from "../utils/anvil";
 

--- a/test/e2e/tests/write.test.ts
+++ b/test/e2e/tests/write.test.ts
@@ -45,7 +45,6 @@ describe("Write Tests", () => {
     expect(transactionStatus.minedAt).toBeDefined();
     assert(res.result.deployedAddress, "deployedAddress must be defined");
     tokenContractAddress = res.result.deployedAddress;
-    console.log("tokenContractAddress", tokenContractAddress);
   });
 
   test("Write to a contract with function name", async () => {

--- a/test/e2e/utils/engine.ts
+++ b/test/e2e/utils/engine.ts
@@ -1,7 +1,7 @@
-import { getAddress } from "viem";
+import { checksumAddress } from "thirdweb/utils";
 import { Engine } from "../../../sdk";
 import { CONFIG } from "../config";
-import { ANVIL_PKEY_A, TEST_ACCOUNT_A } from "./wallets";
+import { ANVIL_PKEY_A, ANVIL_PKEY_B } from "./wallets";
 
 export const setupEngine = () => {
   return new Engine({
@@ -44,19 +44,17 @@ export const createChain = async (engine: Engine) => {
 };
 
 export const getEngineBackendWallet = async (engine: Engine) => {
-  const res = await engine.backendWallet.getAll();
-  if (
-    !res.result.find((r) => r.address.toLowerCase() === TEST_ACCOUNT_A.address)
-  ) {
-    console.log("Creating backend wallet");
-    const newWallet = await engine.backendWallet.import({
-      privateKey: ANVIL_PKEY_A,
-    });
-    console.log("Created new wallet", newWallet.result.walletAddress);
+  const { result } = await engine.backendWallet.import({
+    label: "Anvil test wallet A",
+    privateKey: ANVIL_PKEY_A,
+  });
+  return checksumAddress(result.walletAddress);
+};
 
-    return getAddress(newWallet.result.walletAddress);
-  }
-
-  console.log("Using existing wallet", res.result[0].address);
-  return getAddress(res.result[0].address);
+export const getEngineBackendWalletB = async (engine: Engine) => {
+  const { result } = await engine.backendWallet.import({
+    label: "Anvil test wallet B",
+    privateKey: ANVIL_PKEY_B,
+  });
+  return checksumAddress(result.walletAddress);
 };

--- a/test/e2e/utils/wallets.ts
+++ b/test/e2e/utils/wallets.ts
@@ -18,3 +18,8 @@ export const TEST_ACCOUNT_A = privateKeyToAccount({
   client,
   privateKey: ANVIL_PKEY_A,
 });
+
+export const TEST_ACCOUNT_B = privateKeyToAccount({
+  client,
+  privateKey: ANVIL_PKEY_B,
+});


### PR DESCRIPTION
Maps the following routes to the v5 SDK methods:

- erc20/transfer -> transfer
- erc20/transferFrom -> transferFrom
- erc721/transfer -> transferFrom
- erc721/transferFrom -> transferFrom
- erc1155/transfer -> safeTransferFrom
- erc1155/transferFrom -> safeTransferFrom

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality and testing of ERC20, ERC721, and ERC1155 token transfers, along with improving schema definitions and utility functions. It introduces new test cases and refines existing code for better clarity and usability.

### Detailed summary
- Added `TEST_ACCOUNT_B` to `test/e2e/utils/wallets.ts`.
- Introduced `HexSchema` in `src/server/schemas/address.ts`.
- Updated example values in comments for `amount` in `sdk/src/services/BackendWalletService.ts`.
- Changed import for `Address` in `test/e2e/tests/setup.ts`.
- Removed console logs and improved assertions in `test/e2e/tests/write.test.ts`.
- Refined parameter descriptions in various services (ERC20, ERC721, ERC1155).
- Added `data` parameter to transfer functions in ERC1155.
- Introduced `getEngineBackendWalletB` function in `test/e2e/utils/engine.ts`.
- Updated contract interaction methods to use `thirdweb` client in multiple files.
- Enhanced transfer tests for ERC20, ERC721, and ERC1155 with new assertions and setup logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->