### PR TITLE
fix: Reduce log line for nonceResyncWorker

### DIFF
--- a/src/worker/tasks/nonce-resync-worker.ts
+++ b/src/worker/tasks/nonce-resync-worker.ts
@@ -75,7 +75,7 @@ const handler: Processor<string, void, string> = async (job: Job<string>) => {
         }
       }
 
-      const message = `wallet=${chainId}:${walletAddress} lastUsedNonceOnchain=${lastUsedNonceOnchain} lastUsedNonceDb=${lastUsedNonceDb}, recycled=${recycled.join(",")}`;
+      const message = `wallet=${chainId}:${walletAddress} lastUsedNonceOnchain=${lastUsedNonceOnchain} lastUsedNonceDb=${lastUsedNonceDb} numRecycled=${recycled.length} (min=${recycled.at(0) ?? "N/A"} max=${recycled.at(-1) ?? "N/A"})`;
       job.log(message);
       logger({ level: "debug", service: "worker", message });
     } catch (error) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the logging message in the `nonce-resync-worker.ts` file to provide more detailed information about the recycled nonces.

### Detailed summary
- Modified the `message` string to include:
  - The count of recycled nonces using `recycled.length`
  - The minimum recycled nonce using `recycled.at(0) ?? "N/A"`
  - The maximum recycled nonce using `recycled.at(-1) ?? "N/A"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->