### PR TITLE
allow cancelling userops

### DIFF
--- a/src/server/routes/transaction/cancel.ts
+++ b/src/server/routes/transaction/cancel.ts
@@ -105,7 +105,12 @@ export async function cancelTransaction(fastify: FastifyInstance) {
           // isUserOp: false,
           gas: 0n,
           ...(transaction.isUserOp
-            ? { userOpHash: "0x", nonce: "cancelled", isUserOp: true }
+            ? {
+                userOpHash:
+                  "0x0000000000000000000000000000000000000000000000000000000000000000",
+                nonce: "cancelled",
+                isUserOp: true,
+              }
             : { nonce: -1, sentTransactionHashes: [], isUserOp: false }),
         };
       } else if (transaction.status === "sent") {

--- a/src/server/routes/transaction/cancel.ts
+++ b/src/server/routes/transaction/cancel.ts
@@ -82,33 +82,34 @@ export async function cancelTransaction(fastify: FastifyInstance) {
 
       const message = "Transaction successfully cancelled.";
       let cancelledTransaction: CancelledTransaction | null = null;
-      if (!transaction.isUserOp) {
-        if (transaction.status === "queued") {
-          // Remove all retries from the SEND_TRANSACTION queue.
-          const config = await getConfig();
-          for (
-            let resendCount = 0;
-            resendCount < config.maxRetriesPerTx;
-            resendCount++
-          ) {
-            await SendTransactionQueue.remove({ queueId, resendCount });
-          }
+      if (transaction.status === "queued") {
+        // Remove all retries from the SEND_TRANSACTION queue.
+        const config = await getConfig();
+        for (
+          let resendCount = 0;
+          resendCount < config.maxRetriesPerTx;
+          resendCount++
+        ) {
+          await SendTransactionQueue.remove({ queueId, resendCount });
+        }
 
-          cancelledTransaction = {
-            ...transaction,
-            status: "cancelled",
-            cancelledAt: new Date(),
+        cancelledTransaction = {
+          ...transaction,
+          status: "cancelled",
+          cancelledAt: new Date(),
 
-            // Dummy data since the transaction was never sent.
-            sentAt: new Date(),
-            sentAtBlock: await getBlockNumberish(transaction.chainId),
+          // Dummy data since the transaction was never sent.
+          sentAt: new Date(),
+          sentAtBlock: await getBlockNumberish(transaction.chainId),
 
-            isUserOp: false,
-            gas: 0n,
-            nonce: -1,
-            sentTransactionHashes: [],
-          };
-        } else if (transaction.status === "sent") {
+          // isUserOp: false,
+          gas: 0n,
+          ...(transaction.isUserOp
+            ? { userOpHash: "0x", nonce: "cancelled", isUserOp: true }
+            : { nonce: -1, sentTransactionHashes: [], isUserOp: false }),
+        };
+      } else if (transaction.status === "sent") {
+        if (!transaction.isUserOp) {
           // Cancel a sent transaction with the same nonce.
           const { chainId, from, nonce } = transaction;
           const transactionHash = await sendCancellationTransaction({
@@ -143,7 +144,10 @@ export async function cancelTransaction(fastify: FastifyInstance) {
           queueId,
           status: "success",
           message,
-          transactionHash: cancelledTransaction.sentTransactionHashes.at(-1),
+          transactionHash:
+            "sentTransactionHashes" in cancelledTransaction
+              ? cancelledTransaction.sentTransactionHashes.at(-1)
+              : cancelledTransaction.userOpHash,
         },
       });
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refines the `cancelTransaction` function in the `src/server/routes/transaction/cancel.ts` file to improve the handling of transaction cancellations, especially for user operations. It ensures that the cancellation logic is clearer and correctly differentiates between user operations and standard transactions.

### Detailed summary
- Removed the check for `transaction.isUserOp` before handling the "queued" status.
- Simplified the construction of `cancelledTransaction` by merging properties conditionally based on `isUserOp`.
- Adjusted the retrieval of `transactionHash` for the response based on whether `cancelledTransaction` contains `sentTransactionHashes` or `userOpHash`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified cancellation for queued and sent transactions, including user-operation–based ones.
  - Immediate cleanup of queued retries on cancel, with clearer cancelled status and timestamps.

- Bug Fixes
  - Returns the correct transaction hash after cancellation across both user-op and non-user-op flows.
  - Ensures cancellation transactions are appended and visible in history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->