### PR TITLE
fix non sbw flow for AA atomic transactions

### DIFF
--- a/src/server/routes/backend-wallet/send-transaction-batch-atomic.ts
+++ b/src/server/routes/backend-wallet/send-transaction-batch-atomic.ts
@@ -1,7 +1,7 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
-import type { Address, Hex } from "thirdweb";
+import { getAddress, type Address, type Hex } from "thirdweb";
 import { insertTransaction } from "../../../shared/utils/transaction/insert-transaction";
 import {
   requestQuerystringSchema,
@@ -29,7 +29,9 @@ const requestBodySchema = Type.Object({
   }),
 });
 
-export async function sendTransactionBatchAtomicRoute(fastify: FastifyInstance) {
+export async function sendTransactionBatchAtomicRoute(
+  fastify: FastifyInstance,
+) {
   fastify.route<{
     Params: Static<typeof walletChainParamSchema>;
     Body: Static<typeof requestBodySchema>;
@@ -113,8 +115,10 @@ export async function sendTransactionBatchAtomicRoute(fastify: FastifyInstance) 
 
       const queueId = await insertTransaction({
         insertedTransaction: {
+          ...(hasSmartHeaders
+            ? { isUserOp: true, signerAddress: getAddress(fromAddress) }
+            : { isUserOp: false }),
           transactionMode: undefined,
-          isUserOp: false,
           chainId,
           from: fromAddress as Address,
           accountAddress: maybeAddress(accountAddress, "x-account-address"),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `sendTransactionBatchAtomicRoute` function by improving type imports and modifying the structure of the transaction object being inserted, particularly in relation to user operations.

### Detailed summary
- Changed the import of `Address` and `Hex` from `thirdweb` to include `getAddress`.
- Modified the `sendTransactionBatchAtomicRoute` function signature to include a new line for better readability.
- Updated the inserted transaction structure to conditionally include `isUserOp` and `signerAddress` based on `hasSmartHeaders`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->