### PR TITLE
chore: expose webhook concurrency in env var

### DIFF
--- a/src/shared/utils/env.ts
+++ b/src/shared/utils/env.ts
@@ -94,6 +94,8 @@ export const env = createEnv({
     CUSTOM_HMAC_AUTH_CLIENT_ID: z.string().optional(),
     CUSTOM_HMAC_AUTH_CLIENT_SECRET: z.string().optional(),
 
+    SEND_WEBHOOK_QUEUE_CONCURRENCY: z.coerce.number().default(10),
+
     /**
      * Experimental env vars. These may be renamed or removed in future non-major releases.
      */
@@ -167,6 +169,7 @@ export const env = createEnv({
       process.env.EXPERIMENTAL__MINE_WORKER_MAX_POLL_INTERVAL_SECONDS,
     EXPERIMENTAL__MINE_WORKER_POLL_INTERVAL_SCALING_FACTOR:
       process.env.EXPERIMENTAL__MINE_WORKER_POLL_INTERVAL_SCALING_FACTOR,
+    SEND_WEBHOOK_QUEUE_CONCURRENCY: process.env.SEND_WEBHOOK_QUEUE_CONCURRENCY,
   },
   onValidationError: (error: ZodError) => {
     console.error(

--- a/src/worker/tasks/send-webhook-worker.ts
+++ b/src/worker/tasks/send-webhook-worker.ts
@@ -23,6 +23,7 @@ import {
   SendWebhookQueue,
   type WebhookJob,
 } from "../queues/send-webhook-queue";
+import { env } from "../../shared/utils/env";
 
 const handler: Processor<string, void, string> = async (job: Job<string>) => {
   const { data, webhook } = superjson.parse<WebhookJob>(job.data);
@@ -102,7 +103,7 @@ const handler: Processor<string, void, string> = async (job: Job<string>) => {
 // Must be explicitly called for the worker to run on this host.
 export const initSendWebhookWorker = () => {
   new Worker(SendWebhookQueue.q.name, handler, {
-    concurrency: 10,
+    concurrency: env.SEND_WEBHOOK_QUEUE_CONCURRENCY,
     connection: redis,
   });
 };


### PR DESCRIPTION
## Changes

- Added a new environment variable `SEND_WEBHOOK_QUEUE_CONCURRENCY` to control the concurrency of the webhook sending queue
- Updated the webhook worker to use this configurable concurrency value instead of the hardcoded value of 10
- Set a default value of 10 to maintain backward compatibility

## How this PR will be tested

- [ ] Set `SEND_WEBHOOK_QUEUE_CONCURRENCY=20` in the environment and verify that the webhook worker uses this value
- [ ] Leave the environment variable unset and verify that the default value of 10 is used
- [ ] Monitor webhook processing performance with different concurrency values

## Output

```
# Example environment configuration
SEND_WEBHOOK_QUEUE_CONCURRENCY=20
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring webhook queue concurrency through an environment variable, allowing dynamic adjustment without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->