### PR TITLE
Add tokenId support to ERC1155 signature generation and remove validityStartTimestamp

### DIFF
--- a/src/server/routes/contract/extensions/erc1155/read/signature-generate.ts
+++ b/src/server/routes/contract/extensions/erc1155/read/signature-generate.ts
@@ -144,7 +144,6 @@ export async function erc1155SignatureGenerate(fastify: FastifyInstance) {
           pricePerToken,
           pricePerTokenWei,
           currency,
-          validityStartTimestamp,
           validityEndTimestamp,
           tokenId,
           uid,
@@ -188,7 +187,6 @@ export async function erc1155SignatureGenerate(fastify: FastifyInstance) {
             tokenId: maybeBigInt(tokenId),
             pricePerTokenWei: maybeBigInt(pricePerTokenWei),
             currency,
-            validityStartTimestamp: new Date(validityStartTimestamp * 1000),
             validityEndTimestamp: validityEndTimestamp
               ? new Date(validityEndTimestamp * 1000)
               : undefined,
@@ -254,7 +252,14 @@ export async function erc1155SignatureGenerate(fastify: FastifyInstance) {
         tokenId,
       });
 
-      const signedPayload = await contract.erc1155.signature.generate(payload);
+      const signedPayload = tokenId
+        ? await contract.erc1155.signature.generateFromTokenId(
+            { ...payload, tokenId: BigInt(tokenId) },
+          )
+        : await contract.erc1155.signature.generate(payload);
+
+      console.log("signedPayload", signedPayload);
+
       reply.status(StatusCodes.OK).send({
         result: {
           ...signedPayload,


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `erc1155SignatureGenerate` function to enhance the signature generation process based on the presence of `tokenId`. It introduces conditional logic for generating a signed payload.

### Detailed summary
- Removed the conversion of `validityStartTimestamp` to a `Date` object.
- Added conditional logic to generate the signed payload:
  - If `tokenId` exists, calls `generateFromTokenId`.
  - If not, calls the original `generate` method.
- Added a `console.log` statement for `signedPayload`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signature generation by updating how token IDs are handled and removing outdated timestamp processing.

* **Chores**
  * Added debug logging for signature payloads to assist with troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->