### PR TITLE
Refactor chainId from number to string in contractSubscriptions

### DIFF
--- a/src/db/contractSubscriptions/createContractSubscription.ts
+++ b/src/db/contractSubscriptions/createContractSubscription.ts
@@ -21,7 +21,7 @@ export const createContractSubscription = async ({
 }: CreateContractSubscriptionParams) => {
   return prisma.contractSubscriptions.create({
     data: {
-      chainId,
+      chainId: chainId.toString(),
       contractAddress,
       webhookId,
       processEventLogs,

--- a/src/db/contractSubscriptions/getContractSubscriptions.ts
+++ b/src/db/contractSubscriptions/getContractSubscriptions.ts
@@ -11,7 +11,7 @@ export const isContractSubscribed = async ({
 }: GetContractSubscriptionsParams) => {
   const contractSubscription = await prisma.contractSubscriptions.findFirst({
     where: {
-      chainId,
+      chainId: chainId.toString(),
       contractAddress,
       deletedAt: null,
     },
@@ -25,7 +25,7 @@ export const getContractSubscriptionsByChainId = async (
 ) => {
   return await prisma.contractSubscriptions.findMany({
     where: {
-      chainId,
+      chainId: chainId.toString(),
       deletedAt: null,
     },
     include: {
@@ -56,5 +56,5 @@ export const getContractSubscriptionsUniqueChainIds = async () => {
     },
   });
 
-  return uniqueChainIds.map((contract) => contract.chainId);
+  return uniqueChainIds.map((contract) => Number.parseInt(contract.chainId));
 };

--- a/src/prisma/migrations/20241105091733_chain_id_from_int_to_string/migration.sql
+++ b/src/prisma/migrations/20241105091733_chain_id_from_int_to_string/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "contract_subscriptions" ALTER COLUMN "chainId" SET DATA TYPE TEXT;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -202,7 +202,7 @@ model Relayers {
 
 model ContractSubscriptions {
   id                         String   @id @default(uuid()) @map("id")
-  chainId                    Int
+  chainId                    String
   contractAddress            String
   webhookId                  Int?
   processEventLogs           Boolean  @default(true)

--- a/src/server/schemas/contractSubscription.ts
+++ b/src/server/schemas/contractSubscription.ts
@@ -22,7 +22,7 @@ export const toContractSubscriptionSchema = (
   contractSubscription: ContractSubscriptions & { webhook: Webhooks | null },
 ): Static<typeof contractSubscriptionSchema> => ({
   id: contractSubscription.id,
-  chainId: contractSubscription.chainId,
+  chainId: Number.parseInt(contractSubscription.chainId),
   contractAddress: contractSubscription.contractAddress,
   webhook: contractSubscription.webhook
     ? toWebhookSchema(contractSubscription.webhook)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on changing the data type of the `chainId` field in the `contract_subscriptions` table from `Int` to `String`. It updates related code to ensure consistent handling of `chainId` as a string.

### Detailed summary
- Altered `chainId` column type in the `contract_subscriptions` table to `TEXT`.
- Updated `createContractSubscription.ts` to convert `chainId` to a string.
- Changed `schema.prisma` to reflect `chainId` as a `String`.
- Modified `contractSubscription.ts` to parse `chainId` as an integer.
- Adjusted `getContractSubscriptions.ts` to convert `chainId` to a string in queries.
- Updated the return value in `getContractSubscriptionsUniqueChainIds` to parse `chainId` as an integer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->