### PR TITLE
Add tokenId support to ERC1155 signature generation

### DIFF
--- a/src/server/routes/contract/extensions/erc1155/read/signature-generate.ts
+++ b/src/server/routes/contract/extensions/erc1155/read/signature-generate.ts
@@ -55,6 +55,7 @@ const requestBodySchemaV5 = Type.Intersect([
     currency: Type.Optional(Type.String()),
     validityStartTimestamp: Type.Integer({ minimum: 0 }),
     validityEndTimestamp: Type.Optional(Type.Integer({ minimum: 0 })),
+    tokenId: Type.Optional(Type.String()),
     uid: Type.Optional(Type.String()),
   }),
   Type.Union([
@@ -145,6 +146,7 @@ export async function erc1155SignatureGenerate(fastify: FastifyInstance) {
           currency,
           validityStartTimestamp,
           validityEndTimestamp,
+          tokenId,
           uid,
         } = args;
 
@@ -183,6 +185,7 @@ export async function erc1155SignatureGenerate(fastify: FastifyInstance) {
             royaltyBps,
             primarySaleRecipient,
             pricePerToken,
+            tokenId: maybeBigInt(tokenId),
             pricePerTokenWei: maybeBigInt(pricePerTokenWei),
             currency,
             validityStartTimestamp: new Date(validityStartTimestamp * 1000),
@@ -223,6 +226,7 @@ export async function erc1155SignatureGenerate(fastify: FastifyInstance) {
         royaltyBps,
         royaltyRecipient,
         uid,
+        tokenId,
       } = request.body as Static<typeof requestBodySchemaV4>;
 
       const contract = await getContractV4({
@@ -247,6 +251,7 @@ export async function erc1155SignatureGenerate(fastify: FastifyInstance) {
         royaltyBps,
         royaltyRecipient,
         uid,
+        tokenId,
       });
 
       const signedPayload = await contract.erc1155.signature.generate(payload);

--- a/src/server/schemas/nft/index.ts
+++ b/src/server/schemas/nft/index.ts
@@ -302,6 +302,12 @@ export const signature1155InputSchema = Type.Object({
       Type.Integer({ minimum: 0 }),
     ]),
   ),
+  tokenId: Type.Optional(
+    Type.String({
+      description:
+        "The token id to mint. If not provided, a new token id will be generated.",
+    }),
+  ),
 });
 
 export const signature1155OutputSchema = Type.Object({


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new optional `tokenId` field to the NFT schema and related functionality in the `erc1155SignatureGenerate` method, allowing for the specification of a token ID during the signature generation process.

### Detailed summary
- Added `tokenId` as an optional field to the schema in `src/server/schemas/nft/index.ts`.
- Updated `erc1155SignatureGenerate` function to accept `tokenId` in its arguments.
- Modified request handling to include `tokenId` in the payload.
- Adjusted contract call to include `tokenId` when generating the signature.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional token ID when generating ERC-1155 signatures. Users can now specify a token ID to mint, or allow the system to generate one automatically.
  
* **API Changes**
  * The ERC-1155 signature generation endpoints now accept and return a token ID field in the request and response payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->