### PR TITLE
add another error phrase for nonce too low

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -16,9 +16,14 @@ const _parseMessage = (error: unknown): string | null => {
 
 export const isNonceAlreadyUsedError = (error: unknown) => {
   const message = _parseMessage(error);
+  const errorPhrases = ["nonce too low", "already known"];
+
   if (message) {
-    return message.includes("nonce too low");
+    return errorPhrases.some((phrase) =>
+      message.toLowerCase().includes(phrase),
+    );
   }
+
   return isEthersErrorCode(error, ethers.errors.NONCE_EXPIRED);
 };
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `isNonceAlreadyUsedError` function in `src/utils/error.ts` to enhance its error handling by checking for multiple phrases related to nonce errors.

### Detailed summary
- Introduced a new constant `errorPhrases` containing "nonce too low" and "already known".
- Replaced the previous check for "nonce too low" with a check that uses `some()` to see if `message` includes any of the phrases in `errorPhrases`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->