### PR TITLE
replace spread with individual assignment

### DIFF
--- a/src/worker/tasks/send-transaction-worker.ts
+++ b/src/worker/tasks/send-transaction-worker.ts
@@ -216,8 +216,9 @@ const _sendUserOp = async (
           {
             client: thirdwebClient,
             chain,
-            ...queuedTransaction,
-            ...overrides,
+            data: queuedTransaction.data,
+            value: queuedTransaction.value,
+            ...overrides, // gas-overrides
             to: getChecksumAddress(toAddress),
           },
         ];
@@ -384,7 +385,9 @@ const _sendTransaction = async (
   });
   populatedTransaction.nonce = nonce;
   job.log(
-    `Populated transaction (isRecycledNonce=${isRecycledNonce}): ${stringify(populatedTransaction)}`,
+    `Populated transaction (isRecycledNonce=${isRecycledNonce}): ${stringify(
+      populatedTransaction,
+    )}`,
   );
 
   // Send transaction to RPC.


### PR DESCRIPTION
queuedTransaction has a "from" field which is the EOA address in the case of userops. The presence of a incorrect "from" address in a userop causes issues like estimation failures. To avoid this, we are selectively passing only the "data" and "value" fields, along with gas overrides.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the transaction object structure in the `_sendTransaction` function to improve clarity and ensure that the `data` and `value` fields from `queuedTransaction` are explicitly included.

### Detailed summary
- Replaced the spread operator for `queuedTransaction` with explicit fields: `data` and `value`.
- Updated the log message to format `populatedTransaction` on a new line for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->