### PR TITLE
When deleting contract sub, don't delete underlying webhook

### DIFF
--- a/src/server/routes/contract/subscriptions/remove-contract-subscription.ts
+++ b/src/server/routes/contract/subscriptions/remove-contract-subscription.ts
@@ -2,7 +2,6 @@ import { type Static, Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { deleteContractSubscription } from "../../../../shared/db/contract-subscriptions/delete-contract-subscription";
-import { deleteWebhook } from "../../../../shared/db/webhooks/revoke-webhook";
 import { standardResponseSchema } from "../../../schemas/shared-api-schemas";
 
 const bodySchema = Type.Object({
@@ -47,9 +46,6 @@ export async function removeContractSubscription(fastify: FastifyInstance) {
       const contractSubscription = await deleteContractSubscription(
         contractSubscriptionId,
       );
-      if (contractSubscription.webhookId) {
-        await deleteWebhook(contractSubscription.webhookId);
-      }
 
       reply.status(StatusCodes.OK).send({
         result: {


### PR DESCRIPTION
Unexpected behavior, we have apis for deleting webhooks


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `removeContractSubscription` function by removing the deletion of a webhook associated with a contract subscription.

### Detailed summary
- Removed the import statement for `deleteWebhook`.
- Eliminated the conditional check and call to `deleteWebhook` based on `contractSubscription.webhookId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->