### PR TITLE
Update thirdweb to 5.93.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "prisma": "^5.14.0",
     "prom-client": "^15.1.3",
     "superjson": "^2.2.1",
-    "thirdweb": "5.90.0",
+    "thirdweb": "5.93.0",
     "undici": "^6.20.1",
     "uuid": "^9.0.1",
     "viem": "2.22.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3861,10 +3861,10 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.29.0.tgz#d0b3d12c07d5a47f42ab0c1ed4f317106f3d4b20"
   integrity sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==
 
-"@tanstack/query-core@5.66.4":
-  version "5.66.4"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.66.4.tgz#44b87bff289466adbfa0de8daa5756cbd2d61c61"
-  integrity sha512-skM/gzNX4shPkqmdTCSoHtJAPMTtmIJNS0hE+xwTTUVYwezArCT34NMermABmBVUg5Ls5aiUXEDXfqwR1oVkcA==
+"@tanstack/query-core@5.67.3":
+  version "5.67.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.67.3.tgz#222795762c584d572f6f41bd4eb97f86f46f2eea"
+  integrity sha512-pq76ObpjcaspAW4OmCbpXLF6BCZP2Zr/J5ztnyizXhSlNe7fIUp0QKZsd0JMkw9aDa+vxDX/OY7N+hjNY/dCGg==
 
 "@tanstack/react-query@5.29.2":
   version "5.29.2"
@@ -3873,12 +3873,12 @@
   dependencies:
     "@tanstack/query-core" "5.29.0"
 
-"@tanstack/react-query@5.66.9":
-  version "5.66.9"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.66.9.tgz#1c8be303adae59e9cee877490fbb2c23dfa26927"
-  integrity sha512-NRI02PHJsP5y2gAuWKP+awamTIBFBSKMnO6UVzi03GTclmHHHInH5UzVgzi5tpu4+FmGfsdT7Umqegobtsp23A==
+"@tanstack/react-query@5.67.3":
+  version "5.67.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.67.3.tgz#4a1a1a54828465ab6bc421e66dc7ebd88191e851"
+  integrity sha512-u/n2HsQeH1vpZIOzB/w2lqKlXUDUKo6BxTdGXSMvNzIq5MHYFckRMVuFABp+QB7RN8LFXWV6X1/oSkuDq+MPIA==
   dependencies:
-    "@tanstack/query-core" "5.66.4"
+    "@tanstack/query-core" "5.67.3"
 
 "@thirdweb-dev/auth@^4.1.87":
   version "4.1.97"
@@ -8826,7 +8826,7 @@ os-browserify@^0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==
 
-ox@0.6.7, ox@0.6.9:
+ox@0.6.10, ox@0.6.7, ox@0.6.9:
   version "0.6.9"
   resolved "https://registry.yarnpkg.com/ox/-/ox-0.6.9.tgz#da1ee04fa10de30c8d04c15bfb80fe58b1f554bd"
   integrity sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==
@@ -10266,15 +10266,14 @@ thirdweb@5.29.6:
     uqr "0.1.2"
     viem "2.13.7"
 
-thirdweb@5.90.0:
-  version "5.90.0"
-  resolved "https://registry.yarnpkg.com/thirdweb/-/thirdweb-5.90.0.tgz#64b7398b0122c13a600de2e4e009f6f6bfbe9db3"
-  integrity sha512-fywfjQbV7RFl8oVO+h4fkRfs3PsyEpJb/lqv7AwITeETAvZ22xzf/YpzDDHgHAB4c1qSwhdbusxTPBwA6w16dQ==
+thirdweb@5.93.0:
+  version "5.93.0"
+  resolved "https://registry.yarnpkg.com/thirdweb/-/thirdweb-5.93.0.tgz#bae1cfe5e6380dc3fff116744ee0e9beaa5b7fa2"
+  integrity sha512-fq3UmlvaRpxoy9oBnoOwYJh/n8ETJJBIeBkuAF2aeE9ZWcsjHCkb3EZhQfVxnJ/G76MrExHEB/HvBy9wLeD5Fg==
   dependencies:
     "@coinbase/wallet-sdk" "4.3.0"
     "@emotion/react" "11.14.0"
     "@emotion/styled" "11.14.0"
-    "@google/model-viewer" "2.1.1"
     "@noble/curves" "1.8.1"
     "@noble/hashes" "1.7.1"
     "@passwordless-id/webauthn" "^2.1.2"
@@ -10282,7 +10281,7 @@ thirdweb@5.90.0:
     "@radix-ui/react-focus-scope" "1.1.2"
     "@radix-ui/react-icons" "1.3.2"
     "@radix-ui/react-tooltip" "1.1.8"
-    "@tanstack/react-query" "5.66.9"
+    "@tanstack/react-query" "5.67.3"
     "@walletconnect/ethereum-provider" "2.17.5"
     "@walletconnect/sign-client" "2.17.5"
     abitype "1.0.8"
@@ -10290,9 +10289,9 @@ thirdweb@5.90.0:
     fuse.js "7.1.0"
     input-otp "^1.4.1"
     mipd "0.0.7"
-    ox "0.6.9"
+    ox "0.6.10"
     uqr "0.1.2"
-    viem "2.23.5"
+    viem "2.23.10"
 
 thread-stream@^0.15.1:
   version "0.15.2"
@@ -10719,7 +10718,7 @@ varint@^6.0.0:
   resolved "https://registry.yarnpkg.com/varint/-/varint-6.0.0.tgz#9881eb0ce8feaea6512439d19ddf84bf551661d0"
   integrity sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==
 
-viem@2.13.7, viem@2.22.17, viem@2.23.5:
+viem@2.13.7, viem@2.22.17, viem@2.23.10:
   version "2.22.17"
   resolved "https://registry.yarnpkg.com/viem/-/viem-2.22.17.tgz#71cb5793d898e7850d440653b0043803c2d00c8d"
   integrity sha512-eqNhlPGgRLR29XEVUT2uuaoEyMiaQZEKx63xT1py9OYsE+ZwlVgjnfrqbXad7Flg2iJ0Bs5Hh7o0FfRWUJGHvg==


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies in the project, particularly the versions of `thirdweb`, `@tanstack/query-core`, `@tanstack/react-query`, and `viem`, along with adjusting the version of `ox`.

### Detailed summary
- Updated `thirdweb` from `5.90.0` to `5.93.0`.
- Updated `@tanstack/query-core` from `5.66.4` to `5.67.3`.
- Updated `@tanstack/react-query` from `5.66.9` to `5.67.3`.
- Updated `viem` from `2.23.5` to `2.23.10`.
- Updated `ox` from `0.6.9` to `0.6.10`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->