### PR TITLE
better keypair auth error message

### DIFF
--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -331,14 +331,12 @@ const handleKeypairAuth = async (args: {
     }) as jsonwebtoken.JwtPayload;
 
     // If `bodyHash` is provided, it must match a hash of the POST request body.
-    if (
-      req.method === "POST" &&
-      payload?.bodyHash &&
-      payload.bodyHash !== hashRequestBody(req)
-    ) {
-      error =
-        "The request body does not match the hash in the access token. See: https://portal.thirdweb.com/engine/features/keypair-authentication";
-      throw error;
+    if (req.method === "POST" && payload?.bodyHash) {
+      const computedBodyHash = hashRequestBody(req);
+      if (computedBodyHash !== payload.bodyHash) {
+        error = `The request body does not match the hash in the access token. See: https://portal.thirdweb.com/engine/v2/features/keypair-authentication. [hash in access token: ${payload.bodyHash}, hash computed from request: ${computedBodyHash}]`;
+        throw error;
+      }
     }
 
     const { isAllowed, ip } = await checkIpInAllowlist(req);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves error handling in the `auth.ts` middleware by refining the hash comparison logic for POST requests. It adds detailed information to the error message, including both the hash from the access token and the computed hash from the request.

### Detailed summary
- Simplified the conditional structure for checking `bodyHash`.
- Introduced a variable `computedBodyHash` to store the hash of the request body.
- Enhanced the error message to include both the expected and computed hashes for better debugging.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Clearer error when a signed POST body hash mismatches, including both hashes for easier debugging.
  - Error message now links to the updated v2 documentation.
- Refactor
  - Streamlined body hash computation to run once per request for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->