### PR TITLE
400 for user errors on contract read

### DIFF
--- a/src/server/routes/contract/read/read.ts
+++ b/src/server/routes/contract/read/read.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../utils/cache/getContract";
+import { createCustomError } from "../../../middleware/error";
 import {
   readRequestQuerySchema,
   type readSchema,
@@ -62,11 +63,28 @@ export async function readContract(fastify: FastifyInstance) {
         return arg;
       });
 
-      let returnData = await contract.call(functionName, parsedArgs ?? []);
+      let returnData: unknown;
+
+      try {
+        returnData = await contract.call(functionName, parsedArgs ?? []);
+      } catch (e) {
+        if (
+          e instanceof Error &&
+          (e.message.includes("is not a function") ||
+            e.message.includes("arguments, but"))
+        ) {
+          throw createCustomError(
+            e.message,
+            StatusCodes.BAD_REQUEST,
+            "BAD_REQUEST",
+          );
+        }
+      }
       returnData = bigNumberReplacer(returnData);
 
       reply.status(StatusCodes.OK).send({
-        result: returnData,
+        // biome-ignore lint/suspicious/noExplicitAny: data from chain
+        result: returnData as any,
       });
     },
   });

--- a/test/e2e/tests/read.test.ts
+++ b/test/e2e/tests/read.test.ts
@@ -1,6 +1,6 @@
-import { beforeAll, describe, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { sepolia } from "thirdweb/chains";
-import { expect } from "vitest";
+import type { ApiError } from "../../../sdk/dist/thirdweb-dev-engine.cjs";
 import type { setupEngine } from "../utils/engine";
 import { setup } from "./setup";
 
@@ -34,5 +34,26 @@ describe("Read Tests", () => {
     expect(result[1]).toEqual("123");
     expect(result[2]).toEqual("1");
     expect(result[3]).toEqual("2");
+  });
+
+  test("Incorrectly read a contract should 400 (incorrect arity)", async () => {
+    const structValues = {
+      name: "test",
+      value: 123,
+    };
+
+    const structString = JSON.stringify(structValues);
+
+    try {
+      await engine.contract.read(
+        "readStructAndInts",
+        chainIdString,
+        structContractAddress,
+        [structString, 1].join(","),
+      );
+      throw new Error("Expected method to throw");
+    } catch (error) {
+      expect((error as ApiError).status).toBe(400);
+    }
   });
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing error handling in the `read` function of the contract and adding a new test case to verify the behavior when reading a contract with incorrect parameters.

### Detailed summary
- Added a new test case in `test/e2e/tests/read.test.ts` for handling incorrect contract reads, expecting a 400 error.
- Improved error handling in `src/server/routes/contract/read/read.ts` to throw a custom error for specific function call issues.
- Updated return type for `returnData` to `unknown` and used `as any` for the response.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->