### PR TITLE
fix: return 400 if transaction logs not found

### DIFF
--- a/src/server/routes/transaction/blockchain/getLogs.ts
+++ b/src/server/routes/transaction/blockchain/getLogs.ts
@@ -12,6 +12,7 @@ import {
   type Hex,
 } from "thirdweb";
 import { resolveContractAbi } from "thirdweb/contract";
+import { TransactionReceipt } from "thirdweb/transaction";
 import { TransactionDB } from "../../../../db/transactions/db";
 import { getChain } from "../../../../utils/chain";
 import { thirdwebClient } from "../../../../utils/sdk";
@@ -168,12 +169,14 @@ export async function getTransactionLogs(fastify: FastifyInstance) {
       }
 
       // Try to get the receipt.
-      const transactionReceipt = await eth_getTransactionReceipt(rpcRequest, {
-        hash,
-      });
-      if (!transactionReceipt) {
+      let transactionReceipt: TransactionReceipt | undefined;
+      try {
+        transactionReceipt = await eth_getTransactionReceipt(rpcRequest, {
+          hash,
+        });
+      } catch {
         throw createCustomError(
-          "Cannot get logs for a transaction that is not mined.",
+          "Unable to get transaction receipt. The transaction may not have been mined yet.",
           StatusCodes.BAD_REQUEST,
           "TRANSACTION_NOT_MINED",
         );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances error handling in the `getTransactionLogs` function by introducing a `try-catch` block for fetching the transaction receipt. It also updates the error message for clarity when a transaction has not been mined.

### Detailed summary
- Added import of `TransactionReceipt` from `thirdweb/transaction`.
- Changed the declaration of `transactionReceipt` to include `TransactionReceipt | undefined`.
- Wrapped the receipt fetching logic in a `try-catch` block.
- Updated the error message to "Unable to get transaction receipt. The transaction may not have been mined yet."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->