### PR TITLE
chore: bump version to 0.0.18 in package.json for @thirdweb-dev/engine

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thirdweb-dev/engine",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "dist/thirdweb-dev-engine.cjs.js",
   "module": "dist/thirdweb-dev-engine.esm.js",
   "files": [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the package `@thirdweb-dev/engine` in the `sdk/package.json` file from `0.0.17` to `0.0.18`.

### Detailed summary
- Updated the `version` field of `@thirdweb-dev/engine` from `0.0.17` to `0.0.18` in `sdk/package.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->