### PR TITLE
feat: add experimental retry for prepareUserOp errors in transaction processing

### DIFF
--- a/src/shared/utils/env.ts
+++ b/src/shared/utils/env.ts
@@ -115,6 +115,8 @@ export const env = createEnv({
       .number()
       .gt(0.0, "scaling factor must be greater than 0")
       .default(1.0),
+    // Retry prepareUserOp errors instead of immediately failing the transaction
+    EXPERIMENTAL__RETRY_PREPARE_USEROP_ERRORS: boolEnvSchema(false),
   },
   clientPrefix: "NEVER_USED",
   client: {},
@@ -169,6 +171,8 @@ export const env = createEnv({
       process.env.EXPERIMENTAL__MINE_WORKER_MAX_POLL_INTERVAL_SECONDS,
     EXPERIMENTAL__MINE_WORKER_POLL_INTERVAL_SCALING_FACTOR:
       process.env.EXPERIMENTAL__MINE_WORKER_POLL_INTERVAL_SCALING_FACTOR,
+    EXPERIMENTAL__RETRY_PREPARE_USEROP_ERRORS:
+      process.env.EXPERIMENTAL__RETRY_PREPARE_USEROP_ERRORS,
     SEND_WEBHOOK_QUEUE_CONCURRENCY: process.env.SEND_WEBHOOK_QUEUE_CONCURRENCY,
   },
   onValidationError: (error: ZodError) => {

--- a/src/worker/tasks/send-transaction-worker.ts
+++ b/src/worker/tasks/send-transaction-worker.ts
@@ -295,12 +295,19 @@ const _sendUserOp = async (
     });
   } catch (error) {
     const errorMessage = wrapError(error, "Bundler").message;
+    job.log(`Failed to populate transaction: ${errorMessage}`);
+    
+    // If retry is enabled for prepareUserOp errors, throw to trigger job retry
+    if (env.EXPERIMENTAL__RETRY_PREPARE_USEROP_ERRORS) {
+      throw error;
+    }
+    
+    // Otherwise, return errored transaction as before
     const erroredTransaction: ErroredTransaction = {
       ...queuedTransaction,
       status: "errored",
       errorMessage,
     };
-    job.log(`Failed to populate transaction: ${errorMessage}`);
     return erroredTransaction;
   }
 
@@ -356,12 +363,19 @@ const _sendUserOp = async (
     const errorMessage = `${
       wrapError(error, "Bundler").message
     } Failed to sign prepared userop`;
+    job.log(`Failed to sign userop: ${errorMessage}`);
+    
+    // If retry is enabled for prepareUserOp errors, throw to trigger job retry
+    if (env.EXPERIMENTAL__RETRY_PREPARE_USEROP_ERRORS) {
+      throw error;
+    }
+    
+    // Otherwise, return errored transaction as before
     const erroredTransaction: ErroredTransaction = {
       ...queuedTransaction,
       status: "errored",
       errorMessage,
     };
-    job.log(`Failed to sign userop: ${errorMessage}`);
     return erroredTransaction;
   }
 
@@ -383,12 +397,19 @@ const _sendUserOp = async (
     const errorMessage = `${
       wrapError(error, "Bundler").message
     } Failed to bundle userop`;
+    job.log(`Failed to bundle userop: ${errorMessage}`);
+    
+    // If retry is enabled for prepareUserOp errors, throw to trigger job retry
+    if (env.EXPERIMENTAL__RETRY_PREPARE_USEROP_ERRORS) {
+      throw error;
+    }
+    
+    // Otherwise, return errored transaction as before
     const erroredTransaction: ErroredTransaction = {
       ...queuedTransaction,
       status: "errored",
       errorMessage,
     };
-    job.log(`Failed to bundle userop: ${errorMessage}`);
     return erroredTransaction;
   }
 


### PR DESCRIPTION
Introduced a new environment variable EXPERIMENTAL__RETRY_PREPARE_USEROP_ERRORS to enable retrying on prepareUserOp errors instead of failing the transaction immediately. Updated transaction handling logic to support this feature.

## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new experimental feature that allows retrying `prepareUserOp` errors instead of failing the transaction immediately. It adds a configuration option and updates the transaction handling logic to support this retry mechanism.

### Detailed summary
- Added `EXPERIMENTAL__RETRY_PREPARE_USEROP_ERRORS` to `env` configuration.
- Updated transaction error handling in `send-transaction-worker.ts` to retry on `prepareUserOp` errors if the new flag is enabled.
- Similar updates in the `_sendUserOp` function to handle retries for signing and bundling operations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces an optional automatic retry for certain transaction preparation errors, reducing immediate failures and improving transaction reliability.
  - Behavior is controlled via a new environment variable and is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->