### PR TITLE
fix: retry webhooks on 429 and 403 responses

### DIFF
--- a/src/worker/tasks/send-webhook-worker.ts
+++ b/src/worker/tasks/send-webhook-worker.ts
@@ -85,7 +85,7 @@ const handler: Processor<string, void, string> = async (job: Job<string>) => {
         logger({
           service: "worker",
           level: "warn",
-          message: `[Webhook] Transaction not found for webhook`,
+          message: "[Webhook] Transaction not found for webhook",
           queueId: data.queueId,
           data: {
             eventType: data.type,
@@ -137,15 +137,21 @@ const handler: Processor<string, void, string> = async (job: Job<string>) => {
     });
   }
 
-  // Throw on 5xx so it remains in the queue to retry later.
-  if (resp && resp.status >= 500) {
+  // Throw on 5xx, 429 (rate limit), or 403 (forbidden) so it remains in the queue to retry later.
+  if (resp && (resp.status >= 500 || resp.status === 429 || resp.status === 403)) {
+    const errorType =
+      resp.status === 429
+        ? "rate limited"
+        : resp.status === 403
+          ? "forbidden"
+          : "server error";
     const error = new Error(
       `Received status ${resp.status} from webhook ${webhook.url}.`,
     );
     job.log(error.message);
     logger({
       level: "error",
-      message: `[Webhook] 5xx error, will retry`,
+      message: `[Webhook] ${resp.status} ${errorType}, will retry`,
       service: "worker",
       queueId: transactionId,
       data: {


### PR DESCRIPTION
https://linear.app/thirdweb/issue/PRO-160/engine-v2-only-retrying-webhook-on-500-errors

Previously, only 5xx errors triggered webhook retries. This change adds 429 (Too Many Requests) and 403 (Forbidden) to the retry logic, treating them the same as server errors with exponential backoff.

This prevents webhook events from being lost when the destination endpoint rate-limits requests or returns transient auth errors.

Also fixes a pre-existing lint error (unused template literal).

## Changes

- Linear: https://linear.app/thirdweb/issue/INF-171/
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error handling in the `send-webhook-worker.ts` file by refining the conditions for retrying failed webhook requests. It updates the error message formatting and expands the range of HTTP status codes considered for retries.

### Detailed summary
- Updated the `message` format from using backticks to standard quotes.
- Expanded the retry conditions to include HTTP status codes `429` (rate limit) and `403` (forbidden).
- Introduced a new variable `errorType` to classify the error based on the status code.
- Modified the log message to reflect the specific error type and status code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Webhook delivery now retries on rate limit (HTTP 429) and forbidden (HTTP 403) responses, in addition to server errors, improving reliability.
  * Enhanced error logging with more descriptive messages identifying the specific failure reason.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->