### PR TITLE
refactor: Improve argument parsing in readContract function

### DIFF
--- a/src/server/routes/contract/read/read.ts
+++ b/src/server/routes/contract/read/read.ts
@@ -43,7 +43,16 @@ export async function readContract(fastify: FastifyInstance) {
         contractAddress,
       });
 
-      const parsedArgs = args?.split(",").map((arg) => {
+      let parsedArgs: unknown[] | undefined = [];
+
+      try {
+        const jsonStringArgs = `[${args}]`;
+        parsedArgs = JSON.parse(jsonStringArgs);
+      } catch {
+        // fallback to string split
+      }
+
+      parsedArgs ??= args?.split(",").map((arg) => {
         if (arg === "true") {
           return true;
         }

--- a/src/server/utils/convertor.ts
+++ b/src/server/utils/convertor.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "ethers";
 
-export const bigNumberReplacer = (value: any): string => {
+export const bigNumberReplacer = (value: any): any => {
   // if we find a BigNumber then make it into a string (since that is safe)
   if (
     BigNumber.isBigNumber(value) ||
@@ -11,5 +11,10 @@ export const bigNumberReplacer = (value: any): string => {
   ) {
     return BigNumber.from(value).toString();
   }
+
+  if (Array.isArray(value)) {
+    return value.map(bigNumberReplacer);
+  }
+
   return value;
 };

--- a/test/e2e/tests/read.test.ts
+++ b/test/e2e/tests/read.test.ts
@@ -1,0 +1,38 @@
+import { beforeAll, describe, test } from "bun:test";
+import { sepolia } from "thirdweb/chains";
+import { expect } from "vitest";
+import type { setupEngine } from "../utils/engine";
+import { setup } from "./setup";
+
+const structContractAddress = "0x83ca896ef0a66d39f0e6fcc1a93c0a09366b85b1";
+const chainIdString = sepolia.id.toString();
+
+describe("Read Tests", () => {
+  let engine: ReturnType<typeof setupEngine>;
+
+  beforeAll(async () => {
+    const { engine: _engine, backendWallet: _backendWallet } = await setup();
+    engine = _engine;
+  });
+
+  test("Write to a contract with function name", async () => {
+    const structValues = {
+      name: "test",
+      value: 123,
+    };
+
+    const structString = JSON.stringify(structValues);
+
+    const { result } = await engine.contract.read(
+      "readStructAndInts",
+      chainIdString,
+      structContractAddress,
+      `${structString},1,2`,
+    );
+
+    expect(result[0]).toEqual("test");
+    expect(result[1]).toEqual("123");
+    expect(result[2]).toEqual("1");
+    expect(result[3]).toEqual("2");
+  });
+});

--- a/test/e2e/tests/read.test.ts
+++ b/test/e2e/tests/read.test.ts
@@ -15,7 +15,7 @@ describe("Read Tests", () => {
     engine = _engine;
   });
 
-  test("Write to a contract with function name", async () => {
+  test("Read a contract method with struct and number params", async () => {
     const structValues = {
       name: "test",
       value: 123,


### PR DESCRIPTION
The readContract function in the src/server/routes/contract/read/read.ts file has been refactored to improve the parsing of arguments. Previously, the function split the arguments string by comma and mapped each argument. Now, the function first tries to parse the arguments as a JSON array. If successful, it uses the parsed arguments. If parsing fails, it falls back to the previous method of splitting the string.

This change improves the flexibility and reliability of argument parsing in the readContract function.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the argument parsing logic in the `read` function and improving the handling of `BigNumber` values in the `bigNumberReplacer` function. Additionally, it introduces new tests for reading contract methods with structured parameters.

### Detailed summary
- Updated argument parsing in `src/server/routes/contract/read/read.ts` to use JSON parsing as the primary method, with a fallback to string splitting.
- Changed the return type of `bigNumberReplacer` in `src/server/utils/convertor.ts` from `string` to `any`.
- Added support for arrays in `bigNumberReplacer`.
- Introduced new tests in `test/e2e/tests/read.test.ts` for reading contract methods with structured parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->