### PR TITLE
Increase webhook retry attempts from 3 to 5

### DIFF
--- a/src/worker/queues/send-webhook-queue.ts
+++ b/src/worker/queues/send-webhook-queue.ts
@@ -59,7 +59,7 @@ export class SendWebhookQueue {
     connection: redis,
     defaultJobOptions: {
       ...defaultJobOptions,
-      attempts: 3,
+      attempts: 8,
       backoff: { type: "exponential", delay: 5_000 },
     },
   });

--- a/src/worker/queues/send-webhook-queue.ts
+++ b/src/worker/queues/send-webhook-queue.ts
@@ -59,7 +59,7 @@ export class SendWebhookQueue {
     connection: redis,
     defaultJobOptions: {
       ...defaultJobOptions,
-      attempts: 8,
+      attempts: 5,
       backoff: { type: "exponential", delay: 5_000 },
     },
   });


### PR DESCRIPTION
- Changes webhook delivery attempts from 3 to 8
- Keeps exponential backoff with 5-second base delay
- Total retry window increases from ~15s to ~10m 35s
- Provides better resilience for temporary outages, deployments, and restarts

Timeline:
- Attempt 1: 0s
- Attempt 2: +5s (5s total)
- Attempt 3: +10s (15s total)
- Attempt 4: +20s (35s total)
- Attempt 5: +40s (1m 15s total)
- Attempt 6: +1m 20s (2m 35s total)
- Attempt 7: +2m 40s (5m 15s total)
- Attempt 8: +5m 20s (10m 35s total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Changes

- Linear: https://linear.app/thirdweb/issue/INC-217/amex-mtls-webhook-intermittent-500-errors-engine-cloud-prod
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `attempts` property in the `defaultJobOptions` of the `send-webhook-queue.ts` file to increase the number of retry attempts for failed jobs.

### Detailed summary
- Changed the `attempts` value from `3` to `5` in the `defaultJobOptions` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased webhook retry attempts from 3 to 5 to improve delivery reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->