### PR TITLE
remove check for AA support on chain (to support stealth chains)

### DIFF
--- a/src/shared/utils/transaction/insert-transaction.ts
+++ b/src/shared/utils/transaction/insert-transaction.ts
@@ -82,19 +82,6 @@ export const insertTransaction = async (
         );
       }
 
-      if (
-        !(await doesChainSupportService(
-          queuedTransaction.chainId,
-          "account-abstraction",
-        ))
-      ) {
-        throw createCustomError(
-          "Chain does not support smart backend wallets",
-          StatusCodes.BAD_REQUEST,
-          "SBW_CHAIN_NOT_SUPPORTED",
-        );
-      }
-
       queuedTransaction = {
         ...queuedTransaction,
         isUserOp: true,
@@ -124,19 +111,6 @@ export const insertTransaction = async (
       // entrypointAddress is not set
       // accountFactoryAddress is not set
       if (walletDetails && isSmartBackendWallet(walletDetails)) {
-        if (
-          !(await doesChainSupportService(
-            queuedTransaction.chainId,
-            "account-abstraction",
-          ))
-        ) {
-          throw createCustomError(
-            "Chain does not support smart backend wallets",
-            StatusCodes.BAD_REQUEST,
-            "SBW_CHAIN_NOT_SUPPORTED",
-          );
-        }
-
         queuedTransaction = {
           ...queuedTransaction,
           entrypointAddress: walletDetails.entrypointAddress ?? undefined,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on removing a check for chain support for smart backend wallets in the `insertTransaction` function, streamlining the transaction insertion process.

### Detailed summary
- Removed the conditional check that verifies if the chain supports the "account-abstraction" service.
- Eliminated the error throwing for unsupported chains regarding smart backend wallets.
- Updated the `queuedTransaction` object to set `isUserOp` to `true`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->