### PR TITLE
feat: add gasFeeCeiling to transaction overrides and handling logic

### DIFF
--- a/src/server/schemas/tx-overrides.ts
+++ b/src/server/schemas/tx-overrides.ts
@@ -23,6 +23,13 @@ export const txOverridesSchema = Type.Object({
         ...WeiAmountStringSchema,
         description: "Maximum priority fee per gas",
       }),
+
+      gasFeeCeiling: Type.Optional({
+        ...WeiAmountStringSchema,
+        description:
+          "Maximum gas fee for the transaction. This is the total maximum gas fee you are willing to pay for the transaction. If the chain gas conditions are worse than this, the transaction will be delayed until the gas conditions are better. If chain gas conditions are better than this, the transaction will be sent immediately. This value is only used to determine if the transaction should be delayed or sent immediately, and is not used to calculate the actual gas fee for the transaction.",
+      }),
+
       timeoutSeconds: Type.Optional(
         Type.Integer({
           examples: ["7200"],

--- a/src/server/utils/transaction-overrides.ts
+++ b/src/server/utils/transaction-overrides.ts
@@ -20,6 +20,7 @@ export const parseTransactionOverrides = (
       gasPrice: maybeBigInt(overrides.gasPrice),
       maxFeePerGas: maybeBigInt(overrides.maxFeePerGas),
       maxPriorityFeePerGas: maybeBigInt(overrides.maxPriorityFeePerGas),
+      gasFeeCeiling: maybeBigInt(overrides.gasFeeCeiling),
     },
     timeoutSeconds: overrides.timeoutSeconds,
     // `value` may not be in the overrides object.

--- a/src/shared/db/transactions/queue-tx.ts
+++ b/src/shared/db/transactions/queue-tx.ts
@@ -23,6 +23,7 @@ interface QueueTxParams {
     gas?: string;
     maxFeePerGas?: string;
     maxPriorityFeePerGas?: string;
+    gasFeeCeiling?: string;
     value?: string;
   };
 }

--- a/src/shared/utils/transaction/types.ts
+++ b/src/shared/utils/transaction/types.ts
@@ -45,6 +45,7 @@ export type InsertedTransaction = {
     gasPrice?: bigint;
     maxFeePerGas?: bigint;
     maxPriorityFeePerGas?: bigint;
+    gasFeeCeiling?: bigint;
   };
   timeoutSeconds?: number;
 


### PR DESCRIPTION
* Introduced gasFeeCeiling in transaction schemas and types.
* Updated transaction parsing to include gasFeeCeiling.
* Implemented logic to delay transactions if estimated costs exceed the gas fee ceiling in the send transaction worker.

## Example log:
```
{
  "result": {
    "raw": {
      "chainId": 84532,
      "from": "0x31812b06c9004f091c48AeCE05573389Cc1e0975",
      "to": "0x9aB78C7193c59453F3E8aE9184e1121C6Db3eb4E",
      "data": "0x",
      "value": "0",
      "overrides": {
        "gasFeeCeiling": "100"
      },
      "timeoutSeconds": 100,
      "isUserOp": true,
      "status": "errored",
      "queueId": "427119af-3951-4b47-8fbd-a8bd15d16fa4",
      "queuedAt": "2025-07-04T07:17:44.546Z",
      "resendCount": 0,
      "signerAddress": "0x31812b06c9004f091c48AeCE05573389Cc1e0975",
      "accountAddress": "0x9aB78C7193c59453F3E8aE9184e1121C6Db3eb4E",
      "target": "0x9aB78C7193c59453F3E8aE9184e1121C6Db3eb4E",
      "accountFactoryAddress": "0x4bE0ddfebcA9A5A4a617dee4DeCe99E7c862dceb",
      "entrypointAddress": "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
      "errorMessage": "Exceeded 100s timeout"
    },
    "jobs": [
      {
        "queue": "transactions-1-send",
        "jobId": "427119af-3951-4b47-8fbd-a8bd15d16fa4.0",
        "timestamp": "2025-07-04T07:17:44.546Z",
        "lines": [
          "Override gas fee ceiling (100) is lower than onchain estimated cost (279894904068). Delaying job until Fri Jul 04 2025 12:52:48 GMT+0530 (India Standard Time). [callGasLimit: 27955, preVerificationGas: 68823, verificationGasLimit: 68825, maxFeePerGas: 1690156]",
          "Transaction errored: {\"chainId\":84532,\"from\":\"0x31812b06c9004f091c48AeCE05573389Cc1e0975\",\"to\":\"0x9aB78C7193c59453F3E8aE9184e1121C6Db3eb4E\",\"data\":\"0x\",\"value\":\"0\",\"overrides\":{\"gasFeeCeiling\":\"100\"},\"timeoutSeconds\":100,\"isUserOp\":true,\"status\":\"errored\",\"queueId\":\"427119af-3951-4b47-8fbd-a8bd15d16fa4\",\"queuedAt\":\"2025-07-04T07:17:44.546Z\",\"resendCount\":0,\"signerAddress\":\"0x31812b06c9004f091c48AeCE05573389Cc1e0975\",\"accountAddress\":\"0x9aB78C7193c59453F3E8aE9184e1121C6Db3eb4E\",\"target\":\"0x9aB78C7193c59453F3E8aE9184e1121C6Db3eb4E\",\"accountFactoryAddress\":\"0x4bE0ddfebcA9A5A4a617dee4DeCe99E7c862dceb\",\"entrypointAddress\":\"0x0000000071727De22E5E9d8BAf0edAc6f37da032\",\"errorMessage\":\"Exceeded 100s timeout\"}."
        ],
        "processedOn": "2025-07-04T07:22:48.337Z",
        "finishedOn": "2025-07-04T07:22:48.346Z"
      }
    ]
  }
}
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new optional parameter `gasFeeCeiling` in various transaction-related files, enhancing transaction fee management by allowing jobs to be delayed if the estimated costs exceed this ceiling.

### Detailed summary
- Added `gasFeeCeiling` as an optional parameter in:
  - `src/shared/db/transactions/queue-tx.ts`
  - `src/shared/utils/transaction/types.ts`
- Implemented logic to handle `gasFeeCeiling` in:
  - `src/server/utils/transaction-overrides.ts`
  - `src/server/schemas/tx-overrides.ts`
  - `src/worker/tasks/send-transaction-worker.ts` (multiple instances)
- Enhanced error message formatting for improved readability in `send-transaction-worker.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for a new optional "gas fee ceiling" parameter when submitting transactions, allowing users to specify the maximum total gas fee they are willing to pay. Transactions will be delayed if network fees exceed this ceiling and processed when fees are within the specified limit.

* **Refactor**
  * Improved clarity in the handling of gas fee overrides and related error messages during transaction processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->