### PR TITLE
Refactor contract read route to use thirdweb v5

### DIFF
--- a/sdk/src/services/BackendWalletService.ts
+++ b/sdk/src/services/BackendWalletService.ts
@@ -495,6 +495,17 @@ export class BackendWalletService {
             toAddress?: string;
             data: string;
             value: string;
+            authorizationList?: Array<{
+                /**
+                 * A contract or wallet address
+                 */
+                address: string;
+                chainId: number;
+                nonce: string;
+                'r': string;
+                's': string;
+                yParity: number;
+            }>;
             txOverrides?: {
                 /**
                  * Gas limit for the transaction
@@ -814,6 +825,8 @@ export class BackendWalletService {
             domain: Record<string, any>;
             types: Record<string, any>;
             value: Record<string, any>;
+            primaryType?: string;
+            chainId?: number;
         },
         xIdempotencyKey?: string,
         xTransactionMode?: 'sponsored',

--- a/sdk/src/services/ContractSubscriptionsService.ts
+++ b/sdk/src/services/ContractSubscriptionsService.ts
@@ -68,7 +68,11 @@ export class ContractSubscriptionsService {
              */
             contractAddress: string;
             /**
-             * Webhook URL
+             * The ID of an existing webhook to use for this contract subscription. Either `webhookId` or `webhookUrl` must be provided.
+             */
+            webhookId?: number;
+            /**
+             * Creates a new webhook to call when new onchain data is detected. Either `webhookId` or `webhookUrl` must be provided.
              */
             webhookUrl?: string;
             /**

--- a/src/server/schemas/contract/index.ts
+++ b/src/server/schemas/contract/index.ts
@@ -1,26 +1,6 @@
-import { Type, type Static } from "@sinclair/typebox";
+import { type Static, Type } from "@sinclair/typebox";
 import { AddressSchema } from "../address";
 import type { contractSchemaTypes } from "../shared-api-schemas";
-
-/**
- * Basic schema for all Request Query String
- */
-export const readRequestQuerySchema = Type.Object({
-  functionName: Type.String({
-    description: "Name of the function to call on Contract",
-    examples: ["balanceOf"],
-  }),
-  args: Type.Optional(
-    Type.String({
-      description: "Arguments for the function. Comma Separated",
-      examples: [""],
-    }),
-  ),
-});
-
-export interface readSchema extends contractSchemaTypes {
-  Querystring: Static<typeof readRequestQuerySchema>;
-}
 
 const abiTypeSchema = Type.Object({
   type: Type.Optional(Type.String()),
@@ -64,6 +44,31 @@ export const abiSchema = Type.Object({
 
 export const abiArraySchema = Type.Array(abiSchema);
 export type AbiSchemaType = Static<typeof abiArraySchema>;
+
+/**
+ * Basic schema for all Request Query String
+ */
+export const readRequestQuerySchema = Type.Object({
+  functionName: Type.String({
+    description:
+      "The function to call on the contract. It is highly recommended to provide a full function signature, such as 'function balanceOf(address owner) view returns (uint256)', to avoid ambiguity and to skip ABI resolution",
+    examples: [
+      "function balanceOf(address owner) view returns (uint256)",
+      "balanceOf",
+    ],
+  }),
+  args: Type.Optional(
+    Type.String({
+      description: "Arguments for the function. Comma Separated",
+      examples: [""],
+    }),
+  ),
+  abi: Type.Optional(abiArraySchema),
+});
+
+export interface readSchema extends contractSchemaTypes {
+  Querystring: Static<typeof readRequestQuerySchema>;
+}
 
 export const contractEventSchema = Type.Record(Type.String(), Type.Any());
 

--- a/src/server/utils/convertor.ts
+++ b/src/server/utils/convertor.ts
@@ -3,8 +3,8 @@ import { BigNumber } from "ethers";
 const isHexBigNumber = (value: unknown) => {
   const isNonNullObject = typeof value === "object" && value !== null;
   const hasType = isNonNullObject && "type" in value;
-  return hasType && value.type === "BigNumber" && "hex" in value
-}
+  return hasType && value.type === "BigNumber" && "hex" in value;
+};
 export const bigNumberReplacer = (value: unknown): unknown => {
   // if we find a BigNumber then make it into a string (since that is safe)
   if (BigNumber.isBigNumber(value) || isHexBigNumber(value)) {
@@ -13,6 +13,10 @@ export const bigNumberReplacer = (value: unknown): unknown => {
 
   if (Array.isArray(value)) {
     return value.map(bigNumberReplacer);
+  }
+
+  if (typeof value === "bigint") {
+    return value.toString();
   }
 
   return value;

--- a/tests/e2e/tests/routes/read.test.ts
+++ b/tests/e2e/tests/routes/read.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import assert from "node:assert";
+import { ZERO_ADDRESS } from "thirdweb";
+import type { Address } from "thirdweb/utils";
+import { CONFIG } from "../../config";
+import type { setupEngine } from "../../utils/engine";
+import { pollTransactionStatus } from "../../utils/transactions";
+import { setup } from "../setup";
+
+describe("readContractRoute", () => {
+  let engine: ReturnType<typeof setupEngine>;
+  let backendWallet: Address;
+  let tokenContractAddress: string;
+
+  beforeAll(async () => {
+    const { engine: _engine, backendWallet: _backendWallet } = await setup();
+    engine = _engine;
+    backendWallet = _backendWallet as Address;
+
+    const res = await engine.deploy.deployToken(
+      CONFIG.CHAIN.id.toString(),
+      backendWallet,
+      {
+        contractMetadata: {
+          name: "test token",
+          platform_fee_basis_points: 0,
+          platform_fee_recipient: ZERO_ADDRESS,
+          symbol: "TT",
+          trusted_forwarders: [],
+        },
+      },
+    );
+
+    expect(res.result.queueId).toBeDefined();
+    assert(res.result.queueId, "queueId must be defined");
+    expect(res.result.deployedAddress).toBeDefined();
+
+    const transactionStatus = await pollTransactionStatus(
+      engine,
+      res.result.queueId,
+      true,
+    );
+
+    expect(transactionStatus.minedAt).toBeDefined();
+    assert(res.result.deployedAddress, "deployedAddress must be defined");
+    tokenContractAddress = res.result.deployedAddress;
+  });
+
+  test("readContract with function name", async () => {
+    const res = await engine.contract.read(
+      "name",
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+    );
+
+    expect(res.result).toEqual("test token");
+  });
+
+  test("readContract with function signature", async () => {
+    const res = await engine.contract.read(
+      "function symbol() public view returns (string memory)",
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+    );
+
+    expect(res.result).toEqual("TT");
+  });
+
+  test("readContract with function signature", async () => {
+    const res = await engine.contract.read(
+      "function totalSupply() public view returns (uint256)",
+      CONFIG.CHAIN.id.toString(),
+      tokenContractAddress,
+    );
+
+    expect(res.result).toEqual("0");
+  });
+});


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the `ContractSubscriptionsService`, `BackendWalletService`, and contract reading functionalities, including improved schemas and error handling. It introduces new features such as `webhookId`, updates the `readRequestQuerySchema`, and refines the contract reading process.

### Detailed summary
- Added `webhookId` to `ContractSubscriptionsService` with detailed documentation.
- Updated `BackendWalletService` to include an optional `authorizationList` with address and chainId.
- Revised `readRequestQuerySchema` to include a full function signature and optional `abi`.
- Enhanced error handling in `readContract` with improved method resolution.
- Updated `bigNumberReplacer` to handle `bigint` types.
- Added new tests for contract reading functionalities in `read.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->