### PR TITLE
Add support for untyped contract args in /write

### DIFF
--- a/test/e2e/tests/write.test.ts
+++ b/test/e2e/tests/write.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import assert from "node:assert";
-import type { Address } from "thirdweb";
+import { type Address, stringToHex } from "thirdweb";
 import { zeroAddress } from "viem";
 import type { ApiError } from "../../../sdk/dist/thirdweb-dev-engine.cjs";
 import { CONFIG } from "../config";
@@ -67,6 +67,98 @@ describe("Write Tests", () => {
     );
 
     expect(writeTransactionStatus.minedAt).toBeDefined();
+  });
+
+  test.only("Write to a contract with untyped args", async () => {
+    const res = await engine.deploy.deployNftDrop(
+      CONFIG.CHAIN.id.toString(),
+      backendWallet,
+      {
+        contractMetadata: {
+          name: "test token",
+          platform_fee_basis_points: 0,
+          platform_fee_recipient: zeroAddress,
+          symbol: "TT",
+          trusted_forwarders: [],
+          seller_fee_basis_points: 0,
+          fee_recipient: zeroAddress,
+        },
+      },
+    );
+
+    expect(res.result.queueId).toBeDefined();
+    assert(res.result.queueId, "queueId must be defined");
+    expect(res.result.deployedAddress).toBeDefined();
+    const nftDropContractAddress = res.result.deployedAddress;
+
+    if (!nftDropContractAddress) {
+      throw new Error("nftDropContractAddress must be defined");
+    }
+
+    const transactionStatus = await pollTransactionStatus(
+      engine,
+      res.result.queueId,
+      true,
+    );
+
+    expect(transactionStatus.minedAt).toBeDefined();
+    const writeRes = await engine.contract.write(
+      CONFIG.CHAIN.id.toString(),
+      nftDropContractAddress,
+      backendWallet,
+      {
+        functionName: "setApprovalForAll",
+        args: [
+          "0x1234567890123456789012345678901234567890",
+          "true", // string instead of bool
+        ],
+      },
+    );
+
+    expect(writeRes.result.queueId).toBeDefined();
+
+    const writeTransactionStatus = await pollTransactionStatus(
+      engine,
+      writeRes.result.queueId,
+      true,
+    );
+
+    expect(writeTransactionStatus.minedAt).toBeDefined();
+
+    const writeRes2 = await engine.contract.write(
+      CONFIG.CHAIN.id.toString(),
+      nftDropContractAddress,
+      backendWallet,
+      {
+        functionName: "setClaimConditions",
+        args: [
+          // stringified array of structs
+          JSON.stringify([
+            {
+              startTimestamp: "0",
+              maxClaimableSupply: "100000",
+              supplyClaimed: "0",
+              quantityLimitPerWallet: "10",
+              merkleRoot: stringToHex("", { size: 32 }),
+              pricePerToken: "0",
+              currency: zeroAddress,
+              metadata: "",
+            },
+          ]),
+          "false",
+        ],
+      },
+    );
+
+    expect(writeRes2.result.queueId).toBeDefined();
+
+    const writeTransactionStatus2 = await pollTransactionStatus(
+      engine,
+      writeRes2.result.queueId,
+      true,
+    );
+
+    expect(writeTransactionStatus2.minedAt).toBeDefined();
   });
 
   test("Write to a contract with function signature", async () => {


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `writeToContract` function by adding support for parsing ABI parameters and includes new tests for writing to a contract with untyped arguments.

### Detailed summary
- Added `parseAbiParams` to handle method input parameters in `writeToContract`.
- Changed `params` assignment to use parsed parameters from `method.inputs`.
- Introduced a new test for writing to a contract with untyped arguments.
- Updated existing tests to ensure compatibility with new functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->