### PR TITLE
fix: Support arbitrary-length UIDs for ERC721 signature prepare

### DIFF
--- a/src/server/routes/contract/extensions/erc721/read/signaturePrepare.ts
+++ b/src/server/routes/contract/extensions/erc721/read/signaturePrepare.ts
@@ -2,12 +2,11 @@ import { Type, type Static } from "@sinclair/typebox";
 import { MintRequest721 } from "@thirdweb-dev/sdk";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import { getRandomValues } from "node:crypto";
+import { createHash, getRandomValues } from "node:crypto";
 import {
   ZERO_ADDRESS,
   getContract,
   isHex,
-  stringToHex,
   uint8ArrayToHex,
   type Hex,
 } from "thirdweb";
@@ -286,7 +285,7 @@ export async function erc721SignaturePrepare(fastify: FastifyInstance) {
           }
           parsedUid = uid;
         } else {
-          parsedUid = stringToHex(uid, { size: 32 });
+          parsedUid = `0x${createHash("sha256").update(uid).digest("hex")}`;
         }
       } else {
         parsedUid = uint8ArrayToHex(getRandomValues(new Uint8Array(32)));

--- a/test/e2e/tests/routes/signaturePrepare.test.ts
+++ b/test/e2e/tests/routes/signaturePrepare.test.ts
@@ -5,7 +5,7 @@ describe("signaturePrepareRoute", () => {
   test("Prepare a signature with upload, no uid, no royalty/sale recipients", async () => {
     const { engine, backendWallet } = await setup();
 
-    const res = await engine.erc721.erc721SignaturePrepare(
+    const res = await engine.erc721.signaturePrepare(
       "84532",
       "0x5002e3bF97F376Fe0480109e26c0208786bCDDd4",
       {
@@ -138,7 +138,7 @@ describe("signaturePrepareRoute", () => {
   test("Prepare a signature with provided hex uid", async () => {
     const { engine, backendWallet } = await setup();
 
-    const res = await engine.erc721.erc721SignaturePrepare(
+    const res = await engine.erc721.signaturePrepare(
       "84532",
       "0x5002e3bF97F376Fe0480109e26c0208786bCDDd4",
       {
@@ -153,15 +153,12 @@ describe("signaturePrepareRoute", () => {
     expect(res.result.mintPayload.uid).toEqual(
       "0x25d29226fc7c310ed308c1eea8a3ed2d9f660d873ba6348b6649da4cae3877a4",
     );
-    expect(res.result.mintPayload.uid).toEqual(
-      "0x25d29226fc7c310ed308c1eea8a3ed2d9f660d873ba6348b6649da4cae3877a4",
-    );
   });
 
   test("Prepare a signature with string uid", async () => {
     const { engine, backendWallet } = await setup();
 
-    const res = await engine.erc721.erc721SignaturePrepare(
+    const res = await engine.erc721.signaturePrepare(
       "84532",
       "0x5002e3bF97F376Fe0480109e26c0208786bCDDd4",
       {
@@ -169,15 +166,12 @@ describe("signaturePrepareRoute", () => {
         validityEndTimestamp: 1729194714,
         validityStartTimestamp: 1728589914,
         to: backendWallet,
-        uid: "my-test-uuid",
+        uid: "my-really-long-test-uuid-my-really-long-test-uuid-my-really-long-test-uuid",
       },
     );
 
     expect(res.result.mintPayload.uid).toEqual(
-      "0x6d792d746573742d757569640000000000000000000000000000000000000000",
-    );
-    expect(res.result.mintPayload.uid).toEqual(
-      "0x6d792d746573742d757569640000000000000000000000000000000000000000",
+      "0xa74a3badce5090a5afead99c9d80e08169468a2442a6f79692001aed81acf2bc",
     );
   });
 
@@ -186,7 +180,7 @@ describe("signaturePrepareRoute", () => {
 
     let threw = false;
     try {
-      await engine.erc721.erc721SignaturePrepare(
+      await engine.erc721.signaturePrepare(
         "84532",
         "0x5002e3bF97F376Fe0480109e26c0208786bCDDd4",
         {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `erc721SignaturePrepare` function in `signaturePrepare.ts` to enhance the UID processing and updating the test cases accordingly.

### Detailed summary
- Replaced `stringToHex` with SHA-256 hashing for UID processing in `erc721SignaturePrepare`.
- Updated function call from `erc721.erc721SignaturePrepare` to `erc721.signaturePrepare` in test cases.
- Changed test case UID from "my-test-uuid" to a longer string "my-really-long-test-uuid-my-really-long-test-uuid-my-really-long-test-uuid".
- Updated expected UID values in tests to match the new hashing logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->