### PR TITLE
Refactor send-transaction and sign typed data to v5

### DIFF
--- a/src/server/routes/contract/write/write.ts
+++ b/src/server/routes/contract/write/write.ts
@@ -110,11 +110,13 @@ export async function writeToContract(fastify: FastifyInstance) {
         );
       }
 
+      const { value, overrides } = parseTransactionOverrides(txOverrides);
       const transaction = prepareContractCall({
         contract,
         method,
         params,
-        ...parseTransactionOverrides(txOverrides),
+        value,
+        ...overrides,
       });
 
       const queueId = await queueTransaction({

--- a/src/shared/utils/transaction/types.ts
+++ b/src/shared/utils/transaction/types.ts
@@ -1,9 +1,8 @@
-import {
-  signAuthorization,
+import type {
+  Address,
+  Hex,
   SignedAuthorization,
-  type Address,
-  type Hex,
-  type toSerializableTransaction,
+  toSerializableTransaction,
 } from "thirdweb";
 import type { TransactionType } from "viem";
 


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing transaction handling and data signing in the backend, particularly with smart wallets and transaction overrides. It introduces new types, improves error handling, and refines transaction preparation and queuing.

### Detailed summary
- Updated `src/shared/utils/transaction/types.ts` to import and define types.
- Enhanced `src/server/routes/contract/write/write.ts` to better handle transaction overrides.
- Modified `src/server/routes/backend-wallet/sign-typed-data.ts` to include `chainId` and `primaryType` in the request body, improving smart wallet handling.
- Updated signing logic to use `account.signTypedData`.
- Refined transaction preparation in `src/server/routes/backend-wallet/send-transaction.ts`, integrating overrides and simplifying transaction queuing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->