### PR TITLE
fix: Await chain check for sponsored EOA transactions support

### DIFF
--- a/src/shared/utils/transaction/simulate-queued-transaction.ts
+++ b/src/shared/utils/transaction/simulate-queued-transaction.ts
@@ -64,7 +64,7 @@ export const doSimulateTransaction = async (
     });
 
     if (transaction.transactionMode === "sponsored") {
-      if (!isZkSyncChain(chain)) {
+      if (!(await isZkSyncChain(chain))) {
         throw new Error(
           "Sponsored EOA transactions are only supported on zkSync chains.",
         );

--- a/src/worker/tasks/send-transaction-worker.ts
+++ b/src/worker/tasks/send-transaction-worker.ts
@@ -290,7 +290,7 @@ const _sendTransaction = async (
   let account: Account;
 
   if (queuedTransaction.transactionMode === "sponsored") {
-    if (!isZkSyncChain(chain)) {
+    if (!(await isZkSyncChain(chain))) {
       job.log(
         "Sponsored EOA transactions are only supported on zkSync chains.",
       );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the checks for `sponsored` transactions to ensure that the `isZkSyncChain` function is awaited, improving the accuracy of the validation for these transactions.

### Detailed summary
- In `src/worker/tasks/send-transaction-worker.ts`, changed the check for `isZkSyncChain(chain)` to await the promise.
- In `src/shared/utils/transaction/simulate-queued-transaction.ts`, similarly updated the check for `isZkSyncChain(chain)` to await the promise.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->