### PR TITLE
refactor all int chainId to string

### DIFF
--- a/src/db/chainIndexers/getChainIndexer.ts
+++ b/src/db/chainIndexers/getChainIndexer.ts
@@ -43,7 +43,7 @@ export const getBlockForIndexing = async ({
     FROM
       "chain_indexers"
     WHERE
-      "chainId"=${Prisma.sql`${chainId}`}
+      "chainId"=${Prisma.sql`${chainId.toString()}`}
     FOR UPDATE NOWAIT
   `;
   return lastIndexedBlock[0].lastIndexedBlock;

--- a/src/db/chainIndexers/getChainIndexer.ts
+++ b/src/db/chainIndexers/getChainIndexer.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import type { PrismaTransaction } from "../../schema/prisma";
 import { getPrismaWithPostgresTx } from "../client";
 
@@ -14,7 +15,7 @@ export const getLastIndexedBlock = async ({
 
   const indexedChain = await prisma.chainIndexers.findUnique({
     where: {
-      chainId,
+      chainId: chainId.toString(),
     },
   });
 
@@ -42,7 +43,7 @@ export const getBlockForIndexing = async ({
     FROM
       "chain_indexers"
     WHERE
-      "chainId"=${chainId}
+      "chainId"=${Prisma.sql`${chainId}`}
     FOR UPDATE NOWAIT
   `;
   return lastIndexedBlock[0].lastIndexedBlock;

--- a/src/db/chainIndexers/upsertChainIndexer.ts
+++ b/src/db/chainIndexers/upsertChainIndexer.ts
@@ -1,4 +1,4 @@
-import { PrismaTransaction } from "../../schema/prisma";
+import type { PrismaTransaction } from "../../schema/prisma";
 import { getPrismaWithPostgresTx } from "../client";
 
 interface UpsertChainIndexerParams {
@@ -15,14 +15,14 @@ export const upsertChainIndexer = async ({
   const prisma = getPrismaWithPostgresTx(pgtx);
   return prisma.chainIndexers.upsert({
     where: {
-      chainId,
+      chainId: chainId.toString(),
     },
     update: {
-      chainId,
+      chainId: chainId.toString(),
       lastIndexedBlock: currentBlockNumber,
     },
     create: {
-      chainId,
+      chainId: chainId.toString(),
       lastIndexedBlock: currentBlockNumber,
     },
   });

--- a/src/db/contractEventLogs/deleteContractEventLogs.ts
+++ b/src/db/contractEventLogs/deleteContractEventLogs.ts
@@ -11,7 +11,7 @@ export const deleteContractEventLogs = async ({
 }: DeleteContractEventLogsParams) => {
   return prisma.contractEventLogs.deleteMany({
     where: {
-      chainId,
+      chainId: chainId.toString(),
       contractAddress,
     },
   });

--- a/src/db/contractEventLogs/getContractEventLogs.ts
+++ b/src/db/contractEventLogs/getContractEventLogs.ts
@@ -150,7 +150,7 @@ export const getEventLogsByCursor = async ({
                 { createdAt: { gt: cursorObj.createdAt } },
                 {
                   createdAt: { equals: cursorObj.createdAt },
-                  chainId: { equals: cursorObj.chainId.toString() },
+                  chainId: { gt: cursorObj.chainId.toString() },
                 },
                 {
                   createdAt: { equals: cursorObj.createdAt },

--- a/src/db/contractEventLogs/getContractEventLogs.ts
+++ b/src/db/contractEventLogs/getContractEventLogs.ts
@@ -18,7 +18,7 @@ export const getContractEventLogsByBlockAndTopics = async ({
   topics,
 }: GetContractLogsParams) => {
   const whereClause = {
-    chainId,
+    chainId: chainId.toString(),
     contractAddress,
     blockNumber: {
       gte: fromBlock,
@@ -118,7 +118,9 @@ export const getEventLogsByCursor = async ({
   let cursorObj: z.infer<typeof CursorSchema> | null = null;
   if (cursor) {
     const decodedCursor = base64.decode(cursor);
-    const parsedCursor = decodedCursor.split("-").map((val) => parseInt(val));
+    const parsedCursor = decodedCursor
+      .split("-")
+      .map((val) => Number.parseInt(val));
     const [createdAt, chainId, blockNumber, transactionIndex, logIndex] =
       parsedCursor;
     const validationResult = CursorSchema.safeParse({
@@ -148,22 +150,22 @@ export const getEventLogsByCursor = async ({
                 { createdAt: { gt: cursorObj.createdAt } },
                 {
                   createdAt: { equals: cursorObj.createdAt },
-                  chainId: { gt: cursorObj.chainId },
+                  chainId: { equals: cursorObj.chainId.toString() },
                 },
                 {
                   createdAt: { equals: cursorObj.createdAt },
-                  chainId: { equals: cursorObj.chainId },
+                  chainId: { equals: cursorObj.chainId.toString() },
                   blockNumber: { gt: cursorObj.blockNumber },
                 },
                 {
                   createdAt: { equals: cursorObj.createdAt },
-                  chainId: { equals: cursorObj.chainId },
+                  chainId: { equals: cursorObj.chainId.toString() },
                   blockNumber: { equals: cursorObj.blockNumber },
                   transactionIndex: { gt: cursorObj.transactionIndex },
                 },
                 {
                   createdAt: { equals: cursorObj.createdAt },
-                  chainId: { equals: cursorObj.chainId },
+                  chainId: { equals: cursorObj.chainId.toString() },
                   blockNumber: { equals: cursorObj.blockNumber },
                   transactionIndex: { equals: cursorObj.transactionIndex },
                   logIndex: { gt: cursorObj.logIndex },
@@ -234,7 +236,7 @@ export const getContractEventLogsIndexedBlockRange = async ({
 }: GetContractEventLogsIndexedBlockRangeParams) => {
   const result = await prisma.contractEventLogs.aggregate({
     where: {
-      chainId,
+      chainId: chainId.toString(),
       contractAddress,
     },
     _min: {

--- a/src/db/contractTransactionReceipts/deleteContractTransactionReceipts.ts
+++ b/src/db/contractTransactionReceipts/deleteContractTransactionReceipts.ts
@@ -11,7 +11,7 @@ export const deleteContractTransactionReceipts = async ({
 }: DeleteContractTransactionReceiptsParams) => {
   return prisma.contractTransactionReceipts.deleteMany({
     where: {
-      chainId,
+      chainId: chainId.toString(),
       contractAddress,
     },
   });

--- a/src/db/contractTransactionReceipts/getContractTransactionReceipts.ts
+++ b/src/db/contractTransactionReceipts/getContractTransactionReceipts.ts
@@ -120,7 +120,7 @@ export const getTransactionReceiptsByCursor = async ({
                 { createdAt: { gt: cursorObj.createdAt } },
                 {
                   createdAt: { equals: cursorObj.createdAt },
-                  chainId: { equals: cursorObj.chainId.toString() },
+                  chainId: { gt: cursorObj.chainId.toString() },
                 },
                 {
                   createdAt: { equals: cursorObj.createdAt },

--- a/src/db/contractTransactionReceipts/getContractTransactionReceipts.ts
+++ b/src/db/contractTransactionReceipts/getContractTransactionReceipts.ts
@@ -16,7 +16,7 @@ export const getContractTransactionReceiptsByBlock = async ({
   toBlock,
 }: GetContractTransactionReceiptsParams) => {
   const whereClause = {
-    chainId,
+    chainId: chainId.toString(),
     contractAddress,
     blockNumber: {
       gte: fromBlock,
@@ -90,7 +90,9 @@ export const getTransactionReceiptsByCursor = async ({
   let cursorObj: z.infer<typeof CursorSchema> | null = null;
   if (cursor) {
     const decodedCursor = base64.decode(cursor);
-    const parsedCursor = decodedCursor.split("-").map((val) => parseInt(val));
+    const parsedCursor = decodedCursor
+      .split("-")
+      .map((val) => Number.parseInt(val));
     const [createdAt, chainId, blockNumber, transactionIndex] = parsedCursor;
     const validationResult = CursorSchema.safeParse({
       createdAt,
@@ -118,16 +120,16 @@ export const getTransactionReceiptsByCursor = async ({
                 { createdAt: { gt: cursorObj.createdAt } },
                 {
                   createdAt: { equals: cursorObj.createdAt },
-                  chainId: { gt: cursorObj.chainId },
+                  chainId: { equals: cursorObj.chainId.toString() },
                 },
                 {
                   createdAt: { equals: cursorObj.createdAt },
-                  chainId: { equals: cursorObj.chainId },
+                  chainId: { equals: cursorObj.chainId.toString() },
                   blockNumber: { gt: cursorObj.blockNumber },
                 },
                 {
                   createdAt: { equals: cursorObj.createdAt },
-                  chainId: { equals: cursorObj.chainId },
+                  chainId: { equals: cursorObj.chainId.toString() },
                   blockNumber: { gt: cursorObj.blockNumber },
                   transactionIndex: { gt: cursorObj.transactionIndex },
                 },

--- a/src/prisma/migrations/20241106225714_all_chain_ids_to_string/migration.sql
+++ b/src/prisma/migrations/20241106225714_all_chain_ids_to_string/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The primary key for the `chain_indexers` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- AlterTable
+ALTER TABLE "chain_indexers" DROP CONSTRAINT "chain_indexers_pkey",
+ALTER COLUMN "chainId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "chain_indexers_pkey" PRIMARY KEY ("chainId");
+
+-- AlterTable
+ALTER TABLE "contract_event_logs" ALTER COLUMN "chainId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "contract_transaction_receipts" ALTER COLUMN "chainId" SET DATA TYPE TEXT;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -222,7 +222,7 @@ model ContractSubscriptions {
 }
 
 model ContractEventLogs {
-  chainId          Int
+  chainId          String
   blockNumber      Int
   contractAddress  String
   transactionHash  String
@@ -251,7 +251,7 @@ model ContractEventLogs {
 }
 
 model ContractTransactionReceipts {
-  chainId         Int
+  chainId         String
   blockNumber     Int
   contractAddress String
   contractId      String // ${chainId}:${contractAddress}
@@ -280,7 +280,7 @@ model ContractTransactionReceipts {
 }
 
 model ChainIndexers {
-  chainId          Int @id
+  chainId          String @id
   lastIndexedBlock Int
 
   createdAt DateTime @default(now())

--- a/src/server/routes/contract/events/getContractEventLogs.ts
+++ b/src/server/routes/contract/events/getContractEventLogs.ts
@@ -1,5 +1,5 @@
-import { Static, Type } from "@sinclair/typebox";
-import { FastifyInstance } from "fastify";
+import { Type, type Static } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContractEventLogsByBlockAndTopics } from "../../../../db/contractEventLogs/getContractEventLogs";
 import { isContractSubscribed } from "../../../../db/contractSubscriptions/getContractSubscriptions";
@@ -152,7 +152,7 @@ export async function getContractEventLogs(fastify: FastifyInstance) {
         });
 
         return {
-          chainId: log.chainId,
+          chainId: Number.parseInt(log.chainId),
           contractAddress: log.contractAddress,
           blockNumber: log.blockNumber,
           transactionHash: log.transactionHash,

--- a/src/server/routes/contract/events/getEventLogsByTimestamp.ts
+++ b/src/server/routes/contract/events/getEventLogsByTimestamp.ts
@@ -101,7 +101,7 @@ export async function getEventLogs(fastify: FastifyInstance) {
         });
 
         return {
-          chainId: log.chainId,
+          chainId: Number.parseInt(log.chainId),
           contractAddress: log.contractAddress,
           blockNumber: log.blockNumber,
           transactionHash: log.transactionHash,

--- a/src/server/routes/contract/transactions/getTransactionReceipts.ts
+++ b/src/server/routes/contract/transactions/getTransactionReceipts.ts
@@ -120,7 +120,7 @@ export async function getContractTransactionReceipts(fastify: FastifyInstance) {
 
       const transactionReceipts = resultTransactionReceipts.map((txRcpt) => {
         return {
-          chainId: txRcpt.chainId,
+          chainId: Number.parseInt(txRcpt.chainId),
           blockNumber: txRcpt.blockNumber,
           contractAddress: txRcpt.contractAddress,
           transactionHash: txRcpt.transactionHash,

--- a/src/server/routes/contract/transactions/getTransactionReceiptsByTimestamp.ts
+++ b/src/server/routes/contract/transactions/getTransactionReceiptsByTimestamp.ts
@@ -81,7 +81,7 @@ export async function getContractTransactionReceiptsByTimestamp(
 
       const transactionReceipts = resultTransactionReceipts.map((txRcpt) => {
         return {
-          chainId: txRcpt.chainId,
+          chainId: Number.parseInt(txRcpt.chainId),
           blockNumber: txRcpt.blockNumber,
           contractAddress: txRcpt.contractAddress,
           transactionHash: txRcpt.transactionHash,

--- a/src/server/schemas/eventLog.ts
+++ b/src/server/schemas/eventLog.ts
@@ -27,7 +27,7 @@ export const toEventLogSchema = (
   });
 
   return {
-    chainId: log.chainId,
+    chainId: Number.parseInt(log.chainId),
     contractAddress: log.contractAddress,
     blockNumber: log.blockNumber,
     transactionHash: log.transactionHash,

--- a/src/server/schemas/transactionReceipt.ts
+++ b/src/server/schemas/transactionReceipt.ts
@@ -24,7 +24,7 @@ export const transactionReceiptSchema = Type.Object({
 export const toTransactionReceiptSchema = (
   transactionReceipt: ContractTransactionReceipts,
 ): Static<typeof transactionReceiptSchema> => ({
-  chainId: transactionReceipt.chainId,
+  chainId: Number.parseInt(transactionReceipt.chainId),
   blockNumber: transactionReceipt.blockNumber,
   contractAddress: transactionReceipt.contractAddress,
   transactionHash: transactionReceipt.transactionHash,

--- a/src/worker/tasks/processEventLogsWorker.ts
+++ b/src/worker/tasks/processEventLogsWorker.ts
@@ -173,7 +173,7 @@ const getLogs = async ({
   return await Promise.all(
     allLogs.map(
       async (log): Promise<Prisma.ContractEventLogsCreateInput> => ({
-        chainId,
+        chainId: chainId.toString(),
         blockNumber: Number(log.blockNumber),
         contractAddress: normalizeAddress(log.address),
         transactionHash: log.transactionHash,

--- a/src/worker/tasks/processTransactionReceiptsWorker.ts
+++ b/src/worker/tasks/processTransactionReceiptsWorker.ts
@@ -178,7 +178,7 @@ const getFormattedTransactionReceipts = async ({
       });
 
       receipts.push({
-        chainId,
+        chainId: chainId.toString(),
         blockNumber: Number(receipt.blockNumber),
         contractAddress: toAddress,
         contractId: getContractId(chainId, toAddress),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on changing the data type of `chainId` from `Int` to `String` across various models and functions, ensuring consistent handling of `chainId` as a string throughout the codebase.

### Detailed summary
- Updated `chainId` to `String` in `ContractEventLogs`, `ContractTransactionReceipts`, and `ChainIndexers` models.
- Changed `chainId` handling to `toString()` in multiple queries and functions.
- Parsed `chainId` as `Number.parseInt()` where necessary.
- Modified SQL migration to alter `chainId` data type to `TEXT`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->