### PR TITLE
chore: Update ERC721 mint-to to v5

### DIFF
--- a/src/server/routes/contract/extensions/erc721/write/mintTo.ts
+++ b/src/server/routes/contract/extensions/erc721/write/mintTo.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "thirdweb";
 import { mintTo } from "thirdweb/extensions/erc721";
-import { NFTInput } from "thirdweb/utils";
+import type { NFTInput } from "thirdweb/utils";
 import { getChain } from "../../../../../../utils/chain";
 import { thirdwebClient } from "../../../../../../utils/sdk";
 import { queueTransaction } from "../../../../../../utils/transaction/queueTransation";
@@ -94,15 +94,15 @@ export async function erc721mintTo(fastify: FastifyInstance) {
       const nft: NFTInput | string =
         typeof metadata === "string"
           ? metadata
-          : {
-              name: metadata.name,
-              description: metadata.description,
-              image: metadata.image,
-              animation_url: metadata.animation_url,
-              external_url: metadata.external_url,
-              background_color: metadata.background_color,
+          : ({
+              name: metadata.name?.toString() ?? undefined,
+              description: metadata.description ?? undefined,
+              image: metadata.image ?? undefined,
+              animation_url: metadata.animation_url ?? undefined,
+              external_url: metadata.external_url ?? undefined,
+              background_color: metadata.background_color ?? undefined,
               properties: metadata.properties,
-            };
+            } satisfies NFTInput);
       const transaction = mintTo({
         contract,
         to: receiver,

--- a/src/server/routes/contract/extensions/erc721/write/mintTo.ts
+++ b/src/server/routes/contract/extensions/erc721/write/mintTo.ts
@@ -89,12 +89,11 @@ export async function erc721mintTo(fastify: FastifyInstance) {
         address: contractAddress,
       });
 
-      // Backward compatibility: This endpoint body uses the v4 SDK shape.
-      // Transform to v5 SDK shape to use the v5 endpoint.
+      // Backward compatibility: Transform the request body's v4 shape to v5.
       const nft: NFTInput | string =
         typeof metadata === "string"
           ? metadata
-          : ({
+          : {
               name: metadata.name?.toString() ?? undefined,
               description: metadata.description ?? undefined,
               image: metadata.image ?? undefined,
@@ -102,7 +101,7 @@ export async function erc721mintTo(fastify: FastifyInstance) {
               external_url: metadata.external_url ?? undefined,
               background_color: metadata.background_color ?? undefined,
               properties: metadata.properties,
-            } satisfies NFTInput);
+            };
       const transaction = mintTo({
         contract,
         to: receiver,

--- a/src/server/routes/contract/extensions/erc721/write/mintTo.ts
+++ b/src/server/routes/contract/extensions/erc721/write/mintTo.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "thirdweb";
 import { mintTo } from "thirdweb/extensions/erc721";
+import { NFTInput } from "thirdweb/utils";
 import { getChain } from "../../../../../../utils/chain";
 import { thirdwebClient } from "../../../../../../utils/sdk";
 import { queueTransaction } from "../../../../../../utils/transaction/queueTransation";
@@ -88,10 +89,24 @@ export async function erc721mintTo(fastify: FastifyInstance) {
         address: contractAddress,
       });
 
+      // Backward compatibility: This endpoint body uses the v4 SDK shape.
+      // Transform to v5 SDK shape to use the v5 endpoint.
+      const nft: NFTInput | string =
+        typeof metadata === "string"
+          ? metadata
+          : {
+              name: metadata.name,
+              description: metadata.description,
+              image: metadata.image,
+              animation_url: metadata.animation_url,
+              external_url: metadata.external_url,
+              background_color: metadata.background_color,
+              properties: metadata.properties,
+            };
       const transaction = mintTo({
         contract,
         to: receiver,
-        nft: typeof metadata === "string" ? metadata : { nft: metadata },
+        nft,
       });
 
       const queueId = await queueTransaction({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `erc721mintTo` function in the `mintTo.ts` file to integrate the `thirdweb` SDK for minting NFTs, enhancing the transaction handling and improving input validation.

### Detailed summary
- Replaced local `getContract` and `queueTx` imports with `thirdweb` SDK functions.
- Updated the transaction preparation to use `mintTo` from `thirdweb/extensions/erc721`.
- Added backward compatibility for metadata handling.
- Changed request header variable names for clarity.
- Improved input validation with `maybeAddress` and `requiredAddress` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->