### PR TITLE
fix: typos in documentation files

### DIFF
--- a/src/server/routes/contract/transactions/get-transaction-receipts.ts
+++ b/src/server/routes/contract/transactions/get-transaction-receipts.ts
@@ -102,9 +102,9 @@ export async function getContractTransactionReceipts(fastify: FastifyInstance) {
       });
 
       if (!isSubscribed) {
-        const subcriptionUrl = `/contract/${chain}/${contractAddress}/subscribe`;
+        const subscriptionUrl = `/contract/${chain}/${contractAddress}/subscribe`;
         throw createCustomError(
-          `Contract is not subscribed to! To subscribe, please use ${subcriptionUrl}`,
+          `Contract is not subscribed to! To subscribe, please use ${subscriptionUrl}`,
           StatusCodes.NOT_FOUND,
           "NOT_FOUND",
         );

--- a/src/server/routes/transaction/get-all.ts
+++ b/src/server/routes/transaction/get-all.ts
@@ -13,7 +13,7 @@ const requestQuerySchema = Type.Object({
   ...PaginationSchema.properties,
   status: Type.Union(
     [
-      // Note: 'queued' returns all transcations, not just transactions currently queued.
+      // Note: 'queued' returns all transactions, not just transactions currently queued.
       Type.Literal("queued"),
       Type.Literal("mined"),
       Type.Literal("cancelled"),

--- a/src/server/utils/abi.ts
+++ b/src/server/utils/abi.ts
@@ -10,7 +10,7 @@ export function sanitizeAbi(abi: AbiSchemaType | undefined): Abi | undefined {
     if (item.type === "function") {
       return {
         ...item,
-        // older versions of engine allowed passing in empty inputs/outputs, but necesasry for abi validation
+        // older versions of engine allowed passing in empty inputs/outputs, but necessary for abi validation
         inputs: item.inputs || [],
         outputs: item.outputs || [],
       };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting spelling errors in comments and variable names across multiple files, enhancing code clarity and maintaining consistency.

### Detailed summary
- In `src/server/routes/transaction/get-all.ts`, corrected "transcations" to "transactions" in a comment.
- In `src/server/utils/abi.ts`, fixed "necesasry" to "necessary" in a comment.
- In `src/server/routes/contract/transactions/get-transaction-receipts.ts`:
  - Changed `subcriptionUrl` to `subscriptionUrl`.
  - Updated an error message to reflect the corrected variable name.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->