### PR TITLE
fix: remove extra route causing build error

### DIFF
--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -131,7 +131,6 @@ export async function withRoutes(fastify: FastifyInstance) {
   await fastify.register(getTransactionsForBackendWalletByNonce);
   await fastify.register(resetBackendWalletNoncesRoute);
   await fastify.register(cancelBackendWalletNoncesRoute);
-  await fastify.register(resetBackendWalletNoncesRoute);
   await fastify.register(getBackendWalletNonce);
   await fastify.register(simulateTransaction);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on the registration of routes in the `src/server/routes/index.ts` file, specifically addressing the registration of `resetBackendWalletNoncesRoute`.

### Detailed summary
- Removed duplicate registration of `resetBackendWalletNoncesRoute`.
- Kept the registrations for `cancelBackendWalletNoncesRoute`, `getBackendWalletNonce`, and `simulateTransaction`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->