### PR TITLE
fix: update dashboard import URL

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -126,7 +126,7 @@ export const initServer = async () => {
     level: "info",
     message: `Engine server is listening on port ${
       env.PORT
-    }. Add to your dashboard: https://thirdweb.com/dashboard/engine?importUrl=${encodeURIComponent(
+    }. Add to your dashboard: https://thirdweb.com/team/~/~/engine/import?importUrl=${encodeURIComponent(
       url,
     )}.`,
   });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the URL in the message logged when the `Engine server` starts, changing it from the dashboard link to a team-specific link.

### Detailed summary
- Modified the message in `src/server/index.ts` to change the URL from `https://thirdweb.com/dashboard/engine?importUrl=${encodeURIComponent(url)}` 
- Updated it to `https://thirdweb.com/team/~/~/engine/import?importUrl=${encodeURIComponent(url)}`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->