### PR TITLE
Support hex transaction types in fromTransactionType

### DIFF
--- a/src/shared/utils/sdk.ts
+++ b/src/shared/utils/sdk.ts
@@ -1,5 +1,5 @@
 import { sha256HexSync } from "@thirdweb-dev/crypto";
-import { createThirdwebClient } from "thirdweb";
+import { createThirdwebClient, hexToNumber, isHex } from "thirdweb";
 import type { TransactionReceipt } from "thirdweb/transaction";
 import { env } from "./env";
 
@@ -27,14 +27,6 @@ export const fromTransactionType = (type: TransactionReceipt["type"]) => {
   if (type === "eip2930") return 2;
   if (type === "eip4844") return 3;
   if (type === "eip7702") return 4;
+  if (isHex(type)) return hexToNumber(type);
   throw new Error(`Unexpected transaction type ${type}`);
-};
-
-export const toTransactionType = (value: number) => {
-  if (value === 0) return "legacy";
-  if (value === 1) return "eip1559";
-  if (value === 2) return "eip2930";
-  if (value === 3) return "eip4844";
-  if (value === 4) return "eip7702";
-  throw new Error(`Unexpected transaction type number ${value}`);
 };


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `src/shared/utils/sdk.ts` file by enhancing the `fromTransactionType` function and removing the `toTransactionType` function, streamlining transaction type handling.

### Detailed summary
- Added `hexToNumber` and `isHex` imports from `thirdweb`.
- Updated `fromTransactionType` to convert hex transaction types using `hexToNumber`.
- Removed the entire `toTransactionType` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->