### PR TITLE
fix getWalletDetails to fallback awsKmsAccessKeyId instead of awsKmsKeyId

### DIFF
--- a/src/db/wallets/getWalletDetails.ts
+++ b/src/db/wallets/getWalletDetails.ts
@@ -175,7 +175,7 @@ export const getWalletDetails = async ({
       ? decrypt(walletDetails.awsKmsSecretAccessKey, env.ENCRYPTION_PASSWORD)
       : (config.walletConfiguration.aws?.awsSecretAccessKey ?? null);
 
-    walletDetails.awsKmsKeyId =
+    walletDetails.awsKmsAccessKeyId =
       walletDetails.awsKmsAccessKeyId ??
       config.walletConfiguration.aws?.awsAccessKeyId ??
       null;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on renaming a property in the `walletDetails` object from `awsKmsKeyId` to `awsKmsAccessKeyId`, ensuring consistency in naming conventions related to AWS credentials.

### Detailed summary
- Changed the property `walletDetails.awsKmsKeyId` to `walletDetails.awsKmsAccessKeyId`.
- Updated the assignment for `walletDetails.awsKmsAccessKeyId` to include a fallback to `config.walletConfiguration.aws?.awsAccessKeyId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->