### PR TITLE
fix: check backfill table before Redis so it can override stuck queue…

### DIFF
--- a/src/server/routes/transaction/blockchain/get-logs.ts
+++ b/src/server/routes/transaction/blockchain/get-logs.ts
@@ -160,12 +160,20 @@ export async function getTransactionLogs(fastify: FastifyInstance) {
         // queue IDs that are stuck in Redis (e.g. orphaned "queued" transactions).
         if (env.ENABLE_TX_BACKFILL_FALLBACK) {
           const backfill = await TransactionDB.getBackfill(queueId);
-          if (backfill?.status === "mined" && backfill.transactionHash && isHex(backfill.transactionHash)) {
-            hash = backfill.transactionHash as Hex;
+          if (backfill) {
+            // Backfill entry exists and is authoritative — only set hash if mined.
+            // If backfill is errored, hash stays undefined and we skip Redis lookup.
+            if (backfill.status === "mined" && backfill.transactionHash && isHex(backfill.transactionHash)) {
+              hash = backfill.transactionHash as Hex;
+            }
+          } else {
+            // No backfill entry — fall back to Redis.
+            const transaction = await TransactionDB.get(queueId);
+            if (transaction?.status === "mined") {
+              hash = transaction.transactionHash;
+            }
           }
-        }
-
-        if (!hash) {
+        } else {
           const transaction = await TransactionDB.get(queueId);
           if (transaction?.status === "mined") {
             hash = transaction.transactionHash;

--- a/src/server/routes/transaction/blockchain/get-logs.ts
+++ b/src/server/routes/transaction/blockchain/get-logs.ts
@@ -155,21 +155,20 @@ export async function getTransactionLogs(fastify: FastifyInstance) {
       // Get the transaction hash from the provided input.
       let hash: Hex | undefined;
       if (queueId) {
-        // Primary lookup
-        const transaction = await TransactionDB.get(queueId);
-        if (transaction?.status === "mined") {
-          hash = transaction.transactionHash;
-        }
-
         // SPECIAL LOGIC FOR AMEX
-        // AMEX uses this endpoint to get logs for transactions they didn't receive webhooks for
-        // the queue ID's were cleaned out of REDIS so we backfilled tx hashes to this backfill table
-        // see https://github.com/thirdweb-dev/solutions-customer-scripts/blob/main/amex/scripts/load-backfill-via-api.ts
-        // Fallback to backfill table if enabled and not found
-        if (!hash && env.ENABLE_TX_BACKFILL_FALLBACK) {
+        // Backfill table takes priority — entries are intentional overrides for
+        // queue IDs that are stuck in Redis (e.g. orphaned "queued" transactions).
+        if (env.ENABLE_TX_BACKFILL_FALLBACK) {
           const backfill = await TransactionDB.getBackfill(queueId);
           if (backfill?.status === "mined" && backfill.transactionHash && isHex(backfill.transactionHash)) {
             hash = backfill.transactionHash as Hex;
+          }
+        }
+
+        if (!hash) {
+          const transaction = await TransactionDB.get(queueId);
+          if (transaction?.status === "mined") {
+            hash = transaction.transactionHash;
           }
         }
       } else if (transactionHash) {

--- a/src/server/routes/transaction/status.ts
+++ b/src/server/routes/transaction/status.ts
@@ -145,22 +145,21 @@ export async function getTransactionStatusRoute(fastify: FastifyInstance) {
     handler: async (request, reply) => {
       const { queueId } = request.params;
 
+      // SPECIAL LOGIC FOR AMEX
+      // Backfill table takes priority — entries are intentional overrides for
+      // queue IDs that are stuck in Redis (e.g. orphaned "queued" transactions).
+      // See https://github.com/thirdweb-dev/solutions-customer-scripts/blob/main/amex/scripts/load-backfill-via-api.ts
+      if (env.ENABLE_TX_BACKFILL_FALLBACK) {
+        const backfill = await TransactionDB.getBackfill(queueId);
+        if (backfill) {
+          return reply.status(StatusCodes.OK).send({
+            result: createBackfillResponse(queueId, backfill),
+          });
+        }
+      }
+
       const transaction = await TransactionDB.get(queueId);
       if (!transaction) {
-        // SPECIAL LOGIC FOR AMEX
-        // AMEX uses this endpoint to check transaction status for queue IDs they didn't receive webhooks for.
-        // The queue ID's were cleaned out of Redis so we backfilled tx data to this backfill table.
-        // See https://github.com/thirdweb-dev/solutions-customer-scripts/blob/main/amex/scripts/load-backfill-via-api.ts
-        // Fallback to backfill table if enabled and not found
-        if (env.ENABLE_TX_BACKFILL_FALLBACK) {
-          const backfill = await TransactionDB.getBackfill(queueId);
-          if (backfill) {
-            return reply.status(StatusCodes.OK).send({
-              result: createBackfillResponse(queueId, backfill),
-            });
-          }
-        }
-
         throw createCustomError(
           "Transaction not found.",
           StatusCodes.BAD_REQUEST,
@@ -206,22 +205,20 @@ export async function getTransactionStatusQueryParamRoute(
         );
       }
 
+      // SPECIAL LOGIC FOR AMEX
+      // Backfill table takes priority — entries are intentional overrides for
+      // queue IDs that are stuck in Redis (e.g. orphaned "queued" transactions).
+      if (env.ENABLE_TX_BACKFILL_FALLBACK) {
+        const backfill = await TransactionDB.getBackfill(queueId);
+        if (backfill) {
+          return reply.status(StatusCodes.OK).send({
+            result: createBackfillResponse(queueId, backfill),
+          });
+        }
+      }
+
       const transaction = await TransactionDB.get(queueId);
       if (!transaction) {
-        // SPECIAL LOGIC FOR AMEX
-        // AMEX uses this endpoint to check transaction status for queue IDs they didn't receive webhooks for.
-        // The queue ID's were cleaned out of Redis so we backfilled tx data to this backfill table.
-        // See https://github.com/thirdweb-dev/solutions-customer-scripts/blob/main/amex/scripts/load-backfill-via-api.ts
-        // Fallback to backfill table if enabled and not found
-        if (env.ENABLE_TX_BACKFILL_FALLBACK) {
-          const backfill = await TransactionDB.getBackfill(queueId);
-          if (backfill) {
-            return reply.status(StatusCodes.OK).send({
-              result: createBackfillResponse(queueId, backfill),
-            });
-          }
-        }
-
         throw createCustomError(
           "Transaction not found.",
           StatusCodes.BAD_REQUEST,


### PR DESCRIPTION
…d transactions

Previously the backfill lookup only ran when a transaction was missing from Redis. Orphaned "queued" transactions that still exist in Redis were unreachable by backfill. Moving the check first lets backfill entries act as intentional overrides for stuck queue IDs.

## Changes

- Linear: https://linear.app/thirdweb/issue/PRO-219/move-amex-backfill-txs-as-first-check
- Here is the problem being solved.
- Here are the changes made.

## How this PR will be tested

- [ ] Open the dashboard and click X. Result: A modal should appear.
- [ ] Call the /foo/bar API. Result: Returns 200 with "baz" in the response body.

## Output

(Example: Screenshot/GIF for UI changes, cURL output for API changes)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the transaction retrieval logic by prioritizing backfill entries for transactions that may not have received webhooks, particularly for AMEX. It simplifies the handling of transaction statuses and reduces redundancy in the code.

### Detailed summary
- Removed redundant comments and code related to AMEX webhook handling.
- Prioritized backfill entries when fetching transaction logs.
- Simplified logic for checking transaction status from the backfill table and Redis.
- Ensured that the backfill entry is authoritative if it exists.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction lookup reliability by prioritizing backfill records for hash resolution and status responses when backfill fallback is enabled.
  * Skips secondary lookups when a backfill record exists, and ensures status endpoints return backfill-based responses immediately.
  * Ensures consistent behavior across both path and query status endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->