### PR TITLE
chore: fix some typos in comment

### DIFF
--- a/src/server/routes/backend-wallet/import.ts
+++ b/src/server/routes/backend-wallet/import.ts
@@ -195,7 +195,7 @@ export const importBackendWallet = async (fastify: FastifyInstance) => {
         }
 
         // TODO: with next breaking change, only require GCP KMS resource path
-        // import endoint does not currently have resource path in the request body
+        // import endpoint does not currently have resource path in the request body
         // so we rely on the global configuration for these values
         if (
           !(

--- a/src/shared/db/wallets/create-wallet-details.ts
+++ b/src/shared/db/wallets/create-wallet-details.ts
@@ -15,7 +15,7 @@ type CreateWalletDetailsParams = {
     }
   | {
       type: "aws-kms";
-      awsKmsKeyId?: string; // depcrecated and unused, todo: remove with next breaking change
+      awsKmsKeyId?: string; // deprecated and unused, todo: remove with next breaking change
       awsKmsArn: string;
 
       awsKmsSecretAccessKey: string; // will be encrypted and stored, pass plaintext to this function
@@ -24,10 +24,10 @@ type CreateWalletDetailsParams = {
   | {
       type: "gcp-kms";
       gcpKmsResourcePath: string;
-      gcpKmsKeyRingId?: string; // depcrecated and unused, todo: remove with next breaking change
-      gcpKmsKeyId?: string; // depcrecated and unused, todo: remove with next breaking change
-      gcpKmsKeyVersionId?: string; // depcrecated and unused, todo: remove with next breaking change
-      gcpKmsLocationId?: string; // depcrecated and unused, todo: remove with next breaking change
+      gcpKmsKeyRingId?: string; // deprecated and unused, todo: remove with next breaking change
+      gcpKmsKeyId?: string; // deprecated and unused, todo: remove with next breaking change
+      gcpKmsKeyVersionId?: string; // deprecated and unused, todo: remove with next breaking change
+      gcpKmsLocationId?: string; // deprecated and unused, todo: remove with next breaking change
 
       gcpApplicationCredentialPrivateKey: string; // will be encrypted and stored, pass plaintext to this function
       gcpApplicationCredentialEmail: string;

--- a/src/shared/utils/transaction/queue-transation.ts
+++ b/src/shared/utils/transaction/queue-transation.ts
@@ -36,7 +36,7 @@ export type QueuedTransactionParams = {
  * Encodes a transaction to generate data, and inserts it into the transaction queue using the insertTransaction()
  *
  * Note:
- *  - functionName must be be provided to populate the functionName field in the queued transaction
+ *  - functionName must be provided to populate the functionName field in the queued transaction
  *  - value and chain details are resolved from the transaction
  */
 export async function queueTransaction(args: QueuedTransactionParams) {

--- a/src/worker/queues/send-transaction-queue.ts
+++ b/src/worker/queues/send-transaction-queue.ts
@@ -19,7 +19,7 @@ export class SendTransactionQueue {
     },
   });
 
-  // Allow enqueing the same queueId for multiple retries.
+  // Allow enqueuing the same queueId for multiple retries.
   static jobId = (data: SendTransactionData) =>
     `${data.queueId}.${data.resendCount}`;
 


### PR DESCRIPTION
## Changes

fix some typos in comment

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos in comments throughout the codebase, specifically in the `send-transaction-queue.ts`, `import.ts`, `queue-transaction.ts`, and `create-wallet-details.ts` files. 

### Detailed summary
- Corrected "enqueing" to "enqueuing" in `send-transaction-queue.ts`.
- Fixed "endoint" to "endpoint" in `import.ts`.
- Changed "depcrecated" to "deprecated" in `create-wallet-details.ts` for several comments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->