### PR TITLE
[SDK] fix: Separate properties and attributes in NFTInput

### DIFF
--- a/src/server/routes/contract/extensions/erc1155/write/mint-to.ts
+++ b/src/server/routes/contract/extensions/erc1155/write/mint-to.ts
@@ -106,7 +106,8 @@ export async function erc1155mintTo(fastify: FastifyInstance) {
               animation_url: metadata.animation_url ?? undefined,
               external_url: metadata.external_url ?? undefined,
               background_color: metadata.background_color ?? undefined,
-              properties: metadata.properties || metadata.attributes,
+              properties: metadata.properties ?? undefined,
+              attributes: metadata.attributes ?? undefined,
             };
       const transaction = mintTo({
         contract,

--- a/src/server/routes/contract/extensions/erc721/write/mint-to.ts
+++ b/src/server/routes/contract/extensions/erc721/write/mint-to.ts
@@ -101,7 +101,8 @@ export async function erc721mintTo(fastify: FastifyInstance) {
               animation_url: metadata.animation_url ?? undefined,
               external_url: metadata.external_url ?? undefined,
               background_color: metadata.background_color ?? undefined,
-              properties: metadata.properties || metadata.attributes,
+              properties: metadata.properties ?? undefined,
+              attributes: metadata.attributes ?? undefined,
             };
       const transaction = mintTo({
         contract,


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- In the existing metadata transformation logic, properties and attributes were treated interchangeably (properties: metadata.properties || metadata.attributes). However, these fields serve different purposes and should be handled separately to avoid potential data conflicts and maintain clarity.
- Updated the logic to explicitly set properties and attributes as independent fields in the NFT metadata transformation.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of `properties` and `attributes` in the `mint-to.ts` files for both `erc721` and `erc1155` contracts. The changes ensure that `properties` and `attributes` are set to `undefined` if they are not present in the `metadata`.

### Detailed summary
- Changed `properties` assignment from `metadata.properties || metadata.attributes` to `metadata.properties ?? undefined`.
- Added `attributes` assignment with `metadata.attributes ?? undefined` in both `erc721` and `erc1155` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->