### PR TITLE
Handle 'incorrect account sequence' in nonce error check

### DIFF
--- a/src/shared/utils/error.ts
+++ b/src/shared/utils/error.ts
@@ -19,7 +19,7 @@ export const isNonceAlreadyUsedError = (error: unknown) => {
 
   if (message) {
     return (
-      message.includes("nonce too low") || message.includes("already known")
+      message.includes("nonce too low") || message.includes("already known") || message.includes("incorrect account sequence")
     );
   }
 


### PR DESCRIPTION
Added support for detecting errors with the message 'incorrect account sequence' in the isNonceAlreadyUsedError utility. This improves error handling for cases where the nonce is invalid due to account sequence issues.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on expanding the error message handling in the `src/shared/utils/error.ts` file to include an additional condition for error messages.

### Detailed summary
- Modified the conditional return statement to include a new check: `message.includes("incorrect account sequence")`.
- The updated condition now returns `true` if the message contains "nonce too low", "already known", or "incorrect account sequence".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of nonce-related errors by recognizing “incorrect account sequence” messages alongside existing patterns. This leads to more reliable handling of transaction submission issues, reducing false negatives and improving automatic retries and user feedback when a nonce has already been used, helping prevent confusing failures during busy activity or cross-wallet usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->