### PR TITLE
fix: include gas parameters in mined transaction webhooks

### DIFF
--- a/src/server/schemas/transaction/index.ts
+++ b/src/server/schemas/transaction/index.ts
@@ -277,28 +277,28 @@ export const toTransactionSchema = (
   };
 
   const resolveGas = (): string | null => {
-    if (transaction.status === "sent") {
+    if (transaction.status === "sent" || transaction.status === "mined") {
       return transaction.gas.toString();
     }
     return transaction.overrides?.gas?.toString() ?? null;
   };
 
   const resolveGasPrice = (): string | null => {
-    if (transaction.status === "sent") {
+    if (transaction.status === "sent" || transaction.status === "mined") {
       return transaction.gasPrice?.toString() ?? null;
     }
     return transaction.overrides?.gasPrice?.toString() ?? null;
   };
 
   const resolveMaxFeePerGas = (): string | null => {
-    if (transaction.status === "sent") {
+    if (transaction.status === "sent" || transaction.status === "mined") {
       return transaction.maxFeePerGas?.toString() ?? null;
     }
     return transaction.overrides?.maxFeePerGas?.toString() ?? null;
   };
 
   const resolveMaxPriorityFeePerGas = (): string | null => {
-    if (transaction.status === "sent") {
+    if (transaction.status === "sent" || transaction.status === "mined") {
       return transaction.maxPriorityFeePerGas?.toString() ?? null;
     }
     return transaction.overrides?.maxPriorityFeePerGas?.toString() ?? null;


### PR DESCRIPTION
Previously gasLimit and gasPrice fields were null in mined transaction webhooks because the resolver functions only checked for "sent" status. Since MinedTransaction inherits gas fields from SentTransaction, these values should be available for mined transactions as well.

Updates the resolver functions to include "mined" status:
- resolveGas() - returns transaction.gas for sent/mined transactions
- resolveGasPrice() - returns transaction.gasPrice for sent/mined transactions
- resolveMaxFeePerGas() - returns transaction.maxFeePerGas for sent/mined transactions
- resolveMaxPriorityFeePerGas() - returns transaction.maxPriorityFeePerGas for sent/mined transactions

🤖 Generated with [Claude Code](https://claude.ai/code)

## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the logic in several functions to consider an additional transaction status, `"mined"`, alongside `"sent"` when resolving gas-related values.

### Detailed summary
- Modified `resolveGas` to return gas if `transaction.status` is `"sent"` or `"mined"`.
- Updated `resolveGasPrice` to return gas price for `"sent"` or `"mined"` status.
- Changed `resolveMaxFeePerGas` to check for `"sent"` or `"mined"` status when resolving max fee.
- Altered `resolveMaxPriorityFeePerGas` to include `"mined"` status in its condition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->