### PR TITLE
fix: correct toAddress assignment in transaction queueing logic

### DIFF
--- a/src/server/routes/backend-wallet/transfer.ts
+++ b/src/server/routes/backend-wallet/transfer.ts
@@ -160,7 +160,7 @@ export async function transfer(fastify: FastifyInstance) {
         queueId = await queueTransaction({
           transaction,
           fromAddress: getChecksumAddress(walletAddress),
-          toAddress: getChecksumAddress(to),
+          toAddress: getChecksumAddress(transaction.to),
           accountAddress: getChecksumAddress(accountAddress),
           accountFactoryAddress: getChecksumAddress(accountFactoryAddress),
           accountSalt,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the way the `toAddress` is derived in the `transfer.ts` file, ensuring it uses the `to` address from the `transaction` object instead of a separate variable.

### Detailed summary
- Changed the assignment of `toAddress` from `getChecksumAddress(to)` to `getChecksumAddress(transaction.to)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected recipient address handling for ERC20 transfers by using the address from the prepared transaction, ensuring accurate, checksummed delivery and more reliable queuing.
  - Prevents mismatches between input and prepared transaction data that could cause failed or misrouted ERC20 transfers.
  - Native token transfers are unaffected by this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->