### PR TITLE
fix: signTransaction updated to work with latest v5 SDK

### DIFF
--- a/src/server/routes/backend-wallet/sign-transaction.ts
+++ b/src/server/routes/backend-wallet/sign-transaction.ts
@@ -5,6 +5,7 @@ import { getAccount } from "../../../shared/utils/account";
 import {
   getChecksumAddress,
   maybeBigInt,
+  maybeInt,
 } from "../../../shared/utils/primitive-types";
 import { thirdwebClient } from "../../../shared/utils/sdk";
 import { createCustomError } from "../../middleware/error";
@@ -82,7 +83,7 @@ export async function signTransaction(fastify: FastifyInstance) {
         ...transaction,
         data: transaction.data as Hex | undefined,
         client: thirdwebClient,
-        nonce: nonce ? Number.parseInt(nonce) : undefined,
+        nonce: maybeInt(nonce),
         chain,
         value: maybeBigInt(transaction.value),
         gas: maybeBigInt(transaction.gasLimit),

--- a/src/server/routes/backend-wallet/sign-transaction.ts
+++ b/src/server/routes/backend-wallet/sign-transaction.ts
@@ -5,13 +5,17 @@ import { getAccount } from "../../../shared/utils/account";
 import {
   getChecksumAddress,
   maybeBigInt,
-  maybeInt,
 } from "../../../shared/utils/primitive-types";
-import { toTransactionType } from "../../../shared/utils/sdk";
+import { thirdwebClient } from "../../../shared/utils/sdk";
 import { createCustomError } from "../../middleware/error";
 import { standardResponseSchema } from "../../schemas/shared-api-schemas";
 import { walletHeaderSchema } from "../../schemas/wallet";
-import type { Hex } from "thirdweb";
+import {
+  prepareTransaction,
+  toSerializableTransaction,
+  type Hex,
+} from "thirdweb";
+import { getChain } from "../../../shared/utils/chain";
 
 const requestBodySchema = Type.Object({
   transaction: Type.Object({
@@ -21,7 +25,7 @@ const requestBodySchema = Type.Object({
     gasPrice: Type.Optional(Type.String()),
     data: Type.Optional(Type.String()),
     value: Type.Optional(Type.String()),
-    chainId: Type.Optional(Type.Integer()),
+    chainId: Type.Integer(),
     type: Type.Optional(Type.Integer()),
     accessList: Type.Optional(Type.Any()),
     maxFeePerGas: Type.Optional(Type.String()),
@@ -54,14 +58,17 @@ export async function signTransaction(fastify: FastifyInstance) {
       },
     },
     handler: async (request, reply) => {
-      const { transaction } = request.body;
       const { "x-backend-wallet-address": walletAddress } =
         request.headers as Static<typeof walletHeaderSchema>;
 
+      const { chainId, nonce, ...transaction } = request.body.transaction;
+      const chain = await getChain(chainId);
+
       const account = await getAccount({
-        chainId: 1,
+        chainId,
         from: getChecksumAddress(walletAddress),
       });
+
       if (!account.signTransaction) {
         throw createCustomError(
           'This backend wallet does not support "signTransaction".',
@@ -70,22 +77,24 @@ export async function signTransaction(fastify: FastifyInstance) {
         );
       }
 
-      const serializableTransaction = {
-        chainId: transaction.chainId,
-        to: getChecksumAddress(transaction.to),
-        nonce: maybeInt(transaction.nonce),
+      // const prepareTransactionOptions: StaticPrepareTransactionOptions
+      const prepareTransactionOptions = {
+        ...transaction,
+        data: transaction.data as Hex | undefined,
+        client: thirdwebClient,
+        nonce: nonce ? Number.parseInt(nonce) : undefined,
+        chain,
+        value: maybeBigInt(transaction.value),
         gas: maybeBigInt(transaction.gasLimit),
         gasPrice: maybeBigInt(transaction.gasPrice),
-        data: transaction.data as Hex | undefined,
-        value: maybeBigInt(transaction.value),
-        type: transaction.type
-          ? toTransactionType(transaction.type)
-          : undefined,
-        accessList: transaction.accessList,
         maxFeePerGas: maybeBigInt(transaction.maxFeePerGas),
         maxPriorityFeePerGas: maybeBigInt(transaction.maxPriorityFeePerGas),
-        ccipReadEnabled: transaction.ccipReadEnabled,
       };
+
+      const preparedTransaction = prepareTransaction(prepareTransactionOptions);
+      const serializableTransaction = await toSerializableTransaction({
+        transaction: preparedTransaction,
+      });
 
       const signature = await account.signTransaction(serializableTransaction);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `sign-transaction` functionality by incorporating the `thirdwebClient`, updating the transaction handling logic, and utilizing the `prepareTransaction` and `toSerializableTransaction` methods for improved transaction preparation and serialization.

### Detailed summary
- Replaced `toTransactionType` import with `thirdwebClient`.
- Added imports for `prepareTransaction`, `toSerializableTransaction`, and `getChain`.
- Updated `chainId` definition to be of type `Integer`.
- Modified request handling to destructure `chainId`, `nonce`, and `transaction`.
- Introduced `chain` variable using `getChain`.
- Updated `account` retrieval to use dynamic `chainId`.
- Created `prepareTransactionOptions` object with updated transaction handling.
- Used `prepareTransaction` and `toSerializableTransaction` for transaction preparation and serialization.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->