### PR TITLE
fix: handle blockTags for get-all-events

### DIFF
--- a/src/server/routes/contract/events/get-all-events.ts
+++ b/src/server/routes/contract/events/get-all-events.ts
@@ -13,9 +13,8 @@ import { thirdwebClient } from "../../../../shared/utils/sdk";
 import { getChain } from "../../../../shared/utils/chain";
 import { getChainIdFromChain } from "../../../utils/chain";
 import { getContract, getContractEvents } from "thirdweb";
-import { maybeBigInt } from "../../../../shared/utils/primitive-types";
 import {
-  ContractEventV5,
+  type ContractEventV5,
   toContractEventV4Schema,
 } from "../../../schemas/event";
 import { createCustomError } from "../../../middleware/error";

--- a/src/server/schemas/contract/index.ts
+++ b/src/server/schemas/contract/index.ts
@@ -79,18 +79,25 @@ export const rolesResponseSchema = Type.Object({
   signer: Type.Array(Type.String()),
 });
 
+export const blockNumberOrTagSchema = Type.Union([
+  Type.Integer({ minimum: 0 }),
+  Type.Literal("latest"),
+  Type.Literal("earliest"),
+  Type.Literal("pending"),
+  Type.Literal("safe"),
+  Type.Literal("finalized"),
+]);
+
 export const eventsQuerystringSchema = Type.Object(
   {
-    fromBlock: Type.Optional(
-      Type.Union([Type.Integer({ minimum: 0 }), Type.String()], {
-        default: "0",
-      }),
-    ),
-    toBlock: Type.Optional(
-      Type.Union([Type.Integer({ minimum: 0 }), Type.String()], {
-        default: "latest",
-      }),
-    ),
+    fromBlock: Type.Optional({
+      ...blockNumberOrTagSchema,
+      default: "0",
+    }),
+    toBlock: Type.Optional({
+      ...blockNumberOrTagSchema,
+      default: "latest",
+    }),
     order: Type.Optional(
       Type.Union([Type.Literal("asc"), Type.Literal("desc")], {
         default: "desc",

--- a/src/shared/utils/transaction/insert-transaction.ts
+++ b/src/shared/utils/transaction/insert-transaction.ts
@@ -7,7 +7,6 @@ import {
   WalletDetailsError,
   type ParsedWalletDetails,
 } from "../../../shared/db/wallets/get-wallet-details";
-import { doesChainSupportService } from "../../lib/chain/chain-capabilities";
 import { createCustomError } from "../../../server/middleware/error";
 import { SendTransactionQueue } from "../../../worker/queues/send-transaction-queue";
 import { getChecksumAddress } from "../primitive-types";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the schema validation for blockchain event queries and improving error handling in the event retrieval process.

### Detailed summary
- Added `blockNumberOrTagSchema` for validating block number or tag inputs.
- Updated `fromBlock` and `toBlock` in `eventsQuerystringSchema` to use the new schema.
- Improved error handling in `getAllEvents` function with custom error messages.
- Refactored `fromBlock` and `toBlock` to handle types more robustly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->