### PR TITLE
chore: Simplify contract subscription indexes

### DIFF
--- a/src/prisma/migrations/20250310040146_simplify_contract_subscription_indexes/migration.sql
+++ b/src/prisma/migrations/20250310040146_simplify_contract_subscription_indexes/migration.sql
@@ -1,0 +1,48 @@
+/*
+  Warnings:
+
+  - The primary key for the `contract_event_logs` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropIndex
+DROP INDEX "contract_event_logs_blockNumber_idx";
+
+-- DropIndex
+DROP INDEX "contract_event_logs_contractAddress_idx";
+
+-- DropIndex
+DROP INDEX "contract_event_logs_timestamp_idx";
+
+-- DropIndex
+DROP INDEX "contract_event_logs_topic0_idx";
+
+-- DropIndex
+DROP INDEX "contract_event_logs_topic1_idx";
+
+-- DropIndex
+DROP INDEX "contract_event_logs_topic2_idx";
+
+-- DropIndex
+DROP INDEX "contract_event_logs_topic3_idx";
+
+-- DropIndex
+DROP INDEX "contract_transaction_receipts_chainId_transactionHash_key";
+
+-- DropIndex
+DROP INDEX "contract_transaction_receipts_contractId_blockNumber_idx";
+
+-- DropIndex
+DROP INDEX "contract_transaction_receipts_contractId_timestamp_idx";
+
+-- AlterTable
+ALTER TABLE "contract_event_logs" DROP CONSTRAINT "contract_event_logs_pkey",
+ADD CONSTRAINT "contract_event_logs_pkey" PRIMARY KEY ("chainId", "blockNumber", "transactionHash", "logIndex");
+
+-- AlterTable
+ALTER TABLE "contract_transaction_receipts" ADD CONSTRAINT "contract_transaction_receipts_pkey" PRIMARY KEY ("chainId", "blockNumber", "transactionHash");
+
+-- CreateIndex
+CREATE INDEX "contract_event_logs_timestamp_chainId_contractAddress_idx" ON "contract_event_logs"("timestamp", "chainId", "contractAddress");
+
+-- CreateIndex
+CREATE INDEX "contract_transaction_receipts_timestamp_chainId_contractAdd_idx" ON "contract_transaction_receipts"("timestamp", "chainId", "contractAddress");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -278,14 +278,8 @@ model ContractEventLogs {
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 
-  @@id([transactionHash, logIndex])
-  @@index([timestamp])
-  @@index([blockNumber])
-  @@index([contractAddress])
-  @@index([topic0])
-  @@index([topic1])
-  @@index([topic2])
-  @@index([topic3])
+  @@id([chainId, blockNumber, transactionHash, logIndex])
+  @@index([timestamp, chainId, contractAddress])
   @@map("contract_event_logs")
 }
 
@@ -331,9 +325,8 @@ model ContractTransactionReceipts {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([chainId, transactionHash])
-  @@index([contractId, timestamp])
-  @@index([contractId, blockNumber])
+  @@id([chainId, blockNumber, transactionHash])
+  @@index([timestamp, chainId, contractAddress])
   @@map("contract_transaction_receipts")
 }
 


### PR DESCRIPTION
Goal: make insert/deletes more performant

- Remove unused indexes -- each insert was updating all indexes
- Add chain+blockNumber to the uniqueness constraint to trade off better pruning of the search space for more disk space used

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the primary keys and indexes for the `contract_event_logs` and `contract_transaction_receipts` models in the Prisma schema, enhancing the database structure for better performance and data integrity.

### Detailed summary
- Updated primary key for `contract_event_logs` to include `chainId`, `blockNumber`, `transactionHash`, and `logIndex`.
- Updated primary key for `contract_transaction_receipts` to include `chainId`, `blockNumber`, and `transactionHash`.
- Modified indexes for both models to include `chainId` and `contractAddress`.
- Added SQL migration commands to drop old indexes and create new ones reflecting the schema changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->