### PR TITLE
fix: Handle undefined nonce in transaction status

### DIFF
--- a/src/server/schemas/transaction/index.ts
+++ b/src/server/schemas/transaction/index.ts
@@ -292,7 +292,10 @@ export const toTransactionSchema = (
     toAddress: transaction.to ?? null,
     data: transaction.data ?? null,
     value: transaction.value.toString(),
-    nonce: "nonce" in transaction ? transaction.nonce : null,
+    nonce:
+      "nonce" in transaction && transaction.nonce !== undefined
+        ? transaction.nonce
+        : null,
     deployedContractAddress: transaction.deployedContractAddress ?? null,
     deployedContractType: transaction.deployedContractType ?? null,
     functionName: transaction.functionName ?? null,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the handling of the `nonce` property in the `transaction` object to ensure it is only assigned when it is explicitly defined.

### Detailed summary
- Changed the assignment of `nonce` to check if `"nonce"` exists in `transaction` and if it is not `undefined`.
- If both conditions are met, `nonce` is assigned from `transaction.nonce`; otherwise, it defaults to `null`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->