### PR TITLE
Convert%20bigNumber%20to%20bigint%20string%20in%20payload

### DIFF
--- a/src/server/routes/backend-wallet/sign-typed-data.ts
+++ b/src/server/routes/backend-wallet/sign-typed-data.ts
@@ -6,6 +6,7 @@ import { arbitrumSepolia } from "thirdweb/chains";
 import { isSmartBackendWallet } from "../../../shared/db/wallets/get-wallet-details";
 import { getWalletDetails } from "../../../shared/db/wallets/get-wallet-details";
 import { walletDetailsToAccount } from "../../../shared/utils/account";
+import { transformBigNumbers } from "../../../shared/utils/bignumber";
 import { getChain } from "../../../shared/utils/chain";
 import { createCustomError } from "../../middleware/error";
 import { standardResponseSchema } from "../../schemas/shared-api-schemas";
@@ -47,6 +48,9 @@ export async function signTypedData(fastify: FastifyInstance) {
       const { "x-backend-wallet-address": walletAddress } =
         request.headers as Static<typeof walletHeaderSchema>;
 
+      // Transform any BigNumber objects in the value to stringified bigints
+      const transformedValue = transformBigNumbers(value);
+
       const walletDetails = await getWalletDetails({
         address: walletAddress,
       });
@@ -79,7 +83,7 @@ export async function signTypedData(fastify: FastifyInstance) {
         domain,
         types,
         primaryType: parsedPrimaryType,
-        message: value,
+        message: transformedValue,
       } as never);
 
       reply.status(StatusCodes.OK).send({

--- a/src/shared/utils/bignumber.ts
+++ b/src/shared/utils/bignumber.ts
@@ -1,0 +1,66 @@
+/**
+ * Utility functions for handling BigNumber objects in payloads
+ */
+
+/**
+ * Interface representing a BigNumber object as it comes from the frontend
+ */
+interface BigNumberObject {
+  type: "BigNumber";
+  hex: string;
+}
+
+/**
+ * Type guard to check if an object is a BigNumber object
+ */
+function isBigNumberObject(obj: unknown): obj is BigNumberObject {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "type" in obj &&
+    "hex" in obj &&
+    obj.type === "BigNumber" &&
+    typeof obj.hex === "string"
+  );
+}
+
+/**
+ * Converts a BigNumber object to a stringified bigint
+ */
+function bigNumberToStringifiedBigInt(bigNumberObj: BigNumberObject): string {
+  // Convert hex string to bigint, then to string
+  return BigInt(bigNumberObj.hex).toString();
+}
+
+/**
+ * Recursively transforms all BigNumber objects in an arbitrary object/array
+ * into stringified bigints
+ */
+export function transformBigNumbers(obj: unknown): unknown {
+  // Handle null/undefined
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  // Handle BigNumber objects
+  if (isBigNumberObject(obj)) {
+    return bigNumberToStringifiedBigInt(obj);
+  }
+
+  // Handle arrays
+  if (Array.isArray(obj)) {
+    return obj.map(transformBigNumbers);
+  }
+
+  // Handle objects
+  if (typeof obj === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = transformBigNumbers(value);
+    }
+    return result;
+  }
+
+  // Handle primitives (string, number, boolean, etc.)
+  return obj;
+}


### PR DESCRIPTION
%23%23%20Changes%0A%0A-%20Linear%3A%20https%3A%2F%2Flinear.app%2Fthirdweb%2Fissue%2FBLD-37%2Fhandle-bignumber-inputs-in-engine-v2-with-quick-patch%0A-%20**Problem%20being%20solved**%3A%20The%20%60backend-wallet%2Fsign-typed-data%60%20endpoint%27s%20%60message%60%20payload%20might%20contain%20%60%7B%22type%22%3A%22BigNumber%22%2C%22hex%22%3A%220x...%22%7D%60%20objects%2C%20which%20are%20not%20directly%20compatible%20with%20the%20SDK%27s%20expected%20stringified%20bigint%20format.%20This%20causes%20issues%20when%20signing%20typed%20data%20for%20applications%20that%20send%20BigNumber%20objects.%0A-%20**Changes%20made**%3A%0A%20%20%20%20-%20Created%20a%20new%20utility%20function%20%60transformBigNumbers%60%20in%20%60src%2Fshared%2Futils%2Fbignumber.ts%60.%20This%20function%20recursively%20converts%20%60%7B%22type%22%3A%22BigNumber%22%2C%22hex%22%3A%220x...%22%7D%60%20objects%20into%20their%20stringified%20bigint%20representation%20(e.g.%2C%20%60%221234567890%22%60).%0A%20%20%20%20-%20Applied%20this%20%60transformBigNumbers%60%20utility%20to%20the%20%60value%60%20(which%20becomes%20the%20%60message%60)%20in%20the%20%60backend-wallet%2Fsign-typed-data%60%20endpoint%20before%20passing%20it%20to%20the%20%60account.signTypedData()%60%20method.%0A%0A%23%23%20How%20this%20PR%20will%20be%20tested%0A%0A-%20%5B%20%5D%20Send%20a%20%60sign-typed-data%60%20request%20to%20the%20backend-wallet%20endpoint%20where%20the%20%60value%60%20(message)%20contains%20a%20nested%20%60%7B%22type%22%3A%22BigNumber%22%2C%22hex%22%3A%220x...%22%7D%60%20object.%0A%20%20%20%20-%20**Example%20Payload%20Snippet**%3A%0A%20%20%20%20%60%60%60json%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22domain%22%3A%20%7B%20%22name%22%3A%20%22MyDApp%22%2C%20%22version%22%3A%20%221%22%2C%20%22chainId%22%3A%201%2C%20%22verifyingContract%22%3A%20%220x...%22%20%7D%2C%0A%20%20%20%20%20%20%22types%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22EIP712Domain%22%3A%20%5B%20%7B%20%22name%22%3A%20%22name%22%2C%20%22type%22%3A%20%22string%22%20%7D%2C%20%7B%20%22name%22%3A%20%22version%22%2C%20%22type%22%3A%20%22string%22%20%7D%2C%20%7B%20%22name%22%3A%20%22chainId%22%2C%20%22type%22%3A%20%22uint256%22%20%7D%2C%20%7B%20%22name%22%3A%20%22verifyingContract%22%2C%20%22type%22%3A%20%22address%22%20%7D%20%5D%2C%0A%20%20%20%20%20%20%20%20%22MyType%22%3A%20%5B%20%7B%20%22name%22%3A%20%22amount%22%2C%20%22type%22%3A%20%22uint256%22%20%7D%2C%20%7B%20%22name%22%3A%20%22user%22%2C%20%22type%22%3A%20%22address%22%20%7D%20%5D%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%22primaryType%22%3A%20%22MyType%22%2C%0A%20%20%20%20%20%20%22value%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22amount%22%3A%20%7B%20%22type%22%3A%20%22BigNumber%22%2C%20%22hex%22%3A%20%220x1%22%20%7D%2C%0A%20%20%20%20%20%20%20%20%22user%22%3A%20%220x...%22%0A%20%20%20%20%20%20%7D%0A%20%