### PR TITLE
Consider allowing host.docker.internal with the http protocol for local development

### DIFF
--- a/src/server/utils/validator.ts
+++ b/src/server/utils/validator.ts
@@ -98,7 +98,9 @@ export const isValidWebhookUrl = (input: string): boolean => {
       url.protocol === "https:" ||
       // Allow http for localhost only.
       (url.protocol === "http:" &&
-        ["localhost", "0.0.0.0", "127.0.0.1"].includes(url.hostname))
+        ["localhost", "0.0.0.0", "127.0.0.1", "host.docker.internal"].includes(
+          url.hostname,
+        ))
     );
   } catch {
     return false;

--- a/tests/unit/validator.test.ts
+++ b/tests/unit/validator.test.ts
@@ -30,5 +30,6 @@ describe("isValidWebhookUrl", () => {
     expect(isValidWebhookUrl("http://localhost:3000")).toBe(true);
     expect(isValidWebhookUrl("http://0.0.0.0:3000")).toBe(true);
     expect(isValidWebhookUrl("http://user:pass@127.0.0.1:3000")).toBe(true);
+    expect(isValidWebhookUrl("http://host.docker.internal:3000")).toBe(true);
   });
 });


### PR DESCRIPTION
## Changes

- updates `isValidWebhookUrl` to allow using host.docker.internal with the `http` protocol
- updates the validator unit tests to check if `http://host.docker.internal:3000` is a valid webhook url

This makes it possible to set webhooks for services running on the host when developing locally and running the engine with docker


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the validation logic for webhook URLs to include `host.docker.internal` as a valid hostname for HTTP requests, enhancing local development compatibility.

### Detailed summary
- Added a test case in `tests/unit/validator.test.ts` to validate `http://host.docker.internal:3000`.
- Modified the validation logic in `src/server/utils/validator.ts` to include `host.docker.internal` in the list of allowed hostnames for HTTP.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->