### PR TITLE
fix: /reset-nonces endpoint allows deleting nonce state without resyncing

### DIFF
--- a/src/server/routes/backend-wallet/reset-nonces.ts
+++ b/src/server/routes/backend-wallet/reset-nonces.ts
@@ -21,8 +21,9 @@ const requestBodySchema = Type.Object({
     description:
       "The backend wallet address to reset nonces for. Omit to reset all backend wallets.",
   }),
-  resetOnchainNonce: Type.Boolean({
-    description: "Resets the nonce to the onchain value. (Default: true)",
+  syncOnchainNonces: Type.Boolean({
+    description:
+      "Resync nonces to match the onchain transaction count for your backend wallets. (Default: true)",
     default: true,
   }),
 });
@@ -68,7 +69,7 @@ export const resetBackendWalletNoncesRoute = async (
       const {
         chainId,
         walletAddress: _walletAddress,
-        resetOnchainNonce,
+        syncOnchainNonces,
       } = req.body;
 
       // If chain+wallet are provided, only process that wallet.
@@ -85,7 +86,7 @@ export const resetBackendWalletNoncesRoute = async (
         // Delete nonce state for these backend wallets.
         await deleteNoncesForBackendWallets(backendWallets);
 
-        if (resetOnchainNonce) {
+        if (syncOnchainNonces) {
           // Resync nonces for these backend wallets.
           await Promise.allSettled(
             batch.map(({ chainId, walletAddress }) =>

--- a/src/shared/db/wallets/wallet-nonce.ts
+++ b/src/shared/db/wallets/wallet-nonce.ts
@@ -10,6 +10,7 @@ import { normalizeAddress } from "../../utils/primitive-types";
 import { redis } from "../../utils/redis/redis";
 import { thirdwebClient } from "../../utils/sdk";
 import { updateNonceMap } from "./nonce-map";
+import { nonceHistoryKey } from "../../../worker/tasks/nonce-health-check-worker";
 
 /**
  * Get all used backend wallets.
@@ -45,7 +46,7 @@ export const getUsedBackendWallets = async (
 
 /**
  * The "last used nonce" stores the last nonce submitted onchain.
- * Example: "25"
+ * Example: 25 -> nonce 25 is onchain, nonce 26 is unused or inflight.
  */
 export const lastUsedNonceKey = (chainId: number, walletAddress: Address) =>
   `nonce:${chainId}:${normalizeAddress(walletAddress)}`;
@@ -260,6 +261,7 @@ export async function deleteNoncesForBackendWallets(
     lastUsedNonceKey(chainId, walletAddress),
     recycledNoncesKey(chainId, walletAddress),
     sentNoncesKey(chainId, walletAddress),
+    nonceHistoryKey(chainId, walletAddress),
   ]);
   await redis.del(keys);
 }

--- a/src/worker/tasks/nonce-health-check-worker.ts
+++ b/src/worker/tasks/nonce-health-check-worker.ts
@@ -116,7 +116,10 @@ async function getCurrentNonceState(
   };
 }
 
-function nonceHistoryKey(walletAddress: Address, chainId: number) {
+/**
+ * Stores a list of onchain vs sent nonces to check if the nonce is stuck over time.
+ */
+export function nonceHistoryKey(chainId: number, walletAddress: Address) {
   return `nonce-history:${chainId}:${getAddress(walletAddress)}`;
 }
 
@@ -128,7 +131,7 @@ async function getHistoricalNonceStates(
   chainId: number,
   periods: number,
 ): Promise<NonceState[]> {
-  const key = nonceHistoryKey(walletAddress, chainId);
+  const key = nonceHistoryKey(chainId, walletAddress);
   const historicalStates = await redis.lrange(key, 0, periods - 1);
   return historicalStates.map((state) => JSON.parse(state));
 }
@@ -136,7 +139,7 @@ async function getHistoricalNonceStates(
 // Update nonce history
 async function updateNonceHistory(walletAddress: Address, chainId: number) {
   const currentState = await getCurrentNonceState(walletAddress, chainId);
-  const key = nonceHistoryKey(walletAddress, chainId);
+  const key = nonceHistoryKey(chainId, walletAddress);
 
   await redis
     .multi()


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces enhancements to nonce management in the wallet system, including the addition of a nonce history tracking feature and adjustments to the backend wallet nonce reset functionality.

### Detailed summary
- Added `nonceHistoryKey` function to track onchain vs sent nonces.
- Updated `deleteNoncesForBackendWallets` to include nonce history key.
- Modified `resetBackendWalletNoncesRoute` to include `syncOnchainNonces` parameter.
- Changed variable name `RESYNC_BATCH_SIZE` to `BATCH_SIZE`.
- Conditional resync of nonces based on `syncOnchainNonces` flag.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->