### PR TITLE
fix: Correct missing scripts folder after folder reorganization

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "eslint --fix 'src/**/*.ts'",
     "test:unit": "vitest",
     "test:coverage": "vitest run --coverage",
-    "copy-files": "cp -r ./src/prisma ./dist/"
+    "copy-files": "cp -r ./src/prisma ./dist/ && cp -r ./scripts ./dist/"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.679.0",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `package.json` file to enhance the `copy-files` script, allowing it to copy both the `prisma` directory and the `scripts` directory to the `dist` folder.

### Detailed summary
- Modified the `copy-files` script:
  - Added `&& cp -r ./scripts ./dist/` to copy the `scripts` directory in addition to the existing `prisma` directory.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->