### PR TITLE
feat: allow configuring the block batch size for contract subscriptions

### DIFF
--- a/src/server/routes/contract/subscriptions/remove-contract-subscription.ts
+++ b/src/server/routes/contract/subscriptions/remove-contract-subscription.ts
@@ -43,9 +43,7 @@ export async function removeContractSubscription(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { contractSubscriptionId } = request.body;
 
-      const contractSubscription = await deleteContractSubscription(
-        contractSubscriptionId,
-      );
+      await deleteContractSubscription(contractSubscriptionId);
 
       reply.status(StatusCodes.OK).send({
         result: {

--- a/src/shared/utils/env.ts
+++ b/src/shared/utils/env.ts
@@ -86,6 +86,8 @@ export const env = createEnv({
     QUEUE_FAIL_HISTORY_COUNT: z.coerce.number().default(10_000),
     // Sets the number of recent nonces to map to queue IDs.
     NONCE_MAP_COUNT: z.coerce.number().default(10_000),
+    // Sets the estimated number of blocks to query per contract subscription job. Defaults to 1 block (real-time).
+    CONTRACT_SUBSCRIPTION_BLOCK_RANGE: z.coerce.number().default(1),
 
     ENABLE_KEYPAIR_AUTH: boolEnvSchema(false),
     ENABLE_CUSTOM_HMAC_AUTH: boolEnvSchema(false),
@@ -136,6 +138,8 @@ export const env = createEnv({
     QUEUE_COMPLETE_HISTORY_COUNT: process.env.QUEUE_COMPLETE_HISTORY_COUNT,
     QUEUE_FAIL_HISTORY_COUNT: process.env.QUEUE_FAIL_HISTORY_COUNT,
     NONCE_MAP_COUNT: process.env.NONCE_MAP_COUNT,
+    CONTRACT_SUBSCRIPTION_BLOCK_RANGE:
+      process.env.CONTRACT_SUBSCRIPTION_BLOCK_RANGE,
     EXPERIMENTAL__MINE_WORKER_TIMEOUT_SECONDS:
       process.env.EXPERIMENTAL__MINE_WORKER_TIMEOUT_SECONDS,
     EXPERIMENTAL__MAX_GAS_PRICE_WEI:


### PR DESCRIPTION
Exposes an env var to configure larger batch sizes for contract subscription jobs. This is useful to reduce the amount of RPC calls and DB writes, at the expense of higher delay for jobs to capture events/receipts.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of contract subscriptions by optimizing the deletion process and introducing configuration for block querying.

### Detailed summary
- Simplified the `deleteContractSubscription` call in `remove-contract-subscription.ts`.
- Added `CONTRACT_SUBSCRIPTION_BLOCK_RANGE` to `env.ts` for configuring block queries.
- Updated `createScheduleSeconds` in `chain-indexer-registry.ts` to use `CONTRACT_SUBSCRIPTION_BLOCK_RANGE` for scheduling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->