### PR TITLE
feat(experimental): configure mine worker timeout

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -98,6 +98,14 @@ export const env = createEnv({
     QUEUE_FAIL_HISTORY_COUNT: z.coerce.number().default(10_000),
     // Sets the number of recent nonces to map to queue IDs.
     NONCE_MAP_COUNT: z.coerce.number().default(10_000),
+
+    /**
+     * Experimental env vars. These may be renamed or removed in future non-major releases.
+     */
+    // Sets how long the mine worker waits for a transaction receipt before considering the transaction dropped (default: 30 minutes).
+    EXPERIMENTAL__MINE_WORKER_TIMEOUT_SECONDS: z.coerce
+      .number()
+      .default(30 * 60),
   },
   clientPrefix: "NEVER_USED",
   client: {},
@@ -134,6 +142,8 @@ export const env = createEnv({
     QUEUE_COMPLETE_HISTORY_COUNT: process.env.QUEUE_COMPLETE_HISTORY_COUNT,
     QUEUE_FAIL_HISTORY_COUNT: process.env.QUEUE_FAIL_HISTORY_COUNT,
     NONCE_MAP_COUNT: process.env.NONCE_MAP_COUNT,
+    EXPERIMENTAL__MINE_WORKER_TIMEOUT_SECONDS:
+      process.env.EXPERIMENTAL__MINE_WORKER_TIMEOUT_SECONDS,
     METRICS_PORT: process.env.METRICS_PORT,
     METRICS_ENABLED: process.env.METRICS_ENABLED,
   },

--- a/src/worker/queues/mineTransactionQueue.ts
+++ b/src/worker/queues/mineTransactionQueue.ts
@@ -1,11 +1,15 @@
 import { Queue } from "bullmq";
 import superjson from "superjson";
+import { env } from "../../utils/env";
 import { redis } from "../../utils/redis/redis";
 import { defaultJobOptions } from "./queues";
 
 export type MineTransactionData = {
   queueId: string;
 };
+
+// Attempts are made every ~20 seconds. See backoffStrategy in initMineTransactionWorker().
+const NUM_ATTEMPTS = env.EXPERIMENTAL__MINE_WORKER_TIMEOUT_SECONDS / 20;
 
 export class MineTransactionQueue {
   static q = new Queue<string>("transactions-2-mine", {
@@ -23,7 +27,7 @@ export class MineTransactionQueue {
     const jobId = this.jobId(data);
     await this.q.add(jobId, serialized, {
       jobId,
-      attempts: 100, // > 30 minutes with the backoffStrategy defined on the worker
+      attempts: NUM_ATTEMPTS,
       backoff: { type: "custom" },
     });
   };

--- a/src/worker/tasks/mineTransactionWorker.ts
+++ b/src/worker/tasks/mineTransactionWorker.ts
@@ -162,8 +162,9 @@ const _mineTransaction = async (
   }
 
   // Else the transaction is not mined yet.
+  const ellapsedMs = Date.now() - sentTransaction.queuedAt.getTime();
   job.log(
-    `Transaction is not mined yet. Check again later. sentTransactionHashes=${sentTransaction.sentTransactionHashes}`,
+    `Transaction is not mined yet. Check again later. elapsed=${ellapsedMs / 1000}s`,
   );
 
   // Resend the transaction (after some initial delay).


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the transaction mining process by refining logging, adjusting retry attempts for transactions, and introducing an experimental environment variable to control the timeout for mining workers.

### Detailed summary
- Updated logging in `mineTransactionWorker.ts` to display elapsed time instead of transaction hashes.
- Introduced `NUM_ATTEMPTS` in `mineTransactionQueue.ts` to dynamically set retry attempts based on `EXPERIMENTAL__MINE_WORKER_TIMEOUT_SECONDS`.
- Added documentation for `EXPERIMENTAL__MINE_WORKER_TIMEOUT_SECONDS` in `env.ts` to clarify its purpose.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->