### PR TITLE
[TOOL-2900]: Fix metadata.attributes being ignored

### DIFF
--- a/src/server/routes/contract/extensions/erc1155/write/mint-to.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/mint-to.ts
@@ -1,4 +1,4 @@
-import { Type, type Static } from "@sinclair/typebox";
+import { type Static, Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "thirdweb";
@@ -105,7 +105,7 @@ export async function erc1155mintTo(fastify: FastifyInstance) {
               animation_url: metadata.animation_url ?? undefined,
               external_url: metadata.external_url ?? undefined,
               background_color: metadata.background_color ?? undefined,
-              properties: metadata.properties,
+              properties: metadata.properties || metadata.attributes,
             };
       const transaction = mintTo({
         contract,

--- a/src/server/routes/contract/extensions/erc721/write/mint-to.ts
+++ b/src/server/routes/contract/extensions/erc721/write/mint-to.ts
@@ -1,4 +1,4 @@
-import { Type, type Static } from "@sinclair/typebox";
+import { type Static, Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { getContract } from "thirdweb";
@@ -100,7 +100,7 @@ export async function erc721mintTo(fastify: FastifyInstance) {
               animation_url: metadata.animation_url ?? undefined,
               external_url: metadata.external_url ?? undefined,
               background_color: metadata.background_color ?? undefined,
-              properties: metadata.properties,
+              properties: metadata.properties || metadata.attributes,
             };
       const transaction = mintTo({
         contract,


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `erc721mintTo` and `erc1155mintTo` functions to modify how `properties` are assigned from `metadata`. It introduces a fallback to use `metadata.attributes` if `metadata.properties` is not available.

### Detailed summary
- In `src/server/routes/contract/extensions/erc721/write/mint-to.ts`:
  - Changed `properties: metadata.properties` to `properties: metadata.properties || metadata.attributes`.
  
- In `src/server/routes/contract/extensions/erc1155/write/mint-to.ts`:
  - Changed `properties: metadata.properties` to `properties: metadata.properties || metadata.attributes`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->