### PR TITLE
feat: Add IAM role authentication support for AWS KMS wallets

### DIFF
--- a/src/server/routes/backend-wallet/import.ts
+++ b/src/server/routes/backend-wallet/import.ts
@@ -158,20 +158,17 @@ export const importBackendWallet = async (fastify: FastifyInstance) => {
           credentials?.awsAccessKeyId ??
           config.walletConfiguration.aws?.awsAccessKeyId;
 
-        if (!(accessKeyId && secretAccessKey)) {
-          throw createCustomError(
-            `Please provide 'awsAccessKeyId' and 'awsSecretAccessKey' to import a wallet. Can be provided as configuration or as credential with the request.`,
-            StatusCodes.BAD_REQUEST,
-            "MISSING_PARAMETERS",
-          );
-        }
-
+        // Credentials are optional - if not provided, AWS SDK will use IAM roles or other credential providers
+        const walletCredentials = 
+          accessKeyId && secretAccessKey
+            ? {
+                accessKeyId,
+                secretAccessKey,
+              }
+            : undefined;
         walletAddress = await importAwsKmsWallet({
           awsKmsArn,
-          crendentials: {
-            accessKeyId,
-            secretAccessKey,
-          },
+          crendentials: walletCredentials,
           label,
         });
       }

--- a/src/server/utils/wallets/create-aws-kms-wallet.ts
+++ b/src/server/utils/wallets/create-aws-kms-wallet.ts
@@ -27,10 +27,10 @@ export const createAwsKmsWalletDetails = async ({
   return importAwsKmsWallet({
     awsKmsArn,
     label,
-    crendentials: {
+    crendentials: params.awsAccessKeyId && params.awsSecretAccessKey ? {
       accessKeyId: params.awsAccessKeyId,
       secretAccessKey: params.awsSecretAccessKey,
-    },
+    } : undefined,
   });
 };
 
@@ -54,10 +54,10 @@ export const createAwsKmsKey = async (
 
   const client = new KMSClient({
     region: params.awsRegion,
-    credentials: {
+    credentials: params.awsAccessKeyId && params.awsSecretAccessKey ? {
       accessKeyId: params.awsAccessKeyId,
       secretAccessKey: params.awsSecretAccessKey,
-    },
+    } : undefined,
   });
 
   const res = await client.send(

--- a/src/server/utils/wallets/create-smart-wallet.ts
+++ b/src/server/utils/wallets/create-smart-wallet.ts
@@ -67,10 +67,10 @@ export const createSmartAwsWalletDetails = async ({
     keyId,
     config: {
       region: awsKmsWallet.params.awsRegion,
-      credentials: {
+      credentials: awsKmsWallet.params.awsAccessKeyId && awsKmsWallet.params.awsSecretAccessKey ? {
         accessKeyId: awsKmsWallet.params.awsAccessKeyId,
         secretAccessKey: awsKmsWallet.params.awsSecretAccessKey,
-      },
+      } : undefined,
     },
   });
 

--- a/src/server/utils/wallets/fetch-aws-kms-wallet-params.ts
+++ b/src/server/utils/wallets/fetch-aws-kms-wallet-params.ts
@@ -1,17 +1,18 @@
 import { getConfig } from "../../../shared/utils/cache/get-config";
 
 export type AwsKmsWalletParams = {
-  awsAccessKeyId: string;
-  awsSecretAccessKey: string;
+  awsAccessKeyId?: string;
+  awsSecretAccessKey?: string;
 
-  awsRegion: string;
+  awsRegion?: string;
 };
 
 export class FetchAwsKmsWalletParamsError extends Error {}
 
 /**
  * Fetches the AWS KMS wallet creation parameters from the configuration or overrides.
- * If any required parameter cannot be resolved from either the configuration or the overrides, an error is thrown.
+ * Credentials are optional - if not provided, AWS SDK will use IAM roles or other credential providers.
+ * Only AWS region is required.
  */
 export async function fetchAwsKmsWalletParams(
   overrides: Partial<AwsKmsWalletParams>,
@@ -21,30 +22,12 @@ export async function fetchAwsKmsWalletParams(
   const awsAccessKeyId =
     overrides.awsAccessKeyId ?? config.walletConfiguration.aws?.awsAccessKeyId;
 
-  if (!awsAccessKeyId) {
-    throw new FetchAwsKmsWalletParamsError(
-      "AWS access key ID is required for this wallet type. Could not find in configuration or params.",
-    );
-  }
-
   const awsSecretAccessKey =
     overrides.awsSecretAccessKey ??
     config.walletConfiguration.aws?.awsSecretAccessKey;
 
-  if (!awsSecretAccessKey) {
-    throw new FetchAwsKmsWalletParamsError(
-      "AWS secretAccessKey is required for this wallet type. Could not find in configuration or params.",
-    );
-  }
-
   const awsRegion =
     overrides.awsRegion ?? config.walletConfiguration.aws?.defaultAwsRegion;
-
-  if (!awsRegion) {
-    throw new FetchAwsKmsWalletParamsError(
-      "AWS region is required for this wallet type. Could not find in configuration or params.",
-    );
-  }
 
   return {
     awsAccessKeyId,

--- a/src/server/utils/wallets/import-aws-kms-wallet.ts
+++ b/src/server/utils/wallets/import-aws-kms-wallet.ts
@@ -6,7 +6,7 @@ import { getAwsKmsAccount } from "./get-aws-kms-account";
 
 interface ImportAwsKmsWalletParams {
   awsKmsArn: string;
-  crendentials: {
+  crendentials?: {
     accessKeyId: string;
     secretAccessKey: string;
   };
@@ -27,10 +27,10 @@ export const importAwsKmsWallet = async ({
     keyId,
     config: {
       region,
-      credentials: {
+      credentials: crendentials ? {
         accessKeyId: crendentials.accessKeyId,
         secretAccessKey: crendentials.secretAccessKey,
-      },
+      } : undefined,
     },
   });
 
@@ -42,8 +42,8 @@ export const importAwsKmsWallet = async ({
     awsKmsArn,
     label,
 
-    awsKmsAccessKeyId: crendentials.accessKeyId,
-    awsKmsSecretAccessKey: crendentials.secretAccessKey,
+    awsKmsAccessKeyId: crendentials?.accessKeyId,
+    awsKmsSecretAccessKey: crendentials?.secretAccessKey,
   });
 
   return walletAddress;

--- a/src/shared/db/wallets/create-wallet-details.ts
+++ b/src/shared/db/wallets/create-wallet-details.ts
@@ -18,8 +18,8 @@ type CreateWalletDetailsParams = {
       awsKmsKeyId?: string; // deprecated and unused, todo: remove with next breaking change
       awsKmsArn: string;
 
-      awsKmsSecretAccessKey: string; // will be encrypted and stored, pass plaintext to this function
-      awsKmsAccessKeyId: string;
+      awsKmsSecretAccessKey?: string; // will be encrypted and stored, pass plaintext to this function
+      awsKmsAccessKeyId?: string;
     }
   | {
       type: "gcp-kms";
@@ -35,8 +35,8 @@ type CreateWalletDetailsParams = {
   | {
       type: "smart:aws-kms";
       awsKmsArn: string;
-      awsKmsSecretAccessKey: string; // will be encrypted and stored, pass plaintext to this function
-      awsKmsAccessKeyId: string;
+      awsKmsSecretAccessKey?: string; // will be encrypted and stored, pass plaintext to this function
+      awsKmsAccessKeyId?: string;
       accountSignerAddress: Address;
 
       accountFactoryAddress: Address | undefined;
@@ -99,7 +99,9 @@ export const createWalletDetails = async ({
         ...walletDetails,
         address: walletDetails.address.toLowerCase(),
 
-        awsKmsSecretAccessKey: encrypt(walletDetails.awsKmsSecretAccessKey),
+        awsKmsSecretAccessKey: walletDetails.awsKmsSecretAccessKey 
+          ? encrypt(walletDetails.awsKmsSecretAccessKey)
+          : null,
       },
     });
   }
@@ -123,7 +125,9 @@ export const createWalletDetails = async ({
         ...walletDetails,
 
         address: walletDetails.address.toLowerCase(),
-        awsKmsSecretAccessKey: encrypt(walletDetails.awsKmsSecretAccessKey),
+        awsKmsSecretAccessKey: walletDetails.awsKmsSecretAccessKey 
+          ? encrypt(walletDetails.awsKmsSecretAccessKey)
+          : null,
         accountSignerAddress: walletDetails.accountSignerAddress.toLowerCase(),
 
         accountFactoryAddress:

--- a/src/shared/db/wallets/get-wallet-details.ts
+++ b/src/shared/db/wallets/get-wallet-details.ts
@@ -63,8 +63,8 @@ const awsKmsWalletSchema = z
   .object({
     type: z.literal("aws-kms"),
     awsKmsArn: z.string(),
-    awsKmsSecretAccessKey: z.string(),
-    awsKmsAccessKeyId: z.string(),
+    awsKmsSecretAccessKey: z.string().nullable(),
+    awsKmsAccessKeyId: z.string().nullable(),
   })
   .merge(baseWalletPartialSchema);
 

--- a/src/shared/utils/account.ts
+++ b/src/shared/utils/account.ts
@@ -67,10 +67,10 @@ export const walletDetailsToAccount = async ({
         keyId,
         config: {
           region,
-          credentials: {
+          credentials: walletDetails.awsKmsAccessKeyId && walletDetails.awsKmsSecretAccessKey ? {
             accessKeyId: walletDetails.awsKmsAccessKeyId,
             secretAccessKey: walletDetails.awsKmsSecretAccessKey,
-          },
+          } : undefined,
         },
       });
 
@@ -103,10 +103,10 @@ export const walletDetailsToAccount = async ({
         keyId,
         config: {
           region,
-          credentials: {
+          credentials: walletDetails.awsKmsAccessKeyId && walletDetails.awsKmsSecretAccessKey ? {
             accessKeyId: walletDetails.awsKmsAccessKeyId,
             secretAccessKey: walletDetails.awsKmsSecretAccessKey,
-          },
+          } : undefined,
         },
       });
 

--- a/src/shared/utils/cache/get-wallet.ts
+++ b/src/shared/utils/cache/get-wallet.ts
@@ -62,8 +62,8 @@ export const getWallet = async <TWallet extends EVMWallet>({
       wallet = new AwsKmsWallet({
         keyId: splitArn.keyId,
         region: splitArn.region,
-        accessKeyId: walletDetails.awsKmsAccessKeyId,
-        secretAccessKey: walletDetails.awsKmsSecretAccessKey,
+        accessKeyId: walletDetails.awsKmsAccessKeyId ?? undefined,
+        secretAccessKey: walletDetails.awsKmsSecretAccessKey ?? undefined,
       });
 
       break;
@@ -103,8 +103,8 @@ export const getWallet = async <TWallet extends EVMWallet>({
       const adminWallet = new AwsKmsWallet({
         keyId: splitArn.keyId,
         region: splitArn.region,
-        accessKeyId: walletDetails.awsKmsAccessKeyId,
-        secretAccessKey: walletDetails.awsKmsSecretAccessKey,
+        accessKeyId: walletDetails.awsKmsAccessKeyId ?? undefined,
+        secretAccessKey: walletDetails.awsKmsSecretAccessKey ?? undefined,
       });
 
       const smartWallet: EVMWallet = await getSmartWallet({


### PR DESCRIPTION
## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Add IAM role authentication support for AWS KMS wallets
- Make AWS credentials (access key ID and secret access key) optional during wallet import/creation
- When credentials are not specified, AWS SDK automatically uses the default credential chain (IAM roles, environment variables, etc.)
- This eliminates the need to issue IAM user secret keys when running on EC2/ECS, enabling secure authentication via IAM roles and strengthening security

### Main changes
- `import.ts`: Remove credential validation and make them optional
- `create-aws-kms-wallet.ts`: Set credentials object only when credentials exist
- `fetch-aws-kms-wallet-params.ts`: Remove required checks for credentials (delegated to AWS SDK default chain)
- `create-wallet-details.ts`, `get-wallet-details.ts`: Make credentials nullable in DB schema
- `account.ts`, `get-wallet.ts`: Set credentials only when they exist

### Important notes
- **Frontend not supported**: This is a minimal backend change - thirdweb Dashboard frontend is not yet supported
- **Configuration-based KMS setup**: When setting up via Configuration, Secret Key input remains required
- **Using IAM role authentication**: To use IAM role authentication, API-based setup is required

**API setup example:**
```bash
  POST /backend-wallet/import
  Content-Type: application/json

  {
    "awsKmsArn": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
  }
```
## How this PR will be tested

- Create AWS KMS wallet without credentials in EC2/ECS environment with IAM role and verify it works correctly
- Verify that explicitly specifying credentials (awsAccessKeyId/awsSecretAccessKey) continues to work as before
- Import AWS KMS wallet via /backend-wallet/import API without credentials and verify successful completion
- Verify IAM role authentication works for smart wallets (smart:aws-kms) as well

# Output
To set up from the Dashboard, specify the KMS ARN from the following screen:

<img width="1178" height="609" alt="スクリーンショット 2025-10-04 16 46 44" src="https://github.com/user-attachments/assets/14426221-55d2-4a32-8be8-6d5d9bbc5895" />

