### PR TITLE
fix: return 400 error on invalid args passed to read endpoint

### DIFF
--- a/src/server/routes/contract/read/read.ts
+++ b/src/server/routes/contract/read/read.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "../../../../utils/cache/getContract";
+import { prettifyError } from "../../../../utils/error";
 import { createCustomError } from "../../../middleware/error";
 import {
   readRequestQuerySchema,
@@ -64,22 +65,16 @@ export async function readContract(fastify: FastifyInstance) {
       });
 
       let returnData: unknown;
-
       try {
         returnData = await contract.call(functionName, parsedArgs ?? []);
       } catch (e) {
-        if (
-          e instanceof Error &&
-          (e.message.includes("is not a function") ||
-            e.message.includes("arguments, but"))
-        ) {
-          throw createCustomError(
-            e.message,
-            StatusCodes.BAD_REQUEST,
-            "BAD_REQUEST",
-          );
-        }
+        throw createCustomError(
+          prettifyError(e),
+          StatusCodes.BAD_REQUEST,
+          "BAD_REQUEST",
+        );
       }
+
       returnData = bigNumberReplacer(returnData);
 
       reply.status(StatusCodes.OK).send({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling in the `readContract` function by utilizing the `prettifyError` utility for better error messages when exceptions occur.

### Detailed summary
- Added import for `prettifyError` from `../../../../utils/error`.
- Replaced the previous error handling logic with a call to `prettifyError(e)` within the `createCustomError` function, enhancing the clarity of error messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->