### PR TITLE
fix: use LRUMap for all in-memory caches

### DIFF
--- a/src/server/middleware/cors/vary.ts
+++ b/src/server/middleware/cors/vary.ts
@@ -1,4 +1,4 @@
-import { FastifyReply } from "fastify";
+import type { FastifyReply } from "fastify";
 import LRUCache from "mnemonist/lru-cache";
 
 /**

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,4 +1,5 @@
 import { StatusCodes } from "http-status-codes";
+import { LRUMap } from "mnemonist";
 import type { Address } from "thirdweb";
 import type { Account } from "thirdweb/wallets";
 import { getWalletDetails } from "../db/wallets/getWalletDetails";
@@ -15,7 +16,7 @@ import { decrypt } from "./crypto";
 import { env } from "./env";
 import { thirdwebClient } from "./sdk";
 
-export const _accountsCache = new Map<string, Account>();
+export const _accountsCache = new LRUMap<string, Account>(2048);
 
 export const getAccount = async (args: {
   chainId: number;

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { LRUMap } from "mnemonist";
+import LRUMap from "mnemonist/lru-map";
 import type { Address } from "thirdweb";
 import type { Account } from "thirdweb/wallets";
 import { getWalletDetails } from "../db/wallets/getWalletDetails";

--- a/src/utils/cache/accessToken.ts
+++ b/src/utils/cache/accessToken.ts
@@ -3,7 +3,7 @@ import LRUMap from "mnemonist/lru-map";
 import { getToken } from "../../db/tokens/getToken";
 
 // Cache an access token JWT to the token object, or null if not found.
-export const accessTokenCache = new LRUMap<string, Tokens | null>(1);
+export const accessTokenCache = new LRUMap<string, Tokens | null>(2048);
 
 interface GetAccessTokenParams {
   jwt: string;
@@ -14,11 +14,9 @@ export const getAccessToken = async ({
 }: GetAccessTokenParams): Promise<Tokens | null> => {
   const cached = accessTokenCache.get(jwt);
   if (cached) {
-    console.log("[DEBUG] found access token in cache");
     return cached;
   }
 
-  console.log("[DEBUG] access token not in cache");
   const accessToken = await getToken(jwt);
   accessTokenCache.set(jwt, accessToken);
   return accessToken;

--- a/src/utils/cache/accessToken.ts
+++ b/src/utils/cache/accessToken.ts
@@ -1,8 +1,9 @@
 import type { Tokens } from "@prisma/client";
+import { LRUMap } from "mnemonist";
 import { getToken } from "../../db/tokens/getToken";
 
 // Cache an access token JWT to the token object, or null if not found.
-export const accessTokenCache = new Map<string, Tokens | null>();
+export const accessTokenCache = new LRUMap<string, Tokens | null>(2048);
 
 interface GetAccessTokenParams {
   jwt: string;

--- a/src/utils/cache/accessToken.ts
+++ b/src/utils/cache/accessToken.ts
@@ -1,9 +1,9 @@
 import type { Tokens } from "@prisma/client";
-import { LRUMap } from "mnemonist";
+import LRUMap from "mnemonist/lru-map";
 import { getToken } from "../../db/tokens/getToken";
 
 // Cache an access token JWT to the token object, or null if not found.
-export const accessTokenCache = new LRUMap<string, Tokens | null>(2048);
+export const accessTokenCache = new LRUMap<string, Tokens | null>(1);
 
 interface GetAccessTokenParams {
   jwt: string;
@@ -14,9 +14,11 @@ export const getAccessToken = async ({
 }: GetAccessTokenParams): Promise<Tokens | null> => {
   const cached = accessTokenCache.get(jwt);
   if (cached) {
+    console.log("[DEBUG] found access token in cache");
     return cached;
   }
 
+  console.log("[DEBUG] access token not in cache");
   const accessToken = await getToken(jwt);
   accessTokenCache.set(jwt, accessToken);
   return accessToken;

--- a/src/utils/cache/getSdk.ts
+++ b/src/utils/cache/getSdk.ts
@@ -1,12 +1,13 @@
 import { Type } from "@sinclair/typebox";
 import { ThirdwebSDK } from "@thirdweb-dev/sdk";
+import { LRUMap } from "mnemonist";
 import { getChainMetadata } from "thirdweb/chains";
 import { badChainError } from "../../server/middleware/error";
 import { getChain } from "../chain";
 import { env } from "../env";
 import { getWallet } from "./getWallet";
 
-export const sdkCache = new Map<string, ThirdwebSDK>();
+export const sdkCache = new LRUMap<string, ThirdwebSDK>(2048);
 
 export const networkResponseSchema = Type.Object({
   name: Type.String({

--- a/src/utils/cache/getSdk.ts
+++ b/src/utils/cache/getSdk.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import { ThirdwebSDK } from "@thirdweb-dev/sdk";
-import { LRUMap } from "mnemonist";
+import LRUMap from "mnemonist/lru-map";
 import { getChainMetadata } from "thirdweb/chains";
 import { badChainError } from "../../server/middleware/error";
 import { getChain } from "../chain";

--- a/src/utils/cache/getSmartWalletV5.ts
+++ b/src/utils/cache/getSmartWalletV5.ts
@@ -1,10 +1,10 @@
+import { LRUMap } from "mnemonist";
+import { getContract, readContract, type Address, type Chain } from "thirdweb";
 import { smartWallet, type Account } from "thirdweb/wallets";
 import { getAccount } from "../account";
 import { thirdwebClient } from "../sdk";
 
-import { getContract, readContract, type Address, type Chain } from "thirdweb";
-
-export const smartWalletsCache = new Map<string, Account>();
+export const smartWalletsCache = new LRUMap<string, Account>(2048);
 
 interface SmartWalletParams {
   chain: Chain;

--- a/src/utils/cache/getSmartWalletV5.ts
+++ b/src/utils/cache/getSmartWalletV5.ts
@@ -1,4 +1,4 @@
-import { LRUMap } from "mnemonist";
+import LRUMap from "mnemonist/lru-map";
 import { getContract, readContract, type Address, type Chain } from "thirdweb";
 import { smartWallet, type Account } from "thirdweb/wallets";
 import { getAccount } from "../account";

--- a/src/utils/cache/getWallet.ts
+++ b/src/utils/cache/getWallet.ts
@@ -2,7 +2,7 @@ import type { EVMWallet } from "@thirdweb-dev/wallets";
 import { AwsKmsWallet } from "@thirdweb-dev/wallets/evm/wallets/aws-kms";
 import { GcpKmsWallet } from "@thirdweb-dev/wallets/evm/wallets/gcp-kms";
 import { StatusCodes } from "http-status-codes";
-import { LRUMap } from "mnemonist";
+import LRUMap from "mnemonist/lru-map";
 import { getWalletDetails } from "../../db/wallets/getWalletDetails";
 import type { PrismaTransaction } from "../../schema/prisma";
 import { WalletType } from "../../schema/wallet";

--- a/src/utils/cache/getWallet.ts
+++ b/src/utils/cache/getWallet.ts
@@ -2,6 +2,7 @@ import type { EVMWallet } from "@thirdweb-dev/wallets";
 import { AwsKmsWallet } from "@thirdweb-dev/wallets/evm/wallets/aws-kms";
 import { GcpKmsWallet } from "@thirdweb-dev/wallets/evm/wallets/gcp-kms";
 import { StatusCodes } from "http-status-codes";
+import { LRUMap } from "mnemonist";
 import { getWalletDetails } from "../../db/wallets/getWalletDetails";
 import type { PrismaTransaction } from "../../schema/prisma";
 import { WalletType } from "../../schema/wallet";
@@ -14,7 +15,7 @@ import { decrypt } from "../crypto";
 import { env } from "../env";
 import { getConfig } from "./getConfig";
 
-export const walletsCache = new Map<string, EVMWallet>();
+export const walletsCache = new LRUMap<string, EVMWallet>(2048);
 
 interface GetWalletParams {
   pgtx?: PrismaTransaction;

--- a/src/utils/cache/getWebhook.ts
+++ b/src/utils/cache/getWebhook.ts
@@ -1,8 +1,9 @@
-import { Webhooks } from "@prisma/client";
+import type { Webhooks } from "@prisma/client";
+import { LRUMap } from "mnemonist";
 import { getAllWebhooks } from "../../db/webhooks/getAllWebhooks";
-import { WebhooksEventTypes } from "../../schema/webhooks";
+import type { WebhooksEventTypes } from "../../schema/webhooks";
 
-export const webhookCache = new Map<string, Webhooks[]>();
+export const webhookCache = new LRUMap<string, Webhooks[]>(2048);
 
 export const getWebhooksByEventType = async (
   eventType: WebhooksEventTypes,

--- a/src/utils/cache/getWebhook.ts
+++ b/src/utils/cache/getWebhook.ts
@@ -1,5 +1,5 @@
 import type { Webhooks } from "@prisma/client";
-import { LRUMap } from "mnemonist";
+import LRUMap from "mnemonist/lru-map";
 import { getAllWebhooks } from "../../db/webhooks/getAllWebhooks";
 import type { WebhooksEventTypes } from "../../schema/webhooks";
 

--- a/src/utils/cache/keypair.ts
+++ b/src/utils/cache/keypair.ts
@@ -1,5 +1,5 @@
 import type { Keypairs } from "@prisma/client";
-import { LRUMap } from "mnemonist";
+import LRUMap from "mnemonist/lru-map";
 import { getKeypairByHash, getKeypairByPublicKey } from "../../db/keypair/get";
 
 // Cache a public key to the Keypair object, or null if not found.

--- a/src/utils/cache/keypair.ts
+++ b/src/utils/cache/keypair.ts
@@ -1,8 +1,9 @@
 import type { Keypairs } from "@prisma/client";
+import { LRUMap } from "mnemonist";
 import { getKeypairByHash, getKeypairByPublicKey } from "../../db/keypair/get";
 
 // Cache a public key to the Keypair object, or null if not found.
-export const keypairCache = new Map<string, Keypairs | null>();
+export const keypairCache = new LRUMap<string, Keypairs | null>(2048);
 
 /**
  * Get a keypair by public key or hash.
@@ -16,8 +17,8 @@ export const getKeypair = async (args: {
   const key = publicKey
     ? `public-key:${args.publicKey}`
     : publicKeyHash
-    ? `public-key-hash:${args.publicKeyHash}`
-    : null;
+      ? `public-key-hash:${args.publicKeyHash}`
+      : null;
 
   if (!key) {
     throw new Error('Must provide "publicKey" or "publicKeyHash".');
@@ -31,8 +32,8 @@ export const getKeypair = async (args: {
   const keypair = publicKey
     ? await getKeypairByPublicKey(publicKey)
     : publicKeyHash
-    ? await getKeypairByHash(publicKeyHash)
-    : null;
+      ? await getKeypairByHash(publicKeyHash)
+      : null;
 
   keypairCache.set(key, keypair);
   return keypair;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on optimizing various cache implementations by replacing `Map` with `LRUMap` from the `mnemonist` library across multiple files, enhancing memory efficiency and performance.

### Detailed summary
- Changed `accessTokenCache` from `Map` to `LRUMap`.
- Changed `smartWalletsCache` from `Map` to `LRUMap`.
- Changed `webhookCache` from `Map` to `LRUMap`.
- Changed `_accountsCache` from `Map` to `LRUMap`.
- Changed `sdkCache` from `Map` to `LRUMap`.
- Changed `walletsCache` from `Map` to `LRUMap`.
- Changed `keypairCache` from `Map` to `LRUMap`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->